### PR TITLE
fix: Dont display underlying for v2 pools

### DIFF
--- a/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
@@ -3,7 +3,7 @@ import { GqlChain, GqlPoolTokenDetail } from '@repo/lib/shared/services/api/gene
 import { PoolListItem } from '../pool.types'
 import { TokenIcon } from '../../tokens/TokenIcon'
 import { fNum } from '@repo/lib/shared/utils/numbers'
-import { isStableLike, isWeightedLike } from '../pool.helpers'
+import { isStableLike, isV3Pool, isWeightedLike } from '../pool.helpers'
 import { Pool } from '../PoolProvider'
 
 function NestedTokenPill({
@@ -177,7 +177,7 @@ export function PoolListTokenPills({ pool, iconSize = 24, ...badgeProps }: Props
     token => token.address !== pool.address
   ) as GqlPoolTokenDetail[]
 
-  if (pool.hasErc4626 && !pool.hasNestedErc4626) {
+  if (isV3Pool(pool) && pool.hasErc4626 && !pool.hasNestedErc4626) {
     // TODO: Move this into a general 'displayTokens' helper function.
     poolTokens = poolTokens.map(token =>
       token.underlyingToken


### PR DESCRIPTION
See this pool https://balancer.fi/pools/ethereum/v2/0x1d13531bf6344c102280ce4c458781fbf14dad140000000000000000000006df

We don't look at erc4626 underlying tokens for v2 pools. Other parts of the pool page have been fixed, the last part is just the pills.

I have more work todo around this issue, so the conditional will probably be extracted in a future PR.