### PR TITLE
fix: disable remove when remove usd is too small

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/handlers/ProportionalBoostedAddLiquidityV3.handler.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/handlers/ProportionalBoostedAddLiquidityV3.handler.ts
@@ -40,8 +40,6 @@ export class ProportionalBoostedAddLiquidityV3 implements AddLiquidityHandler {
       inputAmounts.find(item => isSameAddress(item.address, referenceAmountAddress))
     const referenceAmount = foundReferenceAmount || inputAmounts[0]
 
-    console.log({ referenceAmount })
-
     const addLiquidity = new AddLiquidityBoostedV3()
 
     const addLiquidityInput = this.constructSdkInput(referenceAmount, userAddress)

--- a/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -6,7 +6,7 @@ import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { LABELS } from '@repo/lib/shared/labels'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { isDisabledWithReason } from '@repo/lib/shared/utils/functions/isDisabledWithReason'
-import { bn, isZero, safeSum } from '@repo/lib/shared/utils/numbers'
+import { bn, isSmallUsd, isZero, safeSum } from '@repo/lib/shared/utils/numbers'
 import { HumanAmount, TokenAmount, isSameAddress } from '@balancer/sdk'
 import { PropsWithChildren, createContext, useEffect, useMemo, useState } from 'react'
 import { usePool } from '../../PoolProvider'
@@ -44,8 +44,13 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
   const [quotePriceImpact, setQuotePriceImpact] = useState<number>()
 
   const { pool, chainId, bptPrice, isLoading } = usePool()
-  const { getToken, usdValueForToken, getNativeAssetToken, getWrappedNativeAssetToken } =
-    useTokens()
+  const {
+    getToken,
+    usdValueForToken,
+    getNativeAssetToken,
+    getWrappedNativeAssetToken,
+    usdValueForBpt,
+  } = useTokens()
   const { isConnected } = useUserAccount()
 
   const maxHumanBptIn: HumanAmount = getUserWalletBalance(pool)
@@ -121,7 +126,13 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
    * Queries
    */
 
-  const enabled = !urlTxHash && !!tokenOut && !isSingleTokenBalanceMoreThat25Percent
+  const usdValueForHumanBptIn = usdValueForBpt(pool.address, chain, humanBptIn)
+
+  const enabled =
+    !urlTxHash &&
+    !!tokenOut &&
+    !isSingleTokenBalanceMoreThat25Percent &&
+    !isSmallUsd(usdValueForHumanBptIn)
 
   const simulationQuery = useRemoveLiquiditySimulationQuery({
     handler,

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -52,6 +52,8 @@ export const SMALL_PERCENTAGE_LABEL = '<0.01%'
 // fiat value threshold for displaying the fiat format without cents
 export const FIAT_CENTS_THRESHOLD = '100000'
 
+export const USD_LOWER_THRESHOLD = 0.009
+
 const NUMERAL_DECIMAL_LIMIT = 9
 
 export type Numberish = string | number | bigint | BigNumber
@@ -243,4 +245,8 @@ export function safeTokenFormat(
 
 export function isZero(amount: Numberish): boolean {
   return bn(amount).isZero()
+}
+
+export function isSmallUsd(value: Numberish): boolean {
+  return !isZero(value) && bn(value).lt(USD_LOWER_THRESHOLD)
 }


### PR DESCRIPTION
Before: 
Simulation error when bpt to remove was too small.
![image](https://github.com/user-attachments/assets/53c7ad46-3b75-4f9a-82ed-48040f3c4e68)

After:
Simulation and button are disabled: 
<img width="584" alt="Screenshot 2024-12-05 at 17 47 25" src="https://github.com/user-attachments/assets/6ca57da7-5c14-4f1f-a917-2de82457f283">
