### PR TITLE
fix: negative sign in zero swap price impact

### DIFF
--- a/packages/lib/modules/price-impact/price-impact.utils.spec.ts
+++ b/packages/lib/modules/price-impact/price-impact.utils.spec.ts
@@ -1,4 +1,9 @@
-import { calcMarketPriceImpact } from './price-impact.utils'
+import {
+  calcMarketPriceImpact,
+  getFullPriceImpactLabel,
+  getMaxSlippageLabel,
+  getPriceImpactLabel,
+} from './price-impact.utils'
 
 test('calcMarketPriceImpact', () => {
   expect(calcMarketPriceImpact('0', '0')).toBe('0')
@@ -9,4 +14,30 @@ test('calcMarketPriceImpact', () => {
   expect(calcMarketPriceImpact('100', '90')).toBe('0.11111111111111111111') // 11% price impact
   expect(calcMarketPriceImpact('100', '80')).toBe('0.25') // 25% price impact
   expect(calcMarketPriceImpact('100', '110')).toBe('0') // Positive price impacts should be 0%
+})
+
+test('getPriceImpactLabel', () => {
+  getPriceImpactLabel
+  expect(getPriceImpactLabel(undefined)).toBe('')
+  expect(getPriceImpactLabel(-1)).toBe(' (-<0.01%)')
+  expect(getPriceImpactLabel(0)).toBe('')
+  expect(getPriceImpactLabel(0.123)).toBe(' (-12.30%)')
+})
+
+test('getFullPriceImpactLabel', () => {
+  expect(getFullPriceImpactLabel(undefined, '0')).toBe('-')
+  expect(getFullPriceImpactLabel(null, '$0.0')).toBe('-')
+  expect(getFullPriceImpactLabel('0', '$0.0')).toBe('$0.0 (0.00%)')
+  expect(getFullPriceImpactLabel('0', '$0.00025')).toBe('$0.00025 (0.00%)')
+  expect(getFullPriceImpactLabel('0.01', '$0.02')).toBe('-$0.02 (-1.00%)')
+  expect(getFullPriceImpactLabel('0.003', '€123.45678')).toBe('-€123.45678 (-0.30%)')
+})
+
+test('getMaxSlippageLabel', () => {
+  expect(getMaxSlippageLabel(0, '0')).toBe('-')
+  expect(getMaxSlippageLabel('-1', '$0.1')).toBe('$0.1 (0.00%)')
+  expect(getMaxSlippageLabel('0', '$0.123')).toBe('$0.123 (0.00%)')
+  expect(getMaxSlippageLabel('0.01', '$0.02')).toBe('-$0.02 (-0.01%)')
+  expect(getMaxSlippageLabel('0.03', '€123.45678')).toBe('-€123.45678 (-0.03%)')
+  expect(getMaxSlippageLabel('0.004', '€123.45678')).toBe('-€123.45678 (-<0.01%)')
 })

--- a/packages/lib/modules/price-impact/price-impact.utils.ts
+++ b/packages/lib/modules/price-impact/price-impact.utils.ts
@@ -1,4 +1,4 @@
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, fNum, isNegative, isZero } from '@repo/lib/shared/utils/numbers'
 import BigNumber from 'bignumber.js'
 import { PriceImpactLevel } from './PriceImpactProvider'
 
@@ -86,4 +86,30 @@ export const getPriceImpactExceedsLabel = (priceImpactLevel: PriceImpactLevel) =
     default:
       return ''
   }
+}
+
+export function getPriceImpactLabel(priceImpact: string | number | null | undefined) {
+  return priceImpact
+    ? isZero(priceImpact)
+      ? ' (0.00%)'
+      : ` (-${fNum('priceImpact', priceImpact)})`
+    : ''
+}
+
+export function getFullPriceImpactLabel(
+  priceImpact: string | number | null | undefined,
+  currencyPriceImpact: string
+) {
+  if (!priceImpact) return '-'
+  if (isZero(priceImpact) || isNegative(priceImpact)) return `${currencyPriceImpact} (0.00%)`
+
+  return `-${currencyPriceImpact}${getPriceImpactLabel(priceImpact)}`
+}
+
+export function getMaxSlippageLabel(slippage: string | 0, currencyMaxSlippage: string) {
+  if (!slippage) return '-'
+  if (isZero(slippage) || isNegative(slippage)) return `${currencyMaxSlippage} (0.00%)`
+
+  const slippageLabel = fNum('slippage', slippage)
+  return `-${currencyMaxSlippage} (-${slippageLabel})`
 }

--- a/packages/lib/modules/swap/SwapDetails.tsx
+++ b/packages/lib/modules/swap/SwapDetails.tsx
@@ -21,6 +21,7 @@ import { NativeWrapHandler } from './handlers/NativeWrap.handler'
 import { InfoIcon } from '@repo/lib/shared/components/icons/InfoIcon'
 import pluralize from 'pluralize'
 import { BaseDefaultSwapHandler } from './handlers/BaseDefaultSwap.handler'
+import { getFullPriceImpactLabel, getMaxSlippageLabel } from '../price-impact/price-impact.utils'
 
 export function OrderRoute() {
   const { simulationQuery } = useSwap()
@@ -76,9 +77,17 @@ export function SwapDetails() {
       ? usdValueForToken(tokenOutInfo, tokenOut.amount)
       : usdValueForToken(tokenInInfo, tokenIn.amount)
 
-  const priceImpactLabel = priceImpact ? fNum('priceImpact', priceImpact) : '-'
-  const priceImpacUsd = bn(priceImpact || 0).times(returnAmountUsd)
+  const priceImpactUsd = bn(priceImpact || 0).times(returnAmountUsd)
+  const fullPriceImpactLabel = getFullPriceImpactLabel(
+    priceImpact,
+    toCurrency(priceImpactUsd, { abbreviated: false })
+  )
+
   const maxSlippageUsd = bn(_slippage).div(100).times(returnAmountUsd)
+  const fullMaxSlippageLabel = getMaxSlippageLabel(
+    _slippage,
+    toCurrency(maxSlippageUsd, { abbreviated: false })
+  )
 
   const isExactIn = swapType === GqlSorSwapType.ExactIn
 
@@ -109,9 +118,7 @@ export function SwapDetails() {
           {priceImpactLevel === 'unknown' ? (
             <Text>Unknown</Text>
           ) : (
-            <NumberText color={priceImpactColor}>
-              -{toCurrency(priceImpacUsd, { abbreviated: false })} (-{priceImpactLabel})
-            </NumberText>
+            <NumberText color={priceImpactColor}>{fullPriceImpactLabel}</NumberText>
           )}
           <Popover trigger="hover">
             <PopoverTrigger>
@@ -141,9 +148,7 @@ export function SwapDetails() {
       <HStack justify="space-between" w="full">
         <Text color="grayText">Max slippage</Text>
         <HStack>
-          <NumberText color="grayText">
-            -{toCurrency(maxSlippageUsd, { abbreviated: false })} (-{fNum('slippage', _slippage)})
-          </NumberText>
+          <NumberText color="grayText">{fullMaxSlippageLabel}</NumberText>
           <Popover trigger="hover">
             <PopoverTrigger>
               <Box

--- a/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
+++ b/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
@@ -21,7 +21,7 @@ import { useTokens } from '../TokensProvider'
 import { useTokenBalances } from '../TokenBalancesProvider'
 import { useTokenInput } from './useTokenInput'
 import { useCurrency } from '@repo/lib/shared/hooks/useCurrency'
-import { blockInvalidNumberInput, bn, fNum, isZero } from '@repo/lib/shared/utils/numbers'
+import { blockInvalidNumberInput, bn, fNum } from '@repo/lib/shared/utils/numbers'
 import { TokenIcon } from '../TokenIcon'
 import { useTokenInputsValidation } from '../TokenInputsValidationProvider'
 import { ChevronDown } from 'react-feather'
@@ -30,6 +30,7 @@ import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvid
 import { useEffect, useState } from 'react'
 import { useIsMounted } from '@repo/lib/shared/hooks/useIsMounted'
 import { isNativeAsset } from '@repo/lib/shared/utils/addresses'
+import { getPriceImpactLabel } from '../../price-impact/price-impact.utils'
 
 type TokenInputSelectorProps = {
   token: GqlToken | undefined
@@ -128,12 +129,6 @@ function TokenInputFooter({
     }
   }
 
-  const priceImpactLabel = priceImpact
-    ? isZero(priceImpact)
-      ? ' (0.00%)'
-      : ` (-${fNum('priceImpact', priceImpact)})`
-    : ''
-
   return (
     <HStack h="4" justify="space-between" w="full">
       {isBalancesLoading || !isMounted ? (
@@ -145,7 +140,7 @@ function TokenInputFooter({
           variant="secondary"
         >
           {toCurrency(usdValue, { abbreviated: false })}
-          {showPriceImpact && priceImpactLevel !== 'unknown' && priceImpactLabel}
+          {showPriceImpact && priceImpactLevel !== 'unknown' && getPriceImpactLabel(priceImpact)}
         </Text>
       )}
       {isBalancesLoading || !isMounted ? (

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -247,6 +247,10 @@ export function isZero(amount: Numberish): boolean {
   return bn(amount).isZero()
 }
 
+export function isNegative(amount: Numberish): boolean {
+  return bn(amount).isNegative()
+}
+
 export function isSmallUsd(value: Numberish): boolean {
   return !isZero(value) && bn(value).lt(USD_LOWER_THRESHOLD)
 }


### PR DESCRIPTION
Refactors and fixes some price impact labelling issues.
Adds unit tests to avoid regressions.

**Before**:
![Uploading Screenshot 2024-12-09 at 09.32.11.png…]()

**After**:
<img width="524" alt="Screenshot 2024-12-09 at 09 33 13" src="https://github.com/user-attachments/assets/816c7f9a-16f4-4215-ad4d-5802d0e3c6c3">
