### PR TITLE
fix: use fresh swapState when updaring swapStateVar

### DIFF
--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -174,6 +174,7 @@ export function _useSwap({ urlTxHash, ...pathParams }: PathParams) {
   })
 
   function handleSimulationResponse({ returnAmount, swapType }: SimulateSwapResponse) {
+    const swapState = swapStateVar()
     swapStateVar({
       ...swapState,
       swapType,
@@ -192,6 +193,7 @@ export function _useSwap({ urlTxHash, ...pathParams }: PathParams) {
   }
 
   function setTokenIn(tokenAddress: Address) {
+    const swapState = swapStateVar()
     const isSameAsTokenOut = isSameAddress(tokenAddress, swapState.tokenOut.address)
 
     swapStateVar({
@@ -207,6 +209,7 @@ export function _useSwap({ urlTxHash, ...pathParams }: PathParams) {
   }
 
   function setTokenOut(tokenAddress: Address) {
+    const swapState = swapStateVar()
     const isSameAsTokenIn = isSameAddress(tokenAddress, swapState.tokenIn.address)
 
     swapStateVar({
@@ -222,6 +225,7 @@ export function _useSwap({ urlTxHash, ...pathParams }: PathParams) {
   }
 
   function switchTokens() {
+    const swapState = swapStateVar()
     swapStateVar({
       ...swapState,
       tokenIn: swapState.tokenOut,
@@ -288,6 +292,7 @@ export function _useSwap({ urlTxHash, ...pathParams }: PathParams) {
   }
 
   function getDefaultTokenState(chain: GqlChain) {
+    const swapState = swapStateVar()
     const {
       tokens: { defaultSwapTokens },
     } = getNetworkConfig(chain)


### PR DESCRIPTION
We had this bug: 
1. Go to swaps page and select `swap/gnosis/USDC/COW`
2. Manually update the url to `swap/gnosis/xDAI/COW` and hit ENTER
3. Bug: the tokenIn remains USDC when it should be xDAI

The reason is that the functions that udpate `swapStateVar` were using `swapState` without making sure that it had the most recent updated value, causing different issues when performing consecutive updates like in:
``` ts
    setInitialChain(chain)
    setInitialTokenIn(tokenIn)
    setInitialTokenOut(tokenOut)
    setInitialAmounts(amountIn, amountOut)
```

The solution is enforcing that `swapState` has the most last updated value with  `const swapState = swapStateVar()` before updating it again.