### PR TITLE
feat: unblock sepolia pools

### DIFF
--- a/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
+++ b/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
@@ -1,7 +1,7 @@
 import { getNetworkConfig } from '@repo/lib/config/app.config'
 import { BalAlertButton } from '@repo/lib/shared/components/alerts/BalAlertButton'
 import { BalAlertContent } from '@repo/lib/shared/components/alerts/BalAlertContent'
-import { GqlPoolTokenDetail } from '@repo/lib/shared/services/api/generated/graphql'
+import { GqlChain, GqlPoolTokenDetail } from '@repo/lib/shared/services/api/generated/graphql'
 import { isNil } from 'lodash'
 import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
@@ -53,6 +53,9 @@ export function usePoolAlerts(pool: Pool) {
   }
 
   const getTokenPoolAlerts = (pool: Pool): PoolAlert[] => {
+    // Disable alerts for Sepolia pools
+    if (pool.chain === GqlChain.Sepolia) return []
+
     const poolTokens = pool.poolTokens as GqlPoolTokenDetail[]
 
     const alerts: PoolAlert[] = []

--- a/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
+++ b/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react'
 import { zeroAddress } from 'viem'
 import { Pool } from '../PoolProvider'
 import { migrateStakeTooltipLabel } from '../actions/stake.helpers'
-import { hasReviewedRateProvider, isV3Pool } from '../pool.helpers'
+import { hasReviewedRateProvider, isV2Pool } from '../pool.helpers'
 import { shouldMigrateStake } from '../user-balance.helpers'
 import { VulnerabilityDataMap } from './pool-issues/PoolIssue.labels'
 import { PoolIssue } from './pool-issues/PoolIssue.type'
@@ -61,7 +61,7 @@ export function usePoolAlerts(pool: Pool) {
     const alerts: PoolAlert[] = []
 
     poolTokens?.forEach(token => {
-      if (!isV3Pool(pool) && !token.isAllowed) {
+      if (isV2Pool(pool) && !token.isAllowed) {
         alerts.push({
           identifier: `TokenNotAllowed-${token.symbol}`,
           content: `The token ${token.symbol} is currently not supported.`,

--- a/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
+++ b/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react'
 import { zeroAddress } from 'viem'
 import { Pool } from '../PoolProvider'
 import { migrateStakeTooltipLabel } from '../actions/stake.helpers'
-import { hasReviewedRateProvider } from '../pool.helpers'
+import { hasReviewedRateProvider, isV3Pool } from '../pool.helpers'
 import { shouldMigrateStake } from '../user-balance.helpers'
 import { VulnerabilityDataMap } from './pool-issues/PoolIssue.labels'
 import { PoolIssue } from './pool-issues/PoolIssue.type'
@@ -61,7 +61,7 @@ export function usePoolAlerts(pool: Pool) {
     const alerts: PoolAlert[] = []
 
     poolTokens?.forEach(token => {
-      if (!token.isAllowed) {
+      if (!isV3Pool(pool) && !token.isAllowed) {
         alerts.push({
           identifier: `TokenNotAllowed-${token.symbol}`,
           content: `The token ${token.symbol} is currently not supported.`,

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -181,7 +181,7 @@ type Pool = GetPoolQuery['pool']
 export function usePoolHelpers(pool: Pool, chain: GqlChain) {
   const gaugeExplorerLink = getBlockExplorerAddressUrl(
     pool?.staking?.gauge?.gaugeAddress as Address,
-    chain,
+    chain
   )
   const poolExplorerLink = getBlockExplorerAddressUrl(pool.address as Address, chain)
 
@@ -219,7 +219,7 @@ export function isNotSupported(pool: Pool) {
  */
 export function isClaimableGauge(
   gauge: GqlPoolStakingGauge | GqlPoolStakingOtherGauge,
-  chain: GqlChain | number,
+  chain: GqlChain | number
 ): boolean {
   return !(gauge.version === 1 && isNotMainnet(chain))
 }

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -181,7 +181,7 @@ type Pool = GetPoolQuery['pool']
 export function usePoolHelpers(pool: Pool, chain: GqlChain) {
   const gaugeExplorerLink = getBlockExplorerAddressUrl(
     pool?.staking?.gauge?.gaugeAddress as Address,
-    chain
+    chain,
   )
   const poolExplorerLink = getBlockExplorerAddressUrl(pool.address as Address, chain)
 
@@ -219,7 +219,7 @@ export function isNotSupported(pool: Pool) {
  */
 export function isClaimableGauge(
   gauge: GqlPoolStakingGauge | GqlPoolStakingOtherGauge,
-  chain: GqlChain | number
+  chain: GqlChain | number,
 ): boolean {
   return !(gauge.version === 1 && isNotMainnet(chain))
 }
@@ -261,6 +261,9 @@ export function hasReviewedRateProvider(token: GqlPoolTokenDetail): boolean {
  * @see https://github.com/balancer/frontend-v3/issues/613#issuecomment-2149443249
  */
 export function shouldBlockAddLiquidity(pool: Pool) {
+  // avoid blocking Sepolia pools
+  if (pool.chain === GqlChain.Sepolia) return false
+
   const poolTokens = pool.poolTokens as GqlPoolTokenDetail[]
 
   // If pool is an LBP, paused or in recovery mode, we should block adding liquidity


### PR DESCRIPTION
- Avoid pool alerts in sepolia pools
- Avoid blocking add liquidity in sepolia pools
- Only check unsupported tokens for v2 pools

Example of pool that was blocked but it's not anymore:
https://mono-test-v3-mkgddj74u-balancer.vercel.app/pools/sepolia/v3/0x797c69b235cb047c9331d39c96f30f76dce6444d/add-liquidity