### PR TITLE
feat: display swap events in My transactions (pool user events)

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/usePoolCharts.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/usePoolCharts.tsx
@@ -7,7 +7,7 @@ import {
   GqlPoolSnapshotDataRange,
   GqlChain,
 } from '@repo/lib/shared/services/api/generated/graphql'
-import { useQuery } from '@apollo/experimental-nextjs-app-support/ssr'
+import { useQuery } from '@apollo/client'
 import { useCallback, useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 import { usePool } from '../../../PoolProvider'

--- a/packages/lib/modules/pool/PoolDetail/PoolUserEvents.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolUserEvents.tsx
@@ -14,7 +14,12 @@ import {
 import { usePool } from '../PoolProvider'
 import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { useCurrency } from '@repo/lib/shared/hooks/useCurrency'
-import { GetPoolEventsQuery, GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
+import {
+  GetPoolEventsQuery,
+  GqlChain,
+  GqlPoolAddRemoveEventV3,
+  GqlPoolSwapEventV3,
+} from '@repo/lib/shared/services/api/generated/graphql'
 import { TokenIcon } from '@repo/lib/modules/tokens/TokenIcon'
 import { formatDistanceToNow, secondsToMilliseconds } from 'date-fns'
 import { useBlockExplorer } from '@repo/lib/shared/hooks/useBlockExplorer'
@@ -35,40 +40,31 @@ type PoolEventRowProps = {
 
 const GRID_COLUMNS = '100px 150px 100px 1fr'
 
-function Action({ isTypeAdd }: { isTypeAdd: boolean }) {
+function Action({ poolEventType }: { poolEventType: 'Add' | 'Remove' | 'Swap' }) {
+  const eventTypeColor =
+    poolEventType === 'Add' ? 'green.500' : poolEventType === 'Remove' ? 'red.500' : 'blue.500'
   return (
     <HStack>
       <Box
         as="span"
-        backgroundColor={isTypeAdd ? 'green.500' : 'red.500'}
+        backgroundColor={eventTypeColor}
         borderRadius="50%"
         display="inline-block"
         h="8px"
         w="8px"
       />
-      <Text>{isTypeAdd ? 'Add' : 'Remove'}</Text>
+      <Text>{poolEventType}</Text>
     </HStack>
   )
 }
 
 function PoolEventRow({ poolEvent, usdValue, chain, txUrl }: PoolEventRowProps) {
-  if (poolEvent.__typename !== 'GqlPoolAddRemoveEventV3') {
+  // Only show add/remove/swap events
+  if (!['GqlPoolAddRemoveEventV3', 'GqlPoolSwapEventV3'].includes(poolEvent.__typename)) {
     return null
   }
 
-  const isTypeAdd = poolEvent.type === 'ADD'
-
-  const Tokens = () =>
-    poolEvent.tokens
-      .filter(token => token.amount !== '0')
-      .map(token => (
-        <HStack gap={['xs', 'sm']} key={token.address} mb="sm">
-          <TokenIcon address={token.address} alt={token.address} chain={chain} size={24} />
-          <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
-            {fNum('token', token.amount)}
-          </Text>
-        </HStack>
-      ))
+  const poolEventType = getEventType(poolEvent)
 
   return (
     <Grid
@@ -83,10 +79,10 @@ function PoolEventRow({ poolEvent, usdValue, chain, txUrl }: PoolEventRowProps) 
       w="full"
     >
       <GridItem area="action">
-        <Action isTypeAdd={isTypeAdd} />
+        <Action poolEventType={poolEventType} />
       </GridItem>
       <GridItem area="tokens">
-        <Tokens />
+        <Tokens chain={chain} poolEvent={poolEvent} />
       </GridItem>
       <GridItem area="value" textAlign={{ base: 'left', md: 'right' }}>
         <Text>{usdValue}</Text>
@@ -104,6 +100,75 @@ function PoolEventRow({ poolEvent, usdValue, chain, txUrl }: PoolEventRowProps) 
         </HStack>
       </GridItem>
     </Grid>
+  )
+}
+
+function getEventType(item: PoolEventItem) {
+  switch (item.type) {
+    case 'SWAP':
+      return 'Swap'
+    case 'ADD':
+      return 'Add'
+    case 'REMOVE':
+      return 'Remove'
+    default:
+      throw new Error(`Unknown event type: ${item.type}`)
+  }
+}
+
+function Tokens({ poolEvent, chain }: { poolEvent: PoolEventItem; chain: GqlChain }) {
+  if (poolEvent.__typename === 'GqlPoolSwapEventV3') {
+    const swapEvent = poolEvent as GqlPoolSwapEventV3
+    return <SwapTokens chain={chain} swapEvent={swapEvent} />
+  }
+
+  const addRemoveEvent = poolEvent as GqlPoolAddRemoveEventV3
+  return <AddRemoveTokens addRemoveEvent={addRemoveEvent} chain={chain} />
+}
+
+function AddRemoveTokens({
+  addRemoveEvent,
+  chain,
+}: {
+  addRemoveEvent: GqlPoolAddRemoveEventV3
+  chain: GqlChain
+}) {
+  return addRemoveEvent.tokens
+    .filter(token => token.amount !== '0')
+    .map(token => (
+      <HStack gap={['xs', 'sm']} key={token.address} mb="sm">
+        <TokenIcon address={token.address} alt={token.address} chain={chain} size={24} />
+        <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
+          {fNum('token', token.amount)}
+        </Text>
+      </HStack>
+    ))
+}
+
+function SwapTokens({ swapEvent, chain }: { swapEvent: GqlPoolSwapEventV3; chain: GqlChain }) {
+  const tokenIn = swapEvent.tokenIn
+  const tokenOut = swapEvent.tokenOut
+  return (
+    <>
+      <HStack gap={['xs', 'sm']} mb="sm">
+        <TokenIcon address={tokenIn.address} alt={tokenIn.address} chain={chain} size={24} />
+        <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
+          {fNum('token', tokenIn.amount)} in
+        </Text>
+      </HStack>
+
+      <HStack gap={['xs', 'sm']} mb="sm">
+        <TokenIcon
+          address={swapEvent.tokenOut.address}
+          alt={swapEvent.tokenOut.address}
+          chain={chain}
+          size={24}
+        />
+        <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
+          {fNum('token', tokenOut.amount)} out
+        </Text>
+      </HStack>
+    </>
   )
 }
 
@@ -183,7 +248,7 @@ export default function PoolUserEvents({
             lineHeight="34px" // to align with 'My liquidity'
             size="h5"
           >
-            My transactions
+            My transactions 2
           </Heading>
           <Divider />
           <Box display={{ base: 'none', md: 'block' }} w="full">

--- a/packages/lib/modules/pool/PoolDetail/PoolUserEvents.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolUserEvents.tsx
@@ -248,7 +248,7 @@ export default function PoolUserEvents({
             lineHeight="34px" // to align with 'My liquidity'
             size="h5"
           >
-            My transactions 2
+            My transactions
           </Heading>
           <Divider />
           <Box display={{ base: 'none', md: 'block' }} w="full">


### PR DESCRIPTION
Now we can see pool swaps in "My transactions":

<img width="625" alt="Screenshot 2024-12-07 at 08 29 27" src="https://github.com/user-attachments/assets/3e30939c-e223-4f5e-a8ea-08df28f31616">
