### PR TITLE
fix: avoid default mainnet.id in useManagedSendTransaction

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/useAddLiquidityStep.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/useAddLiquidityStep.tsx
@@ -13,6 +13,7 @@ import {
 } from './queries/useAddLiquidityBuildCallDataQuery'
 import { usePool } from '../../PoolProvider'
 import { useTenderly } from '@repo/lib/modules/web3/useTenderly'
+import { DisabledTransactionButton } from '@repo/lib/modules/transactions/transaction-steps/TransactionStepButton'
 
 export const addLiquidityStepId = 'add-liquidity'
 
@@ -71,14 +72,17 @@ export function useAddLiquidityStep(params: AddLiquidityStepParams): Transaction
       onActivated: () => setIsStepActivated(true),
       onDeactivated: () => setIsStepActivated(false),
       onSuccess,
-      renderAction: () => (
-        <ManagedSendTransactionButton
-          gasEstimationMeta={gasEstimationMeta}
-          id={addLiquidityStepId}
-          labels={labels}
-          txConfig={buildCallDataQuery.data}
-        />
-      ),
+      renderAction: () => {
+        if (!buildCallDataQuery.data) return <DisabledTransactionButton />
+        return (
+          <ManagedSendTransactionButton
+            gasEstimationMeta={gasEstimationMeta}
+            id={addLiquidityStepId}
+            labels={labels}
+            txConfig={buildCallDataQuery.data}
+          />
+        )
+      },
     }),
     [transaction, simulationQuery.data, buildCallDataQuery.data]
   )

--- a/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquidityStep.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquidityStep.tsx
@@ -13,6 +13,7 @@ import {
   useRemoveLiquidityBuildCallDataQuery,
 } from './queries/useRemoveLiquidityBuildCallDataQuery'
 import { useTenderly } from '@repo/lib/modules/web3/useTenderly'
+import { DisabledTransactionButton } from '@repo/lib/modules/transactions/transaction-steps/TransactionStepButton'
 
 export const removeLiquidityStepId = 'remove-liquidity'
 
@@ -67,14 +68,17 @@ export function useRemoveLiquidityStep(params: RemoveLiquidityStepParams): Trans
       stepType: 'removeLiquidity',
       labels,
       isComplete,
-      renderAction: () => (
-        <ManagedSendTransactionButton
-          gasEstimationMeta={gasEstimationMeta}
-          id={removeLiquidityStepId}
-          labels={labels}
-          txConfig={buildCallDataQuery.data}
-        />
-      ),
+      renderAction: () => {
+        if (!buildCallDataQuery.data) return <DisabledTransactionButton />
+        return (
+          <ManagedSendTransactionButton
+            gasEstimationMeta={gasEstimationMeta}
+            id={removeLiquidityStepId}
+            labels={labels}
+            txConfig={buildCallDataQuery.data}
+          />
+        )
+      },
       onActivated: () => setIsStepActivated(true),
       onDeactivated: () => setIsStepActivated(false),
       onSuccess: () => refetchPoolUserBalances(),

