### PR TITLE
fix: return zero price impact when user wantsProportional

### DIFF
--- a/packages/lib/config/networks/sepolia.ts
+++ b/packages/lib/config/networks/sepolia.ts
@@ -54,6 +54,7 @@ const networkConfig: NetworkConfig = {
     allowNestedActions: [
       '0x965f7d7387d81056ebf0edaf4a869dc46471a676',
       '0xc9233cc69435591b193b50f702ac31e404a08b10',
+      '0x42de4fa875126fdbaf590b2fc3802adbca58acee',
     ],
   }),
   layerZeroChainId: 10161,

--- a/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
@@ -41,6 +41,8 @@ export function _useAddLiquidity(urlTxHash?: Hash) {
   const [acceptPoolRisks, setAcceptPoolRisks] = useState(false)
   const [wethIsEth, setWethIsEth] = useState(false)
   const [totalUSDValue, setTotalUSDValue] = useState('0')
+  // Used when the user explicitly choses proportional input mode
+  const [wantsProportional, setWantsProportional] = useState(false)
   const [proportionalSlippage, setProportionalSlippage] = useState<string>('0')
 
   const { pool, refetch: refetchPool, isLoading } = usePool()
@@ -110,6 +112,7 @@ export function _useAddLiquidity(urlTxHash?: Hash) {
     handler,
     humanAmountsIn,
     enabled: !urlTxHash,
+    wantsProportional,
   })
 
   /**
@@ -196,6 +199,8 @@ export function _useAddLiquidity(urlTxHash?: Hash) {
     slippage,
     proportionalSlippage,
     isForcedProportionalAdd,
+    wantsProportional,
+    setWantsProportional,
     setProportionalSlippage,
     refetchQuote,
     setHumanAmountIn,

--- a/packages/lib/modules/pool/actions/add-liquidity/form/TokenInputsWithAddable.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/form/TokenInputsWithAddable.tsx
@@ -3,7 +3,7 @@ import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { WalletIcon } from '@repo/lib/shared/components/icons/WalletIcon'
 import { useCurrency } from '@repo/lib/shared/hooks/useCurrency'
 import { Card, HStack, Spacer, VStack, Text, Box, Tooltip } from '@chakra-ui/react'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { XOctagon } from 'react-feather'
 import { useAddLiquidity } from '../AddLiquidityProvider'
 import { TokenInputs } from './TokenInputs'
@@ -26,8 +26,7 @@ export function TokenInputsWithAddable({
 }: Props) {
   const { isConnected } = useUserAccount()
   const { toCurrency } = useCurrency()
-  const { setHumanAmountIn } = useAddLiquidity()
-  const [wantsProportional, setWantsProportional] = useState(false)
+  const { setHumanAmountIn, wantsProportional, setWantsProportional } = useAddLiquidity()
 
   const {
     handleProportionalHumanInputChange,

--- a/packages/lib/modules/pool/actions/add-liquidity/handlers/AddLiquidity.handler.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/handlers/AddLiquidity.handler.ts
@@ -25,7 +25,10 @@ export interface AddLiquidityHandler {
   ): Promise<QueryAddLiquidityOutput>
 
   // Calculate the price impact of adding liquidity
-  getPriceImpact(humanAmountsIn: HumanTokenAmountWithAddress[]): Promise<number>
+  getPriceImpact(
+    humanAmountsIn: HumanTokenAmountWithAddress[],
+    wantsProportional?: boolean // Used when the user is explicitly using the proportional add liquidity feature
+  ): Promise<number>
   /*
     Build tx callData payload for adding liquidity
     It is responsibility of the UI to avoid calling buildAddLiquidityCallData before the last queryAddLiquidity was finished

--- a/packages/lib/modules/pool/actions/add-liquidity/handlers/BaseUnbalancedAddLiquidity.handler.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/handlers/BaseUnbalancedAddLiquidity.handler.ts
@@ -37,11 +37,17 @@ export abstract class BaseUnbalancedAddLiquidityHandler implements AddLiquidityH
     return { bptOut: sdkQueryOutput.bptOut, to: sdkQueryOutput.to, sdkQueryOutput }
   }
 
-  public async getPriceImpact(humanAmountsIn: HumanTokenAmountWithAddress[]): Promise<number> {
+  public async getPriceImpact(
+    humanAmountsIn: HumanTokenAmountWithAddress[],
+    wantsProportional = false
+  ): Promise<number> {
     if (areEmptyAmounts(humanAmountsIn)) {
       // Avoid price impact calculation when there are no amounts in
       return 0
     }
+
+    // When the user is explicitly using the proportional add liquidity feature
+    if (wantsProportional) return 0
 
     const addLiquidityInput = this.constructSdkInput(humanAmountsIn)
 

--- a/packages/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.ts
@@ -17,9 +17,15 @@ type Params = {
   handler: AddLiquidityHandler
   humanAmountsIn: HumanTokenAmountWithAddress[]
   enabled: boolean
+  wantsProportional?: boolean
 }
 
-export function useAddLiquidityPriceImpactQuery({ handler, humanAmountsIn, enabled }: Params) {
+export function useAddLiquidityPriceImpactQuery({
+  handler,
+  humanAmountsIn,
+  enabled,
+  wantsProportional = false,
+}: Params) {
   const { pool, chainId } = usePool()
   const { userAddress } = useUserAccount()
   const { slippage } = useUserSettings()
@@ -36,7 +42,7 @@ export function useAddLiquidityPriceImpactQuery({ handler, humanAmountsIn, enabl
 
   const queryKey = addLiquidityKeys.priceImpact(params)
 
-  const queryFn = async () => handler.getPriceImpact(humanAmountsIn)
+  const queryFn = async () => handler.getPriceImpact(humanAmountsIn, wantsProportional)
 
   return useQuery({
     queryKey,

--- a/packages/lib/modules/price-impact/price-impact.utils.ts
+++ b/packages/lib/modules/price-impact/price-impact.utils.ts
@@ -28,6 +28,12 @@ export function cannotCalculatePriceImpactError(error: Error | null): boolean {
   if (error.name === 'ContractFunctionExecutionError') return true
   // All Swap PI errors are shown as unknown price impact
   if (
+    error.message.startsWith('Unexpected error while calculating') &&
+    error.message.includes('PI')
+  ) {
+    return true
+  }
+  if (
     error.message.startsWith(
       'Unexpected error while calculating addLiquidityUnbalanced PI at Swap step'
     )


### PR DESCRIPTION
Now adding in proportional mode will return hadcoded zero price impact to avoid problems in PI calculations. 

https://mono-test-v3-git-fix-proportionalzeropriceimpact-balancer.vercel.app/pools/sepolia/v3/0x2ff3b96e0057a1f25f1d62ab800554ccdb268ab8/add-liquidity

<img width="601" alt="Screenshot 2024-11-28 at 16 44 54" src="https://github.com/user-attachments/assets/6a5dda7e-b704-4cb3-9864-aa369f9b1c9a">
