### PR TITLE
fix: avoid selected chain change when pool swap

### DIFF
--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -100,8 +100,8 @@ export type SwapProviderProps = {
 }
 export function _useSwap({ poolActionableTokens, pool, pathParams }: SwapProviderProps) {
   const urlTxHash = pathParams.urlTxHash
-  const isPoolSwap = pool && poolActionableTokens
   const isPoolSwapUrl = useIsPoolSwapUrl()
+  const isPoolSwap = pool && poolActionableTokens // Hint to tell TS that pool and poolActionableTokens must be defined when poolSwap
   const swapStateVar = useMakeVarPersisted<SwapState>(
     {
       tokenIn: {
@@ -226,6 +226,7 @@ export function _useSwap({ poolActionableTokens, pool, pathParams }: SwapProvide
   }
 
   function setSelectedChain(_selectedChain: GqlChain) {
+    if (isPoolSwapUrl) return
     const defaultTokenState = getDefaultTokenState(_selectedChain)
     swapStateVar(defaultTokenState)
   }


### PR DESCRIPTION
Avoid selecting wallet chain in case of pool swap. 

**Before**: In pool swaps we were using the connected wallet chain instead of the `pool.chain`. 

**After**:  Now the right pool chain is always used, so chain switch is properly detected:

<img width="632" alt="Screenshot 2024-12-09 at 08 31 59" src="https://github.com/user-attachments/assets/5c2be39c-3977-46d8-a2cf-e17be096dc7b">





