### PR TITLE
fix: show 0% when there are no surplus apr items

### DIFF
--- a/packages/lib/shared/components/tooltips/apr-tooltip/AddLiquidityAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/AddLiquidityAprTooltip.tsx
@@ -56,6 +56,7 @@ function AddLiquidityAprTooltip({ weeklyYield, totalUsdValue, pool, ...props }: 
       shouldDisplayBaseTooltip
       shouldDisplayMaxVeBalTooltip
       usePortal={false}
+      poolType={pool.type}
     >
       <HStack align="center" alignItems="center">
         <Card cursor="pointer" variant="subSection" w="full" p={['sm', 'ms']}>

--- a/packages/lib/shared/components/tooltips/apr-tooltip/AddLiquidityAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/AddLiquidityAprTooltip.tsx
@@ -10,7 +10,7 @@ import { SparklesIcon } from './MainAprTooltip'
 interface Props
   extends Omit<
     BaseAprTooltipProps,
-    'children' | 'totalBaseText' | 'totalBaseVeBalText' | 'maxVeBalText' | 'poolId'
+    'children' | 'totalBaseText' | 'totalBaseVeBalText' | 'maxVeBalText' | 'poolId' | 'poolType'
   > {
   totalUsdValue: string
   weeklyYield: string

--- a/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
@@ -185,15 +185,13 @@ function BaseAprTooltip({
           tooltipText={merklIncentivesTooltipText}
         />
       )}
-      {hasSurplusIncentives && (
-        <TooltipAprItem
-          {...basePopoverAprItemProps}
-          displayValueFormatter={usedDisplayValueFormatter}
-          title="Prevented LVR"
-          apr={surplusIncentivesAprDisplayed}
-          tooltipText={surplusIncentivesTooltipText}
-        />
-      )}
+      <TooltipAprItem
+        {...basePopoverAprItemProps}
+        displayValueFormatter={usedDisplayValueFormatter}
+        title="Prevented LVR"
+        apr={hasSurplusIncentives ? surplusIncentivesAprDisplayed : bn(0)}
+        tooltipText={surplusIncentivesTooltipText}
+      />
       <Divider />
       <TooltipAprItem
         {...basePopoverAprItemProps}

--- a/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
@@ -89,7 +89,6 @@ function BaseAprTooltip({
     stakingIncentivesAprDisplayed,
     merklIncentivesAprDisplayed,
     hasMerklIncentives,
-    hasSurplusIncentives,
     surplusIncentivesAprDisplayed,
     swapFeesDisplayed,
     isSwapFeePresent,
@@ -192,7 +191,7 @@ function BaseAprTooltip({
           {...basePopoverAprItemProps}
           displayValueFormatter={usedDisplayValueFormatter}
           title="Prevented LVR"
-          apr={hasSurplusIncentives ? surplusIncentivesAprDisplayed : bn(0)}
+          apr={surplusIncentivesAprDisplayed}
           tooltipText={surplusIncentivesTooltipText}
         />
       )}

--- a/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
@@ -1,4 +1,4 @@
-import { GqlPoolAprItem } from '@repo/lib/shared/services/api/generated/graphql'
+import { GqlPoolAprItem, GqlPoolType } from '@repo/lib/shared/services/api/generated/graphql'
 import {
   PlacementWithLogical,
   Popover,
@@ -22,7 +22,7 @@ import {
 import { TooltipAprItem } from './TooltipAprItem'
 import BigNumber from 'bignumber.js'
 import { bn, fNum } from '@repo/lib/shared/utils/numbers'
-import { isVebalPool } from '@repo/lib/modules/pool/pool.helpers'
+import { isCowAmmPool, isVebalPool } from '@repo/lib/modules/pool/pool.helpers'
 import { ReactNode } from 'react'
 
 interface Props {
@@ -31,6 +31,7 @@ interface Props {
   displayValueFormatter?: (value: BigNumber) => string
   placement?: PlacementWithLogical
   poolId: string
+  poolType: GqlPoolType
   vebalBoost?: string
   totalBaseText: string | ((hasVeBalBoost?: boolean) => string)
   totalBaseVeBalText: string
@@ -73,6 +74,7 @@ function BaseAprTooltip({
   shouldDisplayBaseTooltip,
   shouldDisplayMaxVeBalTooltip,
   children,
+  poolType,
   usePortal = true,
 }: Props) {
   const colorMode = useThemeColorMode()
@@ -185,13 +187,15 @@ function BaseAprTooltip({
           tooltipText={merklIncentivesTooltipText}
         />
       )}
-      <TooltipAprItem
-        {...basePopoverAprItemProps}
-        displayValueFormatter={usedDisplayValueFormatter}
-        title="Prevented LVR"
-        apr={hasSurplusIncentives ? surplusIncentivesAprDisplayed : bn(0)}
-        tooltipText={surplusIncentivesTooltipText}
-      />
+      {isCowAmmPool(poolType) && (
+        <TooltipAprItem
+          {...basePopoverAprItemProps}
+          displayValueFormatter={usedDisplayValueFormatter}
+          title="Prevented LVR"
+          apr={hasSurplusIncentives ? surplusIncentivesAprDisplayed : bn(0)}
+          tooltipText={surplusIncentivesTooltipText}
+        />
+      )}
       <Divider />
       <TooltipAprItem
         {...basePopoverAprItemProps}

--- a/packages/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
@@ -151,6 +151,7 @@ function MainAprTooltip({
       totalBaseVeBalText="Total base APR"
       customPopoverContent={customPopoverContent}
       vebalBoost={vebalBoost}
+      poolType={pool.type}
     >
       {({ isOpen }) => (
         <HStack align="center" alignItems="center">

--- a/packages/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip.tsx
@@ -23,7 +23,7 @@ import StarIcon from '../../icons/StarIcon'
 interface Props
   extends Omit<
     BaseAprTooltipProps,
-    'children' | 'totalBaseText' | 'totalBaseVeBalText' | 'maxVeBalText'
+    'children' | 'totalBaseText' | 'totalBaseVeBalText' | 'maxVeBalText' | 'poolType'
   > {
   textProps?: TextProps
   onlySparkles?: boolean

--- a/packages/lib/shared/components/tooltips/apr-tooltip/StakeAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/StakeAprTooltip.tsx
@@ -43,6 +43,7 @@ function StakeAprTooltip({ pool, totalUsdValue }: Props) {
       shouldDisplayBaseTooltip
       shouldDisplayMaxVeBalTooltip
       usePortal={false}
+      poolType={pool.type}
     >
       <Card cursor="pointer" variant="subSection" w="full">
         <VStack align="start" w="full" spacing="sm">

--- a/packages/lib/shared/hooks/useAprTooltip.ts
+++ b/packages/lib/shared/hooks/useAprTooltip.ts
@@ -116,7 +116,6 @@ export function useAprTooltip({
 
   // Surplus incentives
   const surplusIncentives = filterByType(aprItems, GqlPoolAprItemType.Surplus)
-  const hasSurplusIncentives = surplusIncentives.length > 0
   const surplusIncentivesAprDisplayed = calculateSingleIncentivesAprDisplayed(surplusIncentives)
 
   // Bal Reward
@@ -177,7 +176,6 @@ export function useAprTooltip({
     merklIncentivesAprDisplayed,
     hasMerklIncentives,
     surplusIncentivesAprDisplayed,
-    hasSurplusIncentives,
     votingAprDisplayed,
     lockingAprDisplayed,
     isVotingPresent,


### PR DESCRIPTION
fixes #62 

when there are no surplus apr items show LVR as 0% for cow amm pools

![image](https://github.com/user-attachments/assets/7caef201-dcdd-4561-b362-938180e83c2a)
