### PR TITLE
chore: temporary use 5 minutes tag cache until we deploy all tags for V3 release

### DIFF
--- a/packages/lib/modules/pool/tags/getPoolTags.ts
+++ b/packages/lib/modules/pool/tags/getPoolTags.ts
@@ -20,7 +20,7 @@ export type PoolTag = {
 export async function getPoolTags(): Promise<PoolTag[] | undefined> {
   try {
     const res = await fetch(POOL_TAGS_URL, {
-      next: { revalidate: mins(15).toSecs() },
+      next: { revalidate: mins(5).toSecs() },
     })
     const tags = (await res.json()) as PoolTag[]
 


### PR DESCRIPTION
We will undo this change with this PR once we finish setting all the tags up.