### PR TITLE
fix: Enforce Wallet connect popup on top

### DIFF
--- a/packages/lib/modules/web3/WagmiConfig.tsx
+++ b/packages/lib/modules/web3/WagmiConfig.tsx
@@ -34,7 +34,19 @@ const connectors = connectorsForWallets(
       ],
     },
   ],
-  { appName, projectId }
+  {
+    appName,
+    projectId,
+    walletConnectParameters: {
+      // Enforce wallet connect popup always on top
+      // More info: https://github.com/wevm/wagmi/discussions/2775
+      qrModalOptions: {
+        themeVariables: {
+          '--wcm-z-index': '9999999',
+        },
+      },
+    },
+  }
 )
 
 export type WagmiConfig = ReturnType<typeof createConfig>


### PR DESCRIPTION
Wallet connect popup was hidden when opened from `Add/Remove/Swap` pool action pages. 

**Before**: 

https://github.com/user-attachments/assets/90545aaf-8b23-4cca-8141-8aff1d64daf6

**After**:

<img width="1489" alt="after" src="https://github.com/user-attachments/assets/155a6888-5273-479c-a119-6acf25462a50">
