### PR TITLE
fix: unblock nested add when the PI calculation fails

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
@@ -16,6 +16,7 @@ import {
   injectNativeAsset,
   replaceWrappedWithNativeAsset,
   requiresProportionalInput,
+  supportsNestedActions,
 } from '../LiquidityActionHelpers'
 import { isDisabledWithReason } from '@repo/lib/shared/utils/functions/isDisabledWithReason'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
@@ -174,7 +175,10 @@ export function _useAddLiquidity(urlTxHash?: Hash) {
     [areEmptyAmounts(humanAmountsIn), 'You must specify one or more token amounts'],
     [hasValidationErrors, 'Errors in token inputs'],
     [needsToAcceptHighPI, 'Accept high price impact first'],
-    [isUnbalancedAddErrorMessage(priceImpactQuery.error), 'Unbalanced join'],
+    [
+      isUnbalancedAddErrorMessage(priceImpactQuery.error) && !supportsNestedActions(pool),
+      'Unbalanced join',
+    ],
     [simulationQuery.isLoading, 'Fetching quote...'],
     [simulationQuery.isError, 'Error fetching quote'],
     [priceImpactQuery.isLoading, 'Fetching price impact...'],

--- a/packages/lib/modules/price-impact/price-impact.utils.ts
+++ b/packages/lib/modules/price-impact/price-impact.utils.ts
@@ -28,9 +28,8 @@ export function cannotCalculatePriceImpactError(error: Error | null): boolean {
   if (error.name === 'ContractFunctionExecutionError') return true
   // All Swap PI errors are shown as unknown price impact
   if (
-    error.message.startsWith(
-      'Unexpected error while calculating addLiquidityUnbalanced PI at Swap step'
-    )
+    error.message.startsWith('Unexpected error while calculating') &&
+    error.message.includes('PI at Swap step')
   ) {
     return true
   }


### PR DESCRIPTION
Nested pool to reproduce: 

http://test.balancer.fi/pools/sepolia/v3/0x693cc6a39bbf35464f53d6a5dbf7d6c2fa93741c/add-liquidity

Adding in some nested pool causes many Price Impact calculation errors like this:

```
Unexpected error while calculating addLiquidityUnbalancedBoosted PI at Swap step:
Error: Unexpected error while calculating addLiquidityUnbalancedBoosted PI at Delta add step:
ContractFunctionExecutionError: The contract function "queryAddLiquidityUnbalancedToERC4626Pool" reverted.

Error: WrapAmountTooSmall(address wrappedToken)
                         (0x8A88124522dbBF1E56352ba3DE1d9F78C143751e)
 
Contract Call:
  address:   0xc6674C0c7694E9b990eAc939E74F8cc3DD39B4b0
  function:  queryAddLiquidityUnbalancedToERC4626Pool(address pool, uint256[] exactUnderlyingAmountsIn, address sender, bytes userData)
  args:                                              (0x59fa488dda749cdd41772bb068bb23ee955a6d7a, ["1049","0"], 0x0000000000000000000000000000000000000000, 0x)

Docs: https://viem.sh/docs/contract/simulateContract
Version: viem@2.21.51"
```

For now, the only solution is showing `Unknown price impact` and enable the Next button so that the user can accept the unwkown price impact and proceed:

<img width="545" alt="Screenshot 2024-12-08 at 17 44 55" src="https://github.com/user-attachments/assets/3827b843-b12e-42a4-937d-4a603589ff2e">



