### PR TITLE
fix: hide erc4626 info for protocol version < 3

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolInfo/Erc4626Info.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolInfo/Erc4626Info.tsx
@@ -101,7 +101,7 @@ export function Erc4626InfoPopOver({ token, data, level, children }: Erc4626Info
     <PopoverInfoBody data={data} level={level} />
   ) : (
     <Text fontSize="sm">
-      Rate provider data is missing.
+      Tokenized vault data is missing.
       <br />
       Proceed with caution.
     </Text>

--- a/packages/lib/modules/pool/PoolDetail/PoolInfo/PoolContracts.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolInfo/PoolContracts.tsx
@@ -34,7 +34,7 @@ import { AlertTriangle, XCircle } from 'react-feather'
 import Image from 'next/image'
 import { RateProviderInfoPopOver } from './RateProviderInfo'
 import { getBlockExplorerAddressUrl } from '@repo/lib/shared/hooks/useBlockExplorer'
-import { getWarnings } from '@repo/lib/modules/pool/pool.helpers'
+import { getWarnings, isV3Pool } from '@repo/lib/modules/pool/pool.helpers'
 import { HookInfoPopOver } from './HookInfo'
 import { Erc4626InfoPopOver } from './Erc4626Info'
 
@@ -162,6 +162,8 @@ export function PoolContracts({ ...props }: CardProps) {
   }, [pool])
 
   const erc4626Tokens = useMemo(() => {
+    if (!isV3Pool(pool)) return []
+
     const erc4626Tokens = pool.poolTokens.filter(token => token.isErc4626)
     const erc4626NestedTokens = pool.poolTokens.flatMap(token =>
       token.nestedPool ? token.nestedPool.tokens.filter(token => token.isErc4626) : []


### PR DESCRIPTION
- also update text

for example with [this pool](https://balancer.fi/pools/gnosis/v2/0xbc2acf5e821c5c9f8667a36bb1131dad26ed64f9000200000000000000000063):
![image](https://github.com/user-attachments/assets/43aa7127-8eae-4166-bc7c-fe53790f64c3)
