### PR TITLE
fix: keep user input when calculating proportional inputs

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/form/useProportionalInputs.tsx
@@ -31,7 +31,16 @@ export function useProportionalInputs() {
       wethIsEth,
     })
 
-    setHumanAmountsIn(proportionalHumanAmountsIn)
+    const proportionalHumanAmountsInWithOriginalUserInput = proportionalHumanAmountsIn.map(
+      amount => {
+        if (isSameAddress(amount.tokenAddress, tokenAddress)) {
+          return { ...amount, humanAmount } // We don't want to change the user input with the result of the proportional calculation
+        }
+        return amount
+      }
+    )
+
+    setHumanAmountsIn(proportionalHumanAmountsInWithOriginalUserInput)
   }
 
   /*
@@ -62,11 +71,6 @@ export function _calculateProportionalHumanAmountsIn({
   wethIsEth,
 }: Params): HumanTokenAmountWithAddress[] {
   const referenceAmount: InputAmount = helpers.toSdkInputAmounts([{ tokenAddress, humanAmount }])[0]
-
-  // getBptAmountFromReferenceAmount(
-  //   constructProportionalSdkAddInput(helpers.chainId, referenceAmount, userAddress as Address),
-  //   helpers.poolStateWithBalances
-  // ).then(result => console.log({ result }))
 
   const proportionalAmounts = calculateProportionalAmounts(
     helpers.poolStateWithBalances,

--- a/packages/lib/modules/transactions/transaction-steps/useSignPermit2Step.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/useSignPermit2Step.tsx
@@ -123,9 +123,9 @@ export function useSignPermit2Step(params: BasePermit2Params): TransactionStep |
 }
 
 function getTitle(details?: StepDetails): string {
-  if (!details?.batchApprovalTokens) return `Permit on balancer`
+  if (!details?.batchApprovalTokens) return `Permit on Balancer`
   if (details.batchApprovalTokens.length === 1) {
-    return `${details.batchApprovalTokens[0]}: Permit on balancer`
+    return `${details.batchApprovalTokens[0]}: Permit on Balancer`
   }
   return 'Sign token approvals'
 }


### PR DESCRIPTION
Pool to reproduce: 
https://test.balancer.fi/pools/sepolia/v3/0xa8c18ce5e987d7d82ccaccb93223e9bb5df4a3c0/add-liquidity

**Before:** 

https://github.com/user-attachments/assets/e962673c-91e4-4746-9e8b-888e833151c7

**After:** 

https://github.com/user-attachments/assets/bd1a19c5-946e-47d2-b140-1a07ddba1ec6

