### PR TITLE
fix: Avoid permit2 step for wrapping swap

### DIFF
--- a/packages/lib/modules/swap/usePermit2SwapStep.tsx
+++ b/packages/lib/modules/swap/usePermit2SwapStep.tsx
@@ -33,9 +33,6 @@ export function useSignPermit2SwapStep({
   const tokenInAddress = (tokenInInfo?.address ?? '') as Address
 
   const queryData = simulationQuery.data as SdkSimulationResponseWithRouter
-  console.log('COCOCO', { queryData, isPermit2 })
-
-  // if (!queryData) return undefined
 
   function getTokenInAmount(): bigint {
     if (!queryData?.queryOutput) return 0n

--- a/packages/lib/modules/swap/usePermit2SwapStep.tsx
+++ b/packages/lib/modules/swap/usePermit2SwapStep.tsx
@@ -33,9 +33,12 @@ export function useSignPermit2SwapStep({
   const tokenInAddress = (tokenInInfo?.address ?? '') as Address
 
   const queryData = simulationQuery.data as SdkSimulationResponseWithRouter
+  console.log('COCOCO', { queryData, isPermit2 })
 
-  function getTokenInAmount(simulationQuery: SwapSimulationQueryResult): bigint {
-    if (!simulationQuery.data) return 0n
+  // if (!queryData) return undefined
+
+  function getTokenInAmount(): bigint {
+    if (!queryData?.queryOutput) return 0n
     if (queryData.queryOutput.swapKind === SwapKind.GivenIn) {
       return queryData.queryOutput.amountIn.amount
     }
@@ -47,7 +50,7 @@ export function useSignPermit2SwapStep({
 
   const tokenIn: TokenAmountIn = {
     address: tokenInAddress,
-    amount: getTokenInAmount(simulationQuery),
+    amount: getTokenInAmount(),
   }
 
   const signPermit2Fn: SignPermit2Fn = (

--- a/packages/lib/modules/transactions/transaction-steps/useSignPermit2Step.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/useSignPermit2Step.tsx
@@ -102,18 +102,21 @@ export function useSignPermit2Step(params: BasePermit2Params): TransactionStep |
   }
 
   return useMemo(
-    () => ({
-      id: 'sign-permit2',
-      stepType: 'signPermit2',
-      details,
-      labels: {
-        title: getTitle(details),
-        init: `Sign permit`,
-        tooltip: 'Sign permit',
-      },
-      isComplete,
-      renderAction: () => <SignPermitButton />,
-    }),
+    () => {
+      if (!isPermit2) return
+      return {
+        id: 'sign-permit2',
+        stepType: 'signPermit2',
+        details,
+        labels: {
+          title: getTitle(details),
+          init: `Sign permit`,
+          tooltip: 'Sign permit',
+        },
+        isComplete,
+        renderAction: () => <SignPermitButton />,
+      }
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [signPermit2State, isLoading, isConnected, isValidPermit2]
   )


### PR DESCRIPTION
Fixes wrap swaps. For example ETH to WETH.

The rules of react hooks make it difficult to do a clause guard return when `isPermit2` is false so we had to add explicit code to avoid an error when `queryData?.queryOutput` is undefined. 

Can be tested here: 
https://mono-test-v3-git-fix-wrappingswap-balancer.vercel.app/swap/ethereum/ETH/WETH/0.0001
