### PR TITLE
fix: display unknown price impact for swap PI errors

### DIFF
--- a/packages/lib/modules/price-impact/price-impact.utils.ts
+++ b/packages/lib/modules/price-impact/price-impact.utils.ts
@@ -19,9 +19,19 @@ export function isUnhandledAddPriceImpactError(error: Error | null): boolean {
 }
 
 export function cannotCalculatePriceImpactError(error: Error | null): boolean {
-  const hasUnbalancedAddError = isUnbalancedAddErrorMessage(error)
+  // TODO: narrow unknown price impact errors when we have better knowledge about them
+  // const hasUnbalancedAddError = isUnbalancedAddErrorMessage(error)
 
-  if (error && error.name === 'ContractFunctionExecutionError' && !hasUnbalancedAddError) {
+  if (!error) return false
+
+  // All ContractFunctionExecutionErrors are shown as unknown price impact
+  if (error.name === 'ContractFunctionExecutionError') return true
+  // All Swap PI errors are shown as unknown price impact
+  if (
+    error.message.startsWith(
+      'Unexpected error while calculating addLiquidityUnbalanced PI at Swap step'
+    )
+  ) {
     return true
   }
 

--- a/packages/lib/modules/swap/handlers/DefaultSwap.handler.integration.spec.tsx
+++ b/packages/lib/modules/swap/handlers/DefaultSwap.handler.integration.spec.tsx
@@ -24,7 +24,7 @@ describe('Pool Swap handler with v2 nested pool', async () => {
       tokenOut: daiAddress,
     })
 
-    expect(result.hopCount).toBe(1)
+    expect(result.hopCount).toBe(2)
     expect(result.protocolVersion).toBe(2)
 
     const queryOutput = result.queryOutput as ExactInQueryOutput


### PR DESCRIPTION
SDK team: 
There are a few different errors that can be the cause depending on the edge case really.
Can you not catch any errors on the FE and display the generic error but we keep the more specific SDK error and pass it to Sentry to help us try to debug?

**If there is a price impact error but no query error**:

- show user the generic error, e.g. "Price impact calculation unknown"
- log the error message from the SDK in Sentry
- show button to assume unknown price risk and proceed

**if there is a price impact error and query error:**

- Show query error message from the SDK
