### PR TITLE
fix: Cant scale amount without token metadata in swaps

### DIFF
--- a/packages/lib/modules/swap/SwapLayout.tsx
+++ b/packages/lib/modules/swap/SwapLayout.tsx
@@ -23,6 +23,11 @@ export default function SwapLayout({ props, children }: Props) {
   const initChain = chain ? slugToChainMap[chain as ChainSlug] : getProjectConfig().defaultNetwork
   const initTokens = props.poolActionableTokens || getTokensByChain(initChain)
 
+  if (!initTokens) {
+    // Avoid "Cant scale amount without token metadata" error when tokens are not ready in SwapProvider
+    return null
+  }
+
   return (
     <TransactionStateProvider>
       <Permit2SignatureProvider>


### PR DESCRIPTION
We had a bug when copy-pasting/reloading a swap url where the init tokens where not ready on `SwapProvider` init. 

This PR should fix this [sentry error](https://balancer-labs.sentry.io/issues/5991657041/?project=4506382607712256&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20level%3Afatal&referrer=issue-stream&statsPeriod=7d&stream_index=4).