### PR TITLE
fix: price impact exceeds percentage

### DIFF
--- a/packages/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquidityPriceImpactQuery.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/queries/useRemoveLiquidityPriceImpactQuery.ts
@@ -39,7 +39,7 @@ export function useRemoveLiquidityPriceImpactQuery({
     userAddress,
     slippage,
     poolId,
-    humanBptIn: humanBptIn,
+    humanBptIn: debouncedBptIn,
     tokenOut,
   }
 

--- a/packages/lib/modules/price-impact/PriceImpactAccordion.tsx
+++ b/packages/lib/modules/price-impact/PriceImpactAccordion.tsx
@@ -18,13 +18,11 @@ import {
   CardFooter,
   CardBody,
 } from '@chakra-ui/react'
-import {
-  PriceImpactLevel,
-  usePriceImpact,
-} from '@repo/lib/modules/price-impact/PriceImpactProvider'
+import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { fNum } from '@repo/lib/shared/utils/numbers'
 import { ReactNode, useEffect } from 'react'
 import { PriceImpactAcceptModal } from './PriceImpactAcceptModal'
+import { getPriceImpactExceedsLabel } from './price-impact.utils'
 
 interface PriceImpactAccordionProps {
   setNeedsToAcceptPIRisk: (value: boolean) => void
@@ -69,19 +67,6 @@ export function PriceImpactAccordion({
       setAcceptPriceImpactRisk(true)
     } else {
       acceptHighImpactDisclosure.onOpen()
-    }
-  }
-
-  const getPriceImpactExceedsLabel = (priceImpactLevel: PriceImpactLevel) => {
-    switch (priceImpactLevel) {
-      case 'medium':
-        return '1.00%'
-      case 'high':
-        return '5.00%'
-      case 'max':
-        return '10.00%'
-      default:
-        return ''
     }
   }
 

--- a/packages/lib/modules/price-impact/PriceImpactAccordion.tsx
+++ b/packages/lib/modules/price-impact/PriceImpactAccordion.tsx
@@ -18,7 +18,10 @@ import {
   CardFooter,
   CardBody,
 } from '@chakra-ui/react'
-import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvider'
+import {
+  PriceImpactLevel,
+  usePriceImpact,
+} from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { fNum } from '@repo/lib/shared/utils/numbers'
 import { ReactNode, useEffect } from 'react'
 import { PriceImpactAcceptModal } from './PriceImpactAcceptModal'
@@ -69,6 +72,19 @@ export function PriceImpactAccordion({
     }
   }
 
+  const getPriceImpactExceedsLabel = (priceImpactLevel: PriceImpactLevel) => {
+    switch (priceImpactLevel) {
+      case 'medium':
+        return '1.00%'
+      case 'high':
+        return '5.00%'
+      case 'max':
+        return '10.00%'
+      default:
+        return ''
+    }
+  }
+
   return (
     <Box w="full">
       <Accordion allowToggle variant="button" w="full">
@@ -93,7 +109,6 @@ export function PriceImpactAccordion({
       {(priceImpactLevel === 'high' || priceImpactLevel === 'max' || isUnknownPriceImpact) && (
         <>
           <VStack align="start" mt="md" spacing="md" w="full">
-            <div>LEVEL: {priceImpactLevel}</div>
             {!avoidPriceImpactAlert && (
               <Alert status="error">
                 <PriceImpactIcon mt="1" priceImpactLevel={priceImpactLevel} size={24} />
@@ -101,9 +116,7 @@ export function PriceImpactAccordion({
                   <AlertTitle>
                     {isUnknownPriceImpact
                       ? 'Unknown price impact'
-                      : `Price impact is high: Exceeds ${
-                          priceImpactLevel === 'high' ? '1' : '5'
-                        }.00%`}
+                      : `Price impact is high: Exceeds ${getPriceImpactExceedsLabel(priceImpactLevel)}`}
                   </AlertTitle>
                   <AlertDescription>
                     <Text color="font.dark" fontSize="sm">

--- a/packages/lib/modules/price-impact/PriceImpactProvider.tsx
+++ b/packages/lib/modules/price-impact/PriceImpactProvider.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, XOctagon } from 'react-feather'
 import { PropsWithChildren, createContext, useEffect, useState } from 'react'
 import { useMandatoryContext } from '../../shared/utils/contexts'
 import { Box, BoxProps } from '@chakra-ui/react'
+import { getPriceImpactColor, getPriceImpactLevel } from './price-impact.utils'
 
 export type PriceImpactLevel = 'low' | 'medium' | 'high' | 'max' | 'unknown'
 
@@ -11,28 +12,6 @@ export function _usePriceImpact() {
   const [acceptPriceImpactRisk, setAcceptPriceImpactRisk] = useState(false)
   const [priceImpact, setPriceImpact] = useState<string | number | undefined | null>()
   const [hasToAcceptHighPriceImpact, setHasToAcceptHighPriceImpact] = useState(false)
-
-  function getPriceImpactLevel(priceImpact: number): PriceImpactLevel {
-    if (priceImpact === null || priceImpact === undefined) return 'unknown'
-    if (priceImpact < 0.01) return 'low' // 1%
-    if (priceImpact < 0.05) return 'medium' // 5%
-    if (priceImpact < 0.1) return 'high' // 10%
-    return 'max'
-  }
-
-  function getPriceImpactColor(priceImpactLevel: PriceImpactLevel) {
-    switch (priceImpactLevel) {
-      case 'unknown':
-      case 'high':
-      case 'max':
-        return 'red.400'
-      case 'medium':
-        return 'font.warning'
-      case 'low':
-      default:
-        return 'grayText'
-    }
-  }
 
   function PriceImpactIcon({
     priceImpactLevel,
@@ -95,7 +74,6 @@ export function _usePriceImpact() {
     priceImpact,
     setPriceImpactColor,
     setAcceptPriceImpactRisk,
-    getPriceImpactColor,
     PriceImpactIcon,
     setPriceImpact,
     setPriceImpactLevel,

--- a/packages/lib/modules/price-impact/PriceImpactProvider.tsx
+++ b/packages/lib/modules/price-impact/PriceImpactProvider.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren, createContext, useEffect, useState } from 'react'
 import { useMandatoryContext } from '../../shared/utils/contexts'
 import { Box, BoxProps } from '@chakra-ui/react'
 
-type PriceImpactLevel = 'low' | 'medium' | 'high' | 'max' | 'unknown'
+export type PriceImpactLevel = 'low' | 'medium' | 'high' | 'max' | 'unknown'
 
 export function _usePriceImpact() {
   const [priceImpactLevel, setPriceImpactLevel] = useState<PriceImpactLevel>('low')

--- a/packages/lib/modules/price-impact/price-impact.utils.ts
+++ b/packages/lib/modules/price-impact/price-impact.utils.ts
@@ -1,5 +1,6 @@
 import { bn } from '@repo/lib/shared/utils/numbers'
 import BigNumber from 'bignumber.js'
+import { PriceImpactLevel } from './PriceImpactProvider'
 
 /*
  ABA priceImpact calculation has some known limitations. Examples:
@@ -51,4 +52,39 @@ export function calcMarketPriceImpact(usdIn: string, usdOut: string) {
   const priceImpact = bn(1).minus(bn(usdIn).div(usdOut))
 
   return BigNumber.min(priceImpact, 0).abs().toString()
+}
+
+export function getPriceImpactColor(priceImpactLevel: PriceImpactLevel) {
+  switch (priceImpactLevel) {
+    case 'unknown':
+    case 'high':
+    case 'max':
+      return 'red.400'
+    case 'medium':
+      return 'font.warning'
+    case 'low':
+    default:
+      return 'grayText'
+  }
+}
+
+export function getPriceImpactLevel(priceImpact: number): PriceImpactLevel {
+  if (priceImpact === null || priceImpact === undefined) return 'unknown'
+  if (priceImpact < 0.01) return 'low' // 1%
+  if (priceImpact < 0.05) return 'medium' // 5%
+  if (priceImpact < 0.1) return 'high' // 10%
+  return 'max'
+}
+
+export const getPriceImpactExceedsLabel = (priceImpactLevel: PriceImpactLevel) => {
+  switch (priceImpactLevel) {
+    case 'medium':
+      return '1.00%'
+    case 'high':
+      return '5.00%'
+    case 'max':
+      return '10.00%'
+    default:
+      return ''
+  }
 }


### PR DESCRIPTION
**"Price Impact exceeds label" was wrong.** 
- Refactored to a function to make it clearer. 
- Moved related functions to the same file for more cohesion 
- We won't use `medium` for now but the code is clearer.

**Remove query keys were not using debounced input** 
Fixes [QA functional issue # 15](https://www.notion.so/QA-Testing-109e395e228180a494edf9a1fdd11027#a0a12105b0004628a0361033ea0fe72e)