--- a/packages/lib/modules/price-impact/PriceImpactAccordion.tsx
+++ b/packages/lib/modules/price-impact/PriceImpactAccordion.tsx
@@ -93,6 +93,7 @@ export function PriceImpactAccordion({
       {(priceImpactLevel === 'high' || priceImpactLevel === 'max' || isUnknownPriceImpact) && (
         <>
           <VStack align="start" mt="md" spacing="md" w="full">
+            <div>LEVEL: {priceImpactLevel}</div>
             {!avoidPriceImpactAlert && (
               <Alert status="error">
                 <PriceImpactIcon mt="1" priceImpactLevel={priceImpactLevel} size={24} />

--- a/packages/lib/modules/swap/useSwapStep.tsx
+++ b/packages/lib/modules/swap/useSwapStep.tsx
@@ -17,6 +17,7 @@ import { useTokenBalances } from '../tokens/TokenBalancesProvider'
 import { useUserAccount } from '../web3/UserAccountProvider'
 import { useTenderly } from '../web3/useTenderly'
 import { getChainId } from '@repo/lib/config/app.config'
+import { DisabledTransactionButton } from '../transactions/transaction-steps/TransactionStepButton'
 
 export const swapStepId = 'swap'
 
@@ -88,16 +89,19 @@ export function useSwapStep({
       onActivated: () => setIsBuildQueryEnabled(true),
       onDeactivated: () => setIsBuildQueryEnabled(false),
       onSuccess: () => refetchBalances(),
-      renderAction: () => (
-        <VStack w="full">
-          <ManagedSendTransactionButton
-            gasEstimationMeta={gasEstimationMeta}
-            id={swapStepId}
-            labels={labels}
-            txConfig={buildSwapQuery.data}
-          />
-        </VStack>
-      ),
+      renderAction: () => {
+        if (!buildSwapQuery.data) return <DisabledTransactionButton />
+        return (
+          <VStack w="full">
+            <ManagedSendTransactionButton
+              gasEstimationMeta={gasEstimationMeta}
+              id={swapStepId}
+              labels={labels}
+              txConfig={buildSwapQuery.data}
+            />
+          </VStack>
+        )
+      },
     }),
     [transaction, simulationQuery.data, buildSwapQuery.data]
   )

--- a/packages/lib/modules/transactions/transaction-steps/TransactionStepButton.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/TransactionStepButton.tsx
@@ -117,3 +117,7 @@ function TransactionError({ step }: Props) {
 
   return null
 }
+
+export function DisabledTransactionButton() {
+  return <Button isDisabled isLoading size="lg" variant="primary" w="full" width="full" />
+}

--- a/packages/lib/modules/web3/contracts/useManagedSendTransaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedSendTransaction.ts
@@ -18,14 +18,13 @@ import {
 } from '@repo/lib/shared/utils/query-errors'
 import { useNetworkConfig } from '@repo/lib/config/useNetworkConfig'
 import { useRecentTransactions } from '../../transactions/RecentTransactionsProvider'
-import { mainnet } from 'viem/chains'
 import { useTxHash } from '../safe.hooks'
 import { getWaitForReceiptTimeout } from './wagmi-helpers'
 import { onlyExplicitRefetch } from '@repo/lib/shared/utils/queries'
 
 export type ManagedSendTransactionInput = {
   labels: TransactionLabels
-  txConfig?: TransactionConfig
+  txConfig: TransactionConfig
   gasEstimationMeta?: Record<string, unknown>
 }
 
@@ -34,8 +33,7 @@ export function useManagedSendTransaction({
   txConfig,
   gasEstimationMeta,
 }: ManagedSendTransactionInput) {
-  // chainId will always have the correct value as the transaction is disabled when txConfig is undefined
-  const chainId = txConfig?.chainId || mainnet.id
+  const chainId = txConfig.chainId
   const { shouldChangeNetwork } = useChainSwitch(chainId)
   const { minConfirmations } = useNetworkConfig()
   const { updateTrackedTransaction } = useRecentTransactions()

--- a/packages/lib/shared/components/errors/UnbalancedError.test.tsx
+++ b/packages/lib/shared/components/errors/UnbalancedError.test.tsx
@@ -10,11 +10,6 @@ describe('getErrorLabels', () => {
   const unbalancedAddErrorV2 = new Error('BAL#304')
   const unbalancedAddErrorV3 = new Error('queryAddLiquidityUnbalanced')
 
-  it('should return default error labels when no error is provided', () => {
-    const result = getErrorLabels(true, null)
-    expect(result).toBeUndefined()
-  })
-
   it('should return correct labels for isInvariantRatioAboveMaxSimulationErrorMessage', () => {
     const result = getErrorLabels(true, invariantRatioAboveMaxError)
     expect(result).toEqual({


### PR DESCRIPTION
Running `useManagedSendTransaction` hook with `undefined` `txConfig` was causing weird issues. 

It does not make sense to run that code when the txConfig is not ready so better to render a disabled button in that case. 