### PR TITLE
chore: console.log permit in remove query when it does exist

### DIFF
--- a/packages/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquidityBuildCallDataQuery.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquidityBuildCallDataQuery.ts
@@ -68,8 +68,8 @@ export function useRemoveLiquidityBuildCallDataQuery({
       wethIsEth,
       permit: permitSignature,
     })
-
     console.log('Call data built:', res)
+    if (permitSignature) console.log('permit for call data:', permitSignature)
     return res
   }
 


### PR DESCRIPTION
console.logging the permit is useful for debugging edge-case issues. 