### PR TITLE
fix: avoid duplicated EURe in adds receipt

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/useAddLiquiditySteps.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/useAddLiquiditySteps.tsx
@@ -51,6 +51,11 @@ export function useAddLiquiditySteps({
       isPermit2,
     })
 
+  console.log(
+    'pending token approvals: ',
+    tokenApprovalSteps.filter(t => !t.isComplete()).map(t => t.details)
+  )
+
   const wethIsEth = helpers.isNativeAssetIn(humanAmountsIn)
 
   const signPermit2Step = useSignPermit2AddStep({

--- a/packages/lib/modules/pool/actions/add-liquidity/useAddLiquiditySteps.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/useAddLiquiditySteps.tsx
@@ -51,11 +51,6 @@ export function useAddLiquiditySteps({
       isPermit2,
     })
 
-  console.log(
-    'pending token approvals: ',
-    tokenApprovalSteps.filter(t => !t.isComplete()).map(t => t.details)
-  )
-
   const wethIsEth = helpers.isNativeAssetIn(humanAmountsIn)
 
   const signPermit2Step = useSignPermit2AddStep({

--- a/packages/lib/modules/transactions/transaction-steps/receipts/receipt-parsers.ts
+++ b/packages/lib/modules/transactions/transaction-steps/receipts/receipt-parsers.ts
@@ -15,6 +15,7 @@ import {
 import { HumanTokenAmountWithAddress } from '../../../tokens/token.types'
 import { emptyAddress } from '../../../web3/contracts/wagmi-helpers'
 import { ProtocolVersion } from '@repo/lib/modules/pool/pool.types'
+import { isSameAddress } from '@repo/lib/shared/utils/addresses'
 
 type ParseProps = {
   receiptLogs: Log[]
@@ -57,8 +58,17 @@ export function parseAddLiquidityReceipt({
   const receivedBptAmount = getIncomingLogs(receiptLogs, userAddress)?.[0]?.args?.value
   const receivedBptUnits = formatUnits(receivedBptAmount || 0n, BPT_DECIMALS)
 
+  // ERC-20: Monerium EURe (EURe)
+  const erc20EURe = '0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430'
+
   return {
-    sentTokens,
+    /*
+      TODO:
+        properly implement this filter getting this info from LiquidityAdded/Removed event instead of Transfers
+        They use frontend (erc20) <> controller (upgradable proxy) setup - where calls to erc20 are forwarded to the controller.
+        Both emit events, which explains the duplicates.
+    */
+    sentTokens: sentTokens.filter(t => !isSameAddress(t.tokenAddress, erc20EURe)),
     receivedBptUnits,
   }
 }

--- a/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.integration.spec.ts
+++ b/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.integration.spec.ts
@@ -5,7 +5,7 @@ import { getGqlChain } from '@repo/lib/config/app.config'
 import { ethAddress, polAddress } from '@repo/lib/debug-helpers'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { Address, Hash } from 'viem'
-import { polygon } from 'viem/chains'
+import { gnosis, polygon } from 'viem/chains'
 import { useAddLiquidityReceipt, useRemoveLiquidityReceipt, useSwapReceipt } from './receipt.hooks'
 import { ProtocolVersion } from '@repo/lib/modules/pool/pool.types'
 
@@ -103,6 +103,42 @@ test('queries add liquidity with native token', async () => {
   ])
 
   expect(result.current.receivedBptUnits).toBe('0.984524168989962117')
+})
+
+test.only('queries add liquidity in V3 GNOSIS pool', async () => {
+  const userAddress = '0xf76142b79Db34E57852d68F9c52C0E24f7349647'
+
+  // const poolId = '0xecc5aebd9569c82a0944007b22d03801a8fdfe99' // 59EURe 1sDAI 40USDC.e
+  //https://gnosisscan.io/tx/0x61286503bc38b6eda1477d3812cdd268114f3443138a513259a76c42b9cc53ac
+  const txHash = '0x61286503bc38b6eda1477d3812cdd268114f3443138a513259a76c42b9cc53ac'
+
+  const result = await testAddReceipt(userAddress, txHash, gnosis.id)
+
+  await waitFor(() => expect(result.current.isLoading).toBeFalsy())
+  await waitFor(() => expect(result.current.sentTokens).toBeDefined())
+
+  expect(result.current.sentTokens).toEqual([
+    {
+      humanAmount: '0.00000000000001',
+      tokenAddress: '0x2a22f9c3b484c3629090feed35f17ff8f88f76f0',
+    },
+    {
+      humanAmount: '0.000063840672042232',
+      tokenAddress: '0xe91d153e0b41518a2ce8dd3d7944fa863463a97d',
+    },
+    // the following one is excluded to avoid duplication
+    // ERC-20: Monerium EURe (EURe)
+    // {
+    //   humanAmount: '0.014361104681096343',
+    //   tokenAddress: '0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430',
+    // },
+    {
+      humanAmount: '0.014361104681096343',
+      tokenAddress: '0xcb444e90d8198415266c6a2724b7900fb12fc56e', // Monerium EUR emoney (EURe)
+    },
+  ])
+
+  expect(result.current.receivedBptUnits).toBe('0.012149307213559577')
 })
 
 test('queries remove liquidity transaction', async () => {

--- a/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.integration.spec.ts
+++ b/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.integration.spec.ts
@@ -105,7 +105,7 @@ test('queries add liquidity with native token', async () => {
   expect(result.current.receivedBptUnits).toBe('0.984524168989962117')
 })
 
-test.only('queries add liquidity in V3 GNOSIS pool', async () => {
+test('queries add liquidity in V3 GNOSIS pool', async () => {
   const userAddress = '0xf76142b79Db34E57852d68F9c52C0E24f7349647'
 
   // const poolId = '0xecc5aebd9569c82a0944007b22d03801a8fdfe99' // 59EURe 1sDAI 40USDC.e

--- a/packages/lib/test/anvil/anvil-setup.ts
+++ b/packages/lib/test/anvil/anvil-setup.ts
@@ -1,8 +1,8 @@
 import { Address, Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { mainnet, polygon, sepolia } from 'viem/chains'
+import { gnosis, mainnet, polygon, sepolia } from 'viem/chains'
 
-const networksWithFork = [mainnet, polygon, sepolia]
+const networksWithFork = [mainnet, polygon, sepolia, gnosis] as const
 export type NetworksWithFork = (typeof networksWithFork)[number]['name']
 
 export type NetworkSetup = {
@@ -41,6 +41,7 @@ const ANVIL_PORTS: Record<NetworksWithFork, number> = {
   Ethereum: 8645,
   Polygon: 8745,
   Sepolia: 8845,
+  Gnosis: 9045,
 }
 
 export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
@@ -66,6 +67,13 @@ export const ANVIL_NETWORKS: Record<NetworksWithFork, NetworkSetup> = {
     port: ANVIL_PORTS.Sepolia,
     // For now we will use the last block until v3 deployments are final
     // forkBlockNumber: 6679621n,
+  },
+  Gnosis: {
+    networkName: 'Gnosis',
+    fallBackRpc: 'https://gnosis.drpc.org',
+    port: ANVIL_PORTS.Gnosis,
+    // For now we will use the last block until v3 deployments are final
+    // forkBlockNumber: ,
   },
 }
 
@@ -104,6 +112,9 @@ export function getForkUrl(networkName: NetworksWithFork, verbose = false): stri
     }
     if (network.networkName === 'Sepolia') {
       return dRpcUrl('sepolia')
+    }
+    if (network.networkName === 'Gnosis') {
+      return dRpcUrl('gnosis')
     }
   }
 

--- a/packages/lib/test/anvil/testWagmiConfig.tsx
+++ b/packages/lib/test/anvil/testWagmiConfig.tsx
@@ -1,6 +1,6 @@
 import { NetworksWithFork, getTestRpcSetup, testAccounts } from '@repo/lib/test/anvil/anvil-setup'
 import { Address, Chain, http } from 'viem'
-import { mainnet, polygon, sepolia } from 'viem/chains'
+import { gnosis, mainnet, polygon, sepolia } from 'viem/chains'
 import { createConfig } from 'wagmi'
 import { mock } from 'wagmi/connectors'
 
@@ -19,7 +19,12 @@ export const sepoliaTest = {
   ...getTestRpcUrls('Sepolia'),
 } as const satisfies Chain
 
-export const testChains = [mainnetTest, polygonTest, sepoliaTest] as const
+export const gnosisTest = {
+  ...gnosis,
+  ...getTestRpcUrls('Gnosis'),
+} as const satisfies Chain
+
+export const testChains = [mainnetTest, polygonTest, sepoliaTest, gnosisTest] as const
 
 function getTestRpcUrls(networkName: NetworksWithFork) {
   const { port, rpcUrl } = getTestRpcSetup(networkName)
@@ -49,6 +54,7 @@ function createTestWagmiConfig() {
       [mainnetTest.id]: http(),
       [polygonTest.id]: http(),
       [sepoliaTest.id]: http(),
+      [gnosisTest.id]: http(),
     },
     ssr: false,
   })

--- a/packages/lib/test/utils/wagmi/wagmi-test-clients.ts
+++ b/packages/lib/test/utils/wagmi/wagmi-test-clients.ts
@@ -1,8 +1,8 @@
 import { testWagmiConfig } from '@repo/lib/test/anvil/testWagmiConfig'
 import { publicActions, testActions, walletActions } from 'viem'
-import { mainnet, polygon, sepolia } from 'viem/chains'
+import { gnosis, mainnet, polygon, sepolia } from 'viem/chains'
 
-export function createTestHttpClient(chainId: 1 | 137 | 11155111) {
+export function createTestHttpClient(chainId: 1 | 137 | 11155111 | 100) {
   return testWagmiConfig
     .getClient({ chainId })
     .extend(testActions({ mode: 'anvil' }))
@@ -13,3 +13,4 @@ export function createTestHttpClient(chainId: 1 | 137 | 11155111) {
 export const mainnetTestPublicClient = createTestHttpClient(mainnet.id)
 export const polygonTestPublicClient = createTestHttpClient(polygon.id)
 export const sepoliaTestPublicClient = createTestHttpClient(sepolia.id)
+export const gnosisTestPublicClient = createTestHttpClient(gnosis.id)


### PR DESCRIPTION
- New setup for gnosis integration tests
- Dirty solution for EUR.e until we properly implement it here: https://github.com/balancer/frontend-monorepo/issues/292

We already had that issue in V2 pools:
https://test.balancer.fi/pools/gnosis/v2/0xdd439304a77f54b1f7854751ac1169b279591ef7000000000000000000000064 

V3 pool: 
https://test.balancer.fi/pools/gnosis/v3/0xecc5aebd9569c82a0944007b22d03801a8fdfe99/add-liquidity/0x09ad952e0b5302f00061e7f9b68849b395a502787585c48ac9148ef511ba05c9