### PR TITLE
fix: improve chainSlug handling

### DIFF
--- a/apps/beets-frontend-v3/app/(app)/pools/[chain]/[variant]/[id]/layout.tsx
+++ b/apps/beets-frontend-v3/app/(app)/pools/[chain]/[variant]/[id]/layout.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { FetchPoolProps } from '@repo/lib/modules/pool/pool.types'
-import { ChainSlug, getPoolTypeLabel, slugToChainMap } from '@repo/lib/modules/pool/pool.utils'
+import { ChainSlug, getChainSlug, getPoolTypeLabel } from '@repo/lib/modules/pool/pool.utils'
 import { PropsWithChildren, Suspense } from 'react'
 import { PoolDetailSkeleton } from '@repo/lib/modules/pool/PoolDetail/PoolDetailSkeleton'
 import { getApolloServerClient } from '@repo/lib/shared/services/api/apollo-server.client'
@@ -16,7 +16,7 @@ type Props = PropsWithChildren<{
 }>
 
 async function getPoolQuery(chain: ChainSlug, id: string) {
-  const _chain = slugToChainMap[chain]
+  const _chain = getChainSlug(chain)
   const variables = { id: id.toLowerCase(), chain: _chain }
 
   try {
@@ -54,7 +54,7 @@ export async function generateMetadata({
 }
 
 export default async function PoolLayout({ params: { id, chain, variant }, children }: Props) {
-  const _chain = slugToChainMap[chain]
+  const _chain = getChainSlug(chain)
 
   const { data, error } = await getPoolQuery(chain, id)
 

--- a/apps/beets-frontend-v3/app/(app)/portfolio/[chain]/page.tsx
+++ b/apps/beets-frontend-v3/app/(app)/portfolio/[chain]/page.tsx
@@ -3,7 +3,7 @@ import { PoolName } from '@repo/lib/modules/pool/PoolName'
 import { Pool } from '@repo/lib/modules/pool/PoolProvider'
 import { ClaimModal } from '@repo/lib/modules/pool/actions/claim/ClaimModal'
 import { ClaimProvider } from '@repo/lib/modules/pool/actions/claim/ClaimProvider'
-import { ChainSlug, slugToChainMap } from '@repo/lib/modules/pool/pool.utils'
+import { ChainSlug, getChainSlug } from '@repo/lib/modules/pool/pool.utils'
 // eslint-disable-next-line max-len
 import { ClaimNetworkPoolsLayout } from '@repo/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPoolsLayout'
 import { usePortfolio } from '@repo/lib/modules/portfolio/PortfolioProvider'
@@ -27,7 +27,8 @@ export default function NetworkClaim() {
     refetchClaimPoolData,
   } = usePortfolio()
 
-  const gqlChain = slugToChainMap[chain as ChainSlug]
+  const gqlChain = getChainSlug(chain as ChainSlug)
+
   const pools = poolsByChainMap[gqlChain]
   const chainName = capitalize(chain as string)
   const claimableFiatBalance = totalFiatClaimableBalanceByChain[gqlChain]

--- a/apps/frontend-v3/app/(app)/pools/[chain]/[variant]/[id]/layout.tsx
+++ b/apps/frontend-v3/app/(app)/pools/[chain]/[variant]/[id]/layout.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { FetchPoolProps } from '@repo/lib/modules/pool/pool.types'
-import { ChainSlug, getPoolTypeLabel, slugToChainMap } from '@repo/lib/modules/pool/pool.utils'
+import { ChainSlug, getChainSlug, getPoolTypeLabel } from '@repo/lib/modules/pool/pool.utils'
 import { PropsWithChildren, Suspense } from 'react'
 import { PoolDetailSkeleton } from '@repo/lib/modules/pool/PoolDetail/PoolDetailSkeleton'
 import { getApolloServerClient } from '@repo/lib/shared/services/api/apollo-server.client'
@@ -16,7 +16,7 @@ type Props = PropsWithChildren<{
 }>
 
 async function getPoolQuery(chain: ChainSlug, id: string) {
-  const _chain = slugToChainMap[chain]
+  const _chain = getChainSlug(chain)
   const variables = { id: id.toLowerCase(), chain: _chain }
 
   try {
@@ -54,7 +54,7 @@ export async function generateMetadata({
 }
 
 export default async function PoolLayout({ params: { id, chain, variant }, children }: Props) {
-  const _chain = slugToChainMap[chain]
+  const _chain = getChainSlug(chain)
 
   const { data, error } = await getPoolQuery(chain, id)
 

--- a/apps/frontend-v3/app/(app)/portfolio/[chain]/page.tsx
+++ b/apps/frontend-v3/app/(app)/portfolio/[chain]/page.tsx
@@ -3,7 +3,7 @@ import { PoolName } from '@repo/lib/modules/pool/PoolName'
 import { Pool } from '@repo/lib/modules/pool/PoolProvider'
 import { ClaimModal } from '@repo/lib/modules/pool/actions/claim/ClaimModal'
 import { ClaimProvider } from '@repo/lib/modules/pool/actions/claim/ClaimProvider'
-import { ChainSlug, slugToChainMap } from '@repo/lib/modules/pool/pool.utils'
+import { ChainSlug, getChainSlug } from '@repo/lib/modules/pool/pool.utils'
 // eslint-disable-next-line max-len
 import { ClaimNetworkPoolsLayout } from '@repo/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPoolsLayout'
 import { usePortfolio } from '@repo/lib/modules/portfolio/PortfolioProvider'
@@ -27,7 +27,7 @@ export default function NetworkClaim() {
     refetchClaimPoolData,
   } = usePortfolio()
 
-  const gqlChain = slugToChainMap[chain as ChainSlug]
+  const gqlChain = getChainSlug(chain as ChainSlug)
   const pools = poolsByChainMap[gqlChain]
   const chainName = capitalize(chain as string)
   const claimableFiatBalance = totalFiatClaimableBalanceByChain[gqlChain]

--- a/packages/lib/modules/pool/PoolDetail/PoolActivity/usePoolActivity.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivity/usePoolActivity.tsx
@@ -8,7 +8,7 @@ import { PoolVariant } from '../../pool.types'
 import { usePool } from '../../PoolProvider'
 import { GqlPoolEventType } from '@repo/lib/shared/services/api/generated/graphql'
 import { usePoolEvents } from '../../usePoolEvents'
-import { slugToChainMap, ChainSlug } from '../../pool.utils'
+import { ChainSlug, getChainSlug } from '../../pool.utils'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { differenceInCalendarDays } from 'date-fns'
 import { fNum } from '@repo/lib/shared/utils/numbers'
@@ -41,7 +41,7 @@ function _usePoolActivity() {
   const [isExpanded, setIsExpanded] = useState(false)
   const { isChartView } = usePoolActivityViewType()
 
-  const _chain = slugToChainMap[chain as ChainSlug]
+  const _chain = getChainSlug(chain as ChainSlug)
 
   const tabsList = useMemo(() => {
     const poolType = pool?.type

--- a/packages/lib/modules/pool/PoolDetail/PoolActivityChart/usePoolActivityChart.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivityChart/usePoolActivityChart.tsx
@@ -7,7 +7,7 @@ import { useParams } from 'next/navigation'
 import { secondsToMilliseconds, differenceInDays, format } from 'date-fns'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import EChartsReactCore from 'echarts-for-react/lib/core'
-import { ChainSlug, slugToChainMap } from '../../pool.utils'
+import { ChainSlug, getChainSlug } from '../../pool.utils'
 import { ColorMode, useTheme as useChakraTheme } from '@chakra-ui/react'
 import { useTheme as useNextTheme } from 'next-themes'
 import { abbreviateAddress } from '@repo/lib/shared/utils/addresses'
@@ -258,7 +258,7 @@ export function usePoolActivityChart() {
   const theme = useChakraTheme()
   const { sortedPoolEvents, minDate, maxDate, maxYAxisValue, isExpanded, isLoading } =
     usePoolActivity()
-  const _chain = slugToChainMap[chain as ChainSlug]
+  const _chain = getChainSlug(chain as ChainSlug)
   const chartHeight = isExpanded ? 400 : 90
 
   return {

--- a/packages/lib/modules/pool/pool.utils.ts
+++ b/packages/lib/modules/pool/pool.utils.ts
@@ -57,7 +57,12 @@ export const chainToSlugMap: Record<GqlChain, ChainSlug> = {
   [GqlChain.Mode]: ChainSlug.Mode,
   [GqlChain.Fraxtal]: ChainSlug.Fraxtal,
 }
-export const slugToChainMap = invert(chainToSlugMap) as Record<ChainSlug, GqlChain>
+const slugToChainMap = invert(chainToSlugMap) as Record<ChainSlug, GqlChain>
+export function getChainSlug(chainSlug: ChainSlug): GqlChain {
+  const chain = slugToChainMap[chainSlug]
+  if (!chain) throw new Error(`Chain ${chainSlug} is not a valid chainName`)
+  return chain
+}
 
 function getVariant(pool: Pool | PoolListItem): PoolVariant {
   // if a pool has certain properties return a custom variant

--- a/packages/lib/modules/swap/SwapLayout.tsx
+++ b/packages/lib/modules/swap/SwapLayout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ChainSlug, slugToChainMap } from '@repo/lib/modules/pool/pool.utils'
+import { ChainSlug, getChainSlug } from '@repo/lib/modules/pool/pool.utils'
 import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { RelayerSignatureProvider } from '@repo/lib/modules/relayer/RelayerSignatureProvider'
 import { SwapProviderProps, SwapProvider } from '@repo/lib/modules/swap/SwapProvider'
@@ -20,7 +20,7 @@ type Props = PropsWithChildren<{
 export default function SwapLayout({ props, children }: Props) {
   const chain = props.pathParams.chain
   const { getTokensByChain } = useTokens()
-  const initChain = chain ? slugToChainMap[chain as ChainSlug] : getProjectConfig().defaultNetwork
+  const initChain = chain ? getChainSlug(chain as ChainSlug) : getProjectConfig().defaultNetwork
   const initTokens = props.poolActionableTokens || getTokensByChain(initChain)
 
   if (!initTokens) {

--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -17,7 +17,7 @@ import { bn } from '@repo/lib/shared/utils/numbers'
 import { invert } from 'lodash'
 import { PropsWithChildren, createContext, useEffect, useMemo, useState } from 'react'
 import { Address, Hash, isAddress, parseUnits } from 'viem'
-import { ChainSlug, chainToSlugMap, slugToChainMap } from '../pool/pool.utils'
+import { ChainSlug, chainToSlugMap, getChainSlug } from '../pool/pool.utils'
 import { calcMarketPriceImpact } from '../price-impact/price-impact.utils'
 import { usePriceImpact } from '../price-impact/PriceImpactProvider'
 import { useTokenBalances } from '../tokens/TokenBalancesProvider'
@@ -484,8 +484,8 @@ export function _useSwap({ poolActionableTokens, pool, pathParams }: SwapProvide
 
   function setInitialChain(slugChain?: string) {
     const _chain =
-      slugChain && slugToChainMap[slugChain as ChainSlug]
-        ? slugToChainMap[slugChain as ChainSlug]
+      slugChain && getChainSlug(slugChain as ChainSlug)
+        ? getChainSlug(slugChain as ChainSlug)
         : walletChain
 
     setSelectedChain(_chain)


### PR DESCRIPTION
Improves safety by enforcing chain slug check. 
Example of wrong url: 
https://mono-test-v3-git-fix-chainslugs-balancer.vercel.app/pools/mainnet/v2/0x3de27efa2f1aa663ae5d458857e731c129069f29000200000000000000000588

Before: 
<img width="1054" alt="Screenshot 2024-12-11 at 10 53 10" src="https://github.com/user-attachments/assets/70b9de3c-905d-4f9c-bfda-2089fb809c90">

After: 
<img width="610" alt="Screenshot 2024-12-11 at 10 51 43" src="https://github.com/user-attachments/assets/731d1cdd-8f22-40bc-ad5f-ab614a25a20e">

TODO: 
- improve API error handling for other cases
