### PR TITLE
feat: use M1 runner in GHA CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   Build:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
 
@@ -34,7 +34,7 @@ jobs:
         run: pnpm run build
 
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - name: Setup
@@ -48,7 +48,7 @@ jobs:
       #   run: pnpm stylelint
 
   Unit-Test:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - name: Setup
@@ -59,7 +59,7 @@ jobs:
         run: pnpm test:unit
 
   Integration-Test:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - name: Setup

--- a/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.integration.spec.ts
+++ b/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.integration.spec.ts
@@ -65,10 +65,7 @@ test('queries add liquidity transaction', async () => {
   expect(result.current.receivedBptUnits).toBe('7.669852124112308228')
 })
 
-/*
-  Skip until dRPC fixes issue with polygon tx queries
-*/
-test.skip('queries add liquidity with native token', async () => {
+test('queries add liquidity with native token', async () => {
   // https://polygonscan.com/tx/0x611a0eeeff15c2a5efc587b173fa577475134de2554a452259f112db67bd4de8
   const userAddress = '0xf76142b79Db34E57852d68F9c52C0E24f7349647'
   const txHash = '0x611a0eeeff15c2a5efc587b173fa577475134de2554a452259f112db67bd4de8'
@@ -88,10 +85,7 @@ test.skip('queries add liquidity with native token', async () => {
   expect(result.current.receivedBptUnits).toBe('0.984524168989962117')
 })
 
-/*
-  Skip until dRPC fixes issue with polygon tx queries
-*/
-test.skip('queries remove liquidity transaction', async () => {
+test('queries remove liquidity transaction', async () => {
   // https://etherscan.io/tx/0x71301b46984d3d2e6b58c1fc0c99cc0561ec0f26d53bda8413528a7fb6828fc3
   const userAddress = '0x84f240cA232917d771DFBbd8C917B4669Ed640CD'
   const txHash = '0x71301b46984d3d2e6b58c1fc0c99cc0561ec0f26d53bda8413528a7fb6828fc3'
@@ -115,10 +109,7 @@ test.skip('queries remove liquidity transaction', async () => {
   expect(result.current.sentBptUnits).toBe('6439.400687368663510166')
 })
 
-/*
-  Skip until dRPC fixes issue with polygon tx queries
-*/
-describe.skip('queries swap transaction', () => {
+describe('queries swap transaction', () => {
   const maticAddress = '0x0000000000000000000000000000000000001010'
   const wMaticAddress = '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
   const daiAddress = '0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063'


### PR DESCRIPTION
Once cached, the workflows are faster than in ubuntu and integration anvil tests looks more reliable 🤞

<img width="311" alt="Screenshot 2024-11-29 at 17 33 50" src="https://github.com/user-attachments/assets/fd4e60c1-7899-4e80-8a00-e7ba20e82ccc">
