### PR TITLE
feat: handle v3 invariant add errors

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -55,6 +55,7 @@ import { ConnectWallet } from '@repo/lib/modules/web3/ConnectWallet'
 import { BalAlert } from '@repo/lib/shared/components/alerts/BalAlert'
 import { SafeAppAlert } from '@repo/lib/shared/components/alerts/SafeAppAlert'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
+import { UnbalancedAddError } from '@repo/lib/shared/components/errors/UnbalancedAddError'
 
 // small wrapper to prevent out of context error
 export function AddLiquidityForm() {
@@ -262,6 +263,9 @@ function AddLiquidityMainForm() {
               customErrorName="Error in query simulation"
               error={simulationQuery.error}
             />
+          )}
+          {(simulationQuery.isError || priceImpactQuery.isError) && (
+            <UnbalancedAddError error={simulationQuery.error || priceImpactQuery.error} />
           )}
           {isConnected ? (
             <Tooltip label={isDisabled ? disabledReason : ''}>

--- a/packages/lib/modules/swap/handlers/DefaultSwap.handler.ts
+++ b/packages/lib/modules/swap/handlers/DefaultSwap.handler.ts
@@ -15,10 +15,7 @@ export class DefaultSwapHandler extends BaseDefaultSwapHandler {
   async simulate({ ...variables }: SimulateSwapInputs): Promise<SdkSimulateSwapResponse> {
     const { data } = await this.apolloClient.query({
       query: GetSorSwapsDocument,
-      variables: {
-        ...variables,
-        queryBatchSwap: false,
-      }, // We don't need the API to do a query because we're doing that via the SDK below.
+      variables,
       fetchPolicy: 'no-cache',
       notifyOnNetworkStatusChange: true,
     })

--- a/packages/lib/shared/components/errors/GenericError.tsx
+++ b/packages/lib/shared/components/errors/GenericError.tsx
@@ -24,6 +24,8 @@ export function GenericError({ error: _error, customErrorName, ...rest }: Props)
   if (isUserRejectedError(error)) return null
   const errorName = customErrorName ? `${customErrorName} (${error.name})` : error.name
 
+  if (isUnbalancedAddError(_error)) return null //We handle this specific error in UnbalancedAddError component
+
   if (isViemHttpFetchError(_error)) {
     return (
       <ErrorAlert title={customErrorName} {...rest}>
@@ -68,16 +70,6 @@ export function GenericError({ error: _error, customErrorName, ...rest }: Props)
           It looks like you don&apos;t have enough gas to complete this transaction. If you believe
           this is a mistake, please report it in{' '}
           <BalAlertLink href="https://discord.balancer.fi/">our discord.</BalAlertLink>
-        </Text>
-      </ErrorAlert>
-    )
-  }
-
-  if (isUnbalancedAddError(_error)) {
-    return (
-      <ErrorAlert title={customErrorName} {...rest}>
-        <Text color="black" variant="secondary">
-          Your input(s) would excessively unbalance the pool. Please adjust to be more proportional.
         </Text>
       </ErrorAlert>
     )

--- a/packages/lib/shared/components/errors/UnbalancedAddError.tsx
+++ b/packages/lib/shared/components/errors/UnbalancedAddError.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { AlertProps, Text } from '@chakra-ui/react'
+import { isUnbalancedAddError } from '../../utils/error-filters'
+import { BalAlertLink } from '../alerts/BalAlertLink'
+import { ErrorAlert } from './ErrorAlert'
+
+type Props = AlertProps & {
+  error?: Error | null
+}
+
+export function UnbalancedAddError({ error }: Props) {
+  function goToProportionalAdds() {
+    // TODO: implement when we have the add tabs (unbalanced and proportional).
+    console.log('Go to proportional adds')
+  }
+
+  if (isUnbalancedAddError(error)) {
+    return (
+      <ErrorAlert title="Unbalanced error">
+        <Text color="black" variant="secondary">
+          Your input(s) would excessively unbalance the pool.{' '}
+          <BalAlertLink onClick={goToProportionalAdds}>Please use proportional mode.</BalAlertLink>
+        </Text>
+      </ErrorAlert>
+    )
+  }
+
+  return null
+}

--- a/packages/lib/shared/services/api/swap.graphql
+++ b/packages/lib/shared/services/api/swap.graphql
@@ -4,7 +4,6 @@ query GetSorSwaps(
   $swapType: GqlSorSwapType!
   $swapAmount: AmountHumanReadable!
   $chain: GqlChain!
-  $queryBatchSwap: Boolean!
   $poolIds: [String!]
 ) {
   swaps: sorGetSwapPaths(
@@ -13,7 +12,6 @@ query GetSorSwaps(
     swapType: $swapType
     swapAmount: $swapAmount
     chain: $chain
-    queryBatchSwap: $queryBatchSwap
     poolIds: $poolIds
   ) {
     effectivePrice

--- a/packages/lib/shared/utils/error-filters.ts
+++ b/packages/lib/shared/utils/error-filters.ts
@@ -65,7 +65,10 @@ export function isUnbalancedAddErrorMessage(error: Error | null): boolean {
 }
 
 export function isInvariantRatioSimulationErrorMessage(errorMessage?: string): boolean {
-  return errorMessage?.includes('InvariantRatioAboveMax') || errorMessage?.includes('InvariantRatioBelowMin') 
+  return (
+    !!errorMessage?.includes('InvariantRatioAboveMax') ||
+    !!errorMessage?.includes('InvariantRatioBelowMin')
+  )
 }
 
 export function isInvariantRatioPIErrorMessage(errorMessage?: string): boolean {

--- a/packages/lib/shared/utils/error-filters.ts
+++ b/packages/lib/shared/utils/error-filters.ts
@@ -65,9 +65,7 @@ export function isUnbalancedAddErrorMessage(error: Error | null): boolean {
 }
 
 export function isInvariantRatioSimulationErrorMessage(errorMessage?: string): boolean {
-  if (errorMessage?.includes('InvariantRatioAboveMax')) return true
-  if (errorMessage?.includes('InvariantRatioBelowMin')) return true
-  return false
+  return errorMessage?.includes('InvariantRatioAboveMax') || errorMessage?.includes('InvariantRatioBelowMin') 
 }
 
 export function isInvariantRatioPIErrorMessage(errorMessage?: string): boolean {

--- a/packages/lib/shared/utils/error-filters.ts
+++ b/packages/lib/shared/utils/error-filters.ts
@@ -47,7 +47,14 @@ export function isPausedErrorMessage(errorMessage: string): boolean {
 
 export function isUnbalancedAddError(error?: Error | null): boolean {
   if (!error) return false
-  return isUnbalancedAddErrorMessage(error)
+  if (
+    isInvariantRatioSimulationErrorMessage(error?.message) ||
+    isInvariantRatioPIErrorMessage(error?.message) ||
+    isUnbalancedAddErrorMessage(error)
+  ) {
+    return true
+  }
+  return false
 }
 
 export function isUnbalancedAddErrorMessage(error: Error | null): boolean {
@@ -55,4 +62,21 @@ export function isUnbalancedAddErrorMessage(error: Error | null): boolean {
   const hasErrors = (errorString: string) => error?.message.includes(errorString)
 
   return errorStrings.some(hasErrors)
+}
+
+export function isInvariantRatioSimulationErrorMessage(errorMessage?: string): boolean {
+  if (errorMessage?.includes('InvariantRatioAboveMax')) return true
+  if (errorMessage?.includes('InvariantRatioBelowMin')) return true
+  return false
+}
+
+export function isInvariantRatioPIErrorMessage(errorMessage?: string): boolean {
+  if (
+    errorMessage?.includes(
+      'addLiquidityUnbalanced operation will fail at SC level with user defined input.'
+    )
+  ) {
+    return true
+  }
+  return false
 }

--- a/packages/lib/shared/utils/query-errors.ts
+++ b/packages/lib/shared/utils/query-errors.ts
@@ -7,6 +7,7 @@ import {
 } from '@sentry/types'
 import { SentryError, ensureError } from './errors'
 import {
+  isInvariantRatioPIErrorMessage,
   isInvariantRatioSimulationErrorMessage,
   isNotEnoughGasErrorMessage,
   isPausedErrorMessage,
@@ -360,10 +361,7 @@ export function shouldIgnore(message: string, stackTrace = ''): boolean {
     When hitting Invariant Ratio Above max error (only in v3 pools) we enforce proportional UX so we don't need sentry logs
     Context: https://github.com/balancer/balancer-maths/blob/8aaf871acd9e138ba855f03be723cdfd630f4246/typescript/src/weighted/weightedMath.ts#L10
     */
-  if (
-    isInvariantRatioSimulationErrorMessage(message) ||
-    isInvariantRatioSimulationErrorMessage(message)
-  ) {
+  if (isInvariantRatioSimulationErrorMessage(message) || isInvariantRatioPIErrorMessage(message)) {
     return true
   }
 

--- a/packages/lib/shared/utils/query-errors.ts
+++ b/packages/lib/shared/utils/query-errors.ts
@@ -7,6 +7,7 @@ import {
 } from '@sentry/types'
 import { SentryError, ensureError } from './errors'
 import {
+  isInvariantRatioSimulationErrorMessage,
   isNotEnoughGasErrorMessage,
   isPausedErrorMessage,
   isUserRejectedError,
@@ -354,6 +355,17 @@ export function shouldIgnore(message: string, stackTrace = ''): boolean {
   }
 
   if (isPausedErrorMessage(message)) return true
+
+  /*
+    When hitting Invariant Ratio Above max error (only in v3 pools) we enforce proportional UX so we don't need sentry logs
+    Context: https://github.com/balancer/balancer-maths/blob/8aaf871acd9e138ba855f03be723cdfd630f4246/typescript/src/weighted/weightedMath.ts#L10
+    */
+  if (
+    isInvariantRatioSimulationErrorMessage(message) ||
+    isInvariantRatioSimulationErrorMessage(message)
+  ) {
+    return true
+  }
 
   return false
 }


### PR DESCRIPTION
Note that we will display the alert and "advice" the user to use proportional inputs in this cases: 
- v3 vault invariant errors
- v2 unbalanced error 

https://github.com/user-attachments/assets/55f844ff-f439-43ee-b8ed-256cb04d7f65

This PR also fixes a GraphQL field  deprecation (`queryBatchSwap` field)

