### PR TITLE
fix: slippage inputs & price impact sign

### DIFF
--- a/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
+++ b/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
@@ -21,7 +21,7 @@ import { useTokens } from '../TokensProvider'
 import { useTokenBalances } from '../TokenBalancesProvider'
 import { useTokenInput } from './useTokenInput'
 import { useCurrency } from '@repo/lib/shared/hooks/useCurrency'
-import { blockInvalidNumberInput, bn, fNum } from '@repo/lib/shared/utils/numbers'
+import { blockInvalidNumberInput, bn, fNum, isZero } from '@repo/lib/shared/utils/numbers'
 import { TokenIcon } from '../TokenIcon'
 import { useTokenInputsValidation } from '../TokenInputsValidationProvider'
 import { ChevronDown } from 'react-feather'
@@ -128,6 +128,12 @@ function TokenInputFooter({
     }
   }
 
+  const priceImpactLabel = priceImpact
+    ? isZero(priceImpact)
+      ? ' (0.00%)'
+      : ` (-${fNum('priceImpact', priceImpact)})`
+    : ''
+
   return (
     <HStack h="4" justify="space-between" w="full">
       {isBalancesLoading || !isMounted ? (
@@ -139,9 +145,7 @@ function TokenInputFooter({
           variant="secondary"
         >
           {toCurrency(usdValue, { abbreviated: false })}
-          {showPriceImpact &&
-            priceImpactLevel !== 'unknown' &&
-            ` (-${fNum('priceImpact', priceImpact)})`}
+          {showPriceImpact && priceImpactLevel !== 'unknown' && priceImpactLabel}
         </Text>
       )}
       {isBalancesLoading || !isMounted ? (

--- a/packages/lib/modules/user/settings/UserSettings.tsx
+++ b/packages/lib/modules/user/settings/UserSettings.tsx
@@ -31,6 +31,13 @@ interface SlippageInputProps {
 export function SlippageInput({ slippage, setSlippage }: SlippageInputProps) {
   const presetOpts = ['0.5', '1', '2']
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.currentTarget.value
+    if (parseFloat(value) <= 50 || !value) {
+      setSlippage(value)
+    }
+  }
+
   return (
     <VStack align="start" w="full">
       <InputGroup>
@@ -38,8 +45,9 @@ export function SlippageInput({ slippage, setSlippage }: SlippageInputProps) {
           autoComplete="off"
           autoCorrect="off"
           bg="background.level1"
+          // max={50}
           min={0}
-          onChange={e => setSlippage(e.currentTarget.value)}
+          onChange={handleChange}
           onKeyDown={blockInvalidNumberInput}
           type="number"
           value={slippage}


### PR DESCRIPTION
Fixes 2 QA issues: 

- 50% max slippage input
- No negative sign when price impact is zero