### PR TITLE
feat: add tooltip for blocked add button

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolHeader/PoolHeader.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolHeader/PoolHeader.tsx
@@ -1,4 +1,4 @@
-import { Stack, Button, VStack, useDisclosure, HStack } from '@chakra-ui/react'
+import { Stack, Button, VStack, useDisclosure, HStack, Tooltip } from '@chakra-ui/react'
 import { usePathname, useRouter } from 'next/navigation'
 import PoolMetaBadges from './PoolMetaBadges'
 
@@ -57,16 +57,18 @@ export function PoolHeader() {
         <Stack direction={{ base: 'column', md: 'row' }} spacing="md">
           <PoolTags />
           <HStack spacing="sm">
-            <Button
-              isDisabled={isAddLiquidityBlocked}
-              onClick={handleClick}
-              size="lg"
-              variant="primary"
-              w="full"
-            >
-              Add liquidity
-            </Button>
-
+            {/* TODO: add proper reason */}
+            <Tooltip label={isAddLiquidityBlocked ? '' : ''}>
+              <Button
+                isDisabled={isAddLiquidityBlocked}
+                onClick={handleClick}
+                size="lg"
+                variant="primary"
+                w="full"
+              >
+                Add liquidity
+              </Button>
+            </Tooltip>
             <PoolAdvancedOptions />
           </HStack>
           <PartnerRedirectModal

--- a/packages/lib/modules/pool/PoolDetail/PoolHeader/PoolHeader.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolHeader/PoolHeader.tsx
@@ -3,7 +3,7 @@ import { usePathname, useRouter } from 'next/navigation'
 import PoolMetaBadges from './PoolMetaBadges'
 
 import { usePool } from '../../PoolProvider'
-import { isFx, shouldBlockAddLiquidity } from '../../pool.helpers'
+import { getPoolAddBlockedReason, isFx, shouldBlockAddLiquidity } from '../../pool.helpers'
 import { AnalyticsEvent, trackEvent } from '@repo/lib/shared/services/fathom/Fathom'
 import { PoolTags } from '../../tags/PoolTags'
 import { PoolBreadcrumbs } from './PoolBreadcrumbs'
@@ -57,8 +57,8 @@ export function PoolHeader() {
         <Stack direction={{ base: 'column', md: 'row' }} spacing="md">
           <PoolTags />
           <HStack spacing="sm">
-            {/* TODO: add proper reason */}
-            <Tooltip label={isAddLiquidityBlocked ? '' : ''}>
+            {/* TODO: Add block reason alerts*/}
+            <Tooltip label={isAddLiquidityBlocked ? getPoolAddBlockedReason(pool) : ''}>
               <Button
                 isDisabled={isAddLiquidityBlocked}
                 onClick={handleClick}

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -300,7 +300,7 @@ export function shouldBlockAddLiquidity(pool: Pool) {
 
     // if price rate provider is set but is not reviewed - we should block adding liquidity
     if (!hasReviewedRateProvider(token)) {
-      console.log('Not reviewd rate provider')
+      console.log('Not reviewed rate provider')
       return true
     }
 
@@ -311,6 +311,42 @@ export function shouldBlockAddLiquidity(pool: Pool) {
 
     return false
   })
+}
+
+/**
+ *  TODO: improve the implementation to display all the blocking reasons instead of just the first one
+ */
+export function getPoolAddBlockedReason(pool: Pool): string {
+  const poolTokens = pool.poolTokens as GqlPoolTokenDetail[]
+
+  if (isLBP(pool.type)) return 'LBP pool'
+  if (pool.dynamicData.isPaused) return 'Paused pool'
+  if (pool.dynamicData.isInRecoveryMode) return 'Pool in recovery'
+
+  if (pool.hook && !hasReviewedHook(pool.hook)) {
+    return 'Unreviewed hook'
+  }
+
+  if (pool.hook?.reviewData?.summary === 'unsafe') {
+    return 'Unsafe hook'
+  }
+
+  for (const token of poolTokens) {
+    // if token is not allowed - we should block adding liquidity
+    if (!token.isAllowed && !isCowAmmPool(pool.type)) {
+      return `Token: ${token.symbol} is not allowed` // TODO: Add instructions and link to get it approved
+    }
+
+    // if price rate provider is set but is not reviewed - we should block adding liquidity
+    if (!hasReviewedRateProvider(token)) {
+      return `Rate provider for token ${token.symbol} was not yet reviewed` // TODO: Add instructions and link to get it reviewed
+    }
+
+    if (token.priceRateProviderData?.summary !== 'safe') {
+      return `Rate provider for token ${token.symbol} is not safe` // TODO: Add instructions and link to get it reviewed
+    }
+  }
+  return ''
 }
 
 export function isAffectedByCspIssue(pool: Pool) {

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -276,16 +276,21 @@ export function shouldBlockAddLiquidity(pool: Pool) {
 
   // If pool is an LBP, paused or in recovery mode, we should block adding liquidity
   if (isLBP(pool.type) || pool.dynamicData.isPaused || pool.dynamicData.isInRecoveryMode) {
+    console.log('LBP/Paused/Recovery')
     return true
   }
 
   if (pool.hook && (!hasReviewedHook(pool.hook) || pool.hook?.reviewData?.summary === 'unsafe')) {
+    console.log('Unreviewed hook')
     return true
   }
 
   return poolTokens.some(token => {
     // if token is not allowed - we should block adding liquidity
-    if (!token.isAllowed && !isCowAmmPool(pool.type)) return true
+    if (!token.isAllowed && !isCowAmmPool(pool.type)) {
+      console.log('Not allowed token')
+      return true
+    }
 
     // if rateProvider is null - we consider it as zero address and not block adding liquidity
     if (isNil(token.priceRateProvider) || token.priceRateProvider === zeroAddress) return false
@@ -294,9 +299,15 @@ export function shouldBlockAddLiquidity(pool: Pool) {
     if (token.priceRateProvider === token.nestedPool?.address) return false
 
     // if price rate provider is set but is not reviewed - we should block adding liquidity
-    if (!hasReviewedRateProvider(token)) return true
+    if (!hasReviewedRateProvider(token)) {
+      console.log('Not reviewd rate provider')
+      return true
+    }
 
-    if (token.priceRateProviderData?.summary !== 'safe') return true
+    if (token.priceRateProviderData?.summary !== 'safe') {
+      console.log('priceRateProvider is not safe')
+      return true
+    }
 
     return false
   })

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -276,19 +276,16 @@ export function shouldBlockAddLiquidity(pool: Pool) {
 
   // If pool is an LBP, paused or in recovery mode, we should block adding liquidity
   if (isLBP(pool.type) || pool.dynamicData.isPaused || pool.dynamicData.isInRecoveryMode) {
-    console.log('LBP/Paused/Recovery')
     return true
   }
 
   if (pool.hook && (!hasReviewedHook(pool.hook) || pool.hook?.reviewData?.summary === 'unsafe')) {
-    console.log('Unreviewed hook')
     return true
   }
 
   return poolTokens.some(token => {
     // if token is not allowed - we should block adding liquidity
     if (!token.isAllowed && !isCowAmmPool(pool.type)) {
-      console.log('Not allowed token')
       return true
     }
 
@@ -300,12 +297,10 @@ export function shouldBlockAddLiquidity(pool: Pool) {
 
     // if price rate provider is set but is not reviewed - we should block adding liquidity
     if (!hasReviewedRateProvider(token)) {
-      console.log('Not reviewed rate provider')
       return true
     }
 
     if (token.priceRateProviderData?.summary !== 'safe') {
-      console.log('priceRateProvider is not safe')
       return true
     }
 

--- a/packages/lib/shared/components/poppover/BalPopover.tsx
+++ b/packages/lib/shared/components/poppover/BalPopover.tsx
@@ -1,0 +1,20 @@
+import { Popover, PopoverContent, PopoverTrigger, Text } from '@chakra-ui/react'
+import { PropsWithChildren } from 'react'
+
+type BalPopoverProps = {
+  text: string
+}
+
+export function BalPopover({ children, text }: PropsWithChildren<BalPopoverProps>) {
+  return (
+    <Popover trigger="hover">
+      <PopoverTrigger>{children}</PopoverTrigger>
+
+      <PopoverContent maxW="300px" p="sm" w="auto">
+        <Text fontSize="sm" variant="secondary">
+          {text}
+        </Text>
+      </PopoverContent>
+    </Popover>
+  )
+}


### PR DESCRIPTION
Do we prefer an alert with all the reasons?
If we go for the tooltip there are two Add liquidity buttons.

Example: 

<img width="453" alt="Screenshot 2024-12-11 at 13 42 12" src="https://github.com/user-attachments/assets/ff178f30-9780-42f7-ab48-6a27e57669f3">


