### PR TITLE
fix: undefined error on swap page

### DIFF
--- a/packages/lib/modules/swap/usePermit2SwapStep.tsx
+++ b/packages/lib/modules/swap/usePermit2SwapStep.tsx
@@ -30,7 +30,7 @@ export function useSignPermit2SwapStep({
   const { userAddress } = useUserAccount()
   const { slippage } = useUserSettings()
 
-  const tokenInAddress = tokenInInfo?.address as Address
+  const tokenInAddress = (tokenInInfo?.address ?? '') as Address
 
   const queryData = simulationQuery.data as SdkSimulationResponseWithRouter
 


### PR DESCRIPTION
Fix unhandled error on swap page, [discord link](https://discord.com/channels/638460494168064021/638529669330894868/1306973621687812179)

I realise this is not the best fix approach but there is general data handling problem in the app, when we pass possible undefined values in the hooks which leads to such errors and necessity to check for undefined in each nested hook. 
I believe "right" fix would lead to huge refactoring