### PR TITLE
fix: avoid token input value change onScroll

### DIFF
--- a/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
+++ b/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
@@ -265,6 +265,10 @@ export const TokenInput = forwardRef(
                 min={0}
                 onChange={handleOnChange}
                 onKeyDown={blockInvalidNumberInput}
+                onWheel={e => {
+                  // Avoid changing the input value when scrolling
+                  return e.currentTarget.blur()
+                }}
                 outline="none"
                 p="0"
                 placeholder="0.00"


### PR DESCRIPTION
Scroll from inside the token input was causing weird issues as it was changing the numeric value of the input.