### PR TITLE
fix: add build v3 page

### DIFF
--- a/apps/frontend-v3/.gitignore
+++ b/apps/frontend-v3/.gitignore
@@ -12,9 +12,6 @@
 /.next/
 /out/
 
-# production
-/build
-
 # misc
 .DS_Store
 *.pem

--- a/apps/frontend-v3/app/(marketing)/build/v3/page.tsx
+++ b/apps/frontend-v3/app/(marketing)/build/v3/page.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable max-len */
+'use client'
+
+import { Box } from '@chakra-ui/react'
+import { V3Hero } from '@repo/lib/shared/components/marketing/build/v3/V3Hero'
+import { V3About } from '@repo/lib/shared/components/marketing/build/v3/V3About'
+import { V3UseCases } from '@repo/lib/shared/components/marketing/build/v3/V3UseCases'
+import { V3Technical } from '@repo/lib/shared/components/marketing/build/v3/V3Technical'
+import { V3Grants } from '@repo/lib/shared/components/marketing/build/v3/V3Grants'
+import { V3VideoTutorial } from '@repo/lib/shared/components/marketing/build/v3/V3VideoTutorial'
+import { ReactLenis } from '@studio-freight/react-lenis'
+
+export default function Home() {
+  return (
+    <ReactLenis root options={{ lerp: 0.1, duration: 1.5 }}>
+      <Box className="build">
+        <V3Hero />
+        <V3VideoTutorial />
+        <V3About />
+        <V3UseCases />
+        <V3Technical />
+        <V3Grants />
+      </Box>
+    </ReactLenis>
+  )
+}


### PR DESCRIPTION
the top level page for /build/v3 was missing because `build/` was still in the app's `.gitignore`