### PR TITLE
fix: avoid underlying tokens in not v3 pools

### DIFF
--- a/packages/lib/modules/pool/actions/LiquidityActionHelpers.integration.spec.ts
+++ b/packages/lib/modules/pool/actions/LiquidityActionHelpers.integration.spec.ts
@@ -591,3 +591,73 @@ describe('Liquidity helpers for GNOSIS V3 Boosted pools', async () => {
     })
   })
 })
+
+describe('Liquidity helpers for GNOSIS V2 pool with isErc4626 tokens (v2 pools are not boosted so they should not use underlying tokens)', async () => {
+  const poolId = '0xbc2acf5e821c5c9f8667a36bb1131dad26ed64f9000200000000000000000063' // Gnosis Balancer 50sDAI-50wstETHr
+
+  const wstETHAddress = '0x6c76971f98945ae98dd7d4dfca8711ebea946ea6'
+  const sDaiAddress = '0xaf204776c7245bf4147c2612bf6e5972ee483701'
+
+  const v2Pool = await getPoolMock(poolId, GqlChain.Gnosis)
+  const helpers = new LiquidityActionHelpers(v2Pool)
+
+  const humanAmountsIn: HumanTokenAmountWithAddress[] = [
+    { humanAmount: '0.1', tokenAddress: sDaiAddress },
+  ]
+
+  it('allPoolTokens return sDaiAddress instead of its underlying token cause it a V2 pool', async () => {
+    expect(allPoolTokens(v2Pool)).toMatchInlineSnapshot(`
+      [
+        {
+          "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
+          "decimals": 18,
+          "index": 0,
+          "name": "Wrapped liquid staked Ether 2.0 from Mainnet",
+          "symbol": "wstETH",
+        },
+        {
+          "address": "0xaf204776c7245bf4147c2612bf6e5972ee483701",
+          "decimals": 18,
+          "index": 1,
+          "name": "Savings xDAI",
+          "symbol": "sDAI",
+        },
+      ]
+    `)
+  })
+
+  it('toInputAmounts', async () => {
+    expect(helpers.toInputAmounts(humanAmountsIn)).toEqual([
+      {
+        address: sDaiAddress,
+        decimals: 18,
+        rawAmount: 100000000000000000n,
+      },
+    ])
+  })
+
+  it('poolStateWithBalances', async () => {
+    const helpers = new LiquidityActionHelpers(v2Pool)
+    expect(helpers.poolStateWithBalances).toEqual({
+      id: poolId,
+      address: '0xbc2acf5e821c5c9f8667a36bb1131dad26ed64f9',
+      protocolVersion: 2,
+      tokens: [
+        {
+          address: wstETHAddress,
+          balance: expect.any(String),
+          decimals: 18,
+          index: 0,
+        },
+        {
+          address: sDaiAddress,
+          balance: expect.any(String),
+          decimals: 18,
+          index: 1,
+        },
+      ],
+      totalShares: expect.any(String),
+      type: 'Weighted',
+    })
+  })
+})


### PR DESCRIPTION
Fixes token helpers for !v3 pools with `ERC4626`. 

Pool to test:
https://mono-test-v3-git-fix-v2boosted-balancer.vercel.app/pools/gnosis/v2/0xbc2acf5e821c5c9f8667a36bb1131dad26ed64f9000200000000000000000063