### PR TITLE
fix: pass original id to pool activity table

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolActivity/poolActivity.types.ts
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivity/poolActivity.types.ts
@@ -12,6 +12,7 @@ export type PoolActivityMetaData = {
   tx: string
   usdValue: string
   action: 'swap' | 'add' | 'remove'
+  id: string
 }
 
 export type PoolActivityEl = [number, string, PoolActivityMetaData]

--- a/packages/lib/modules/pool/PoolDetail/PoolActivity/usePoolActivity.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivity/usePoolActivity.tsx
@@ -97,7 +97,7 @@ function _usePoolActivity() {
 
     const data = events.reduce(
       (acc: PoolActivity, item) => {
-        const { type, timestamp, valueUSD, userAddress, tx } = item
+        const { type, timestamp, valueUSD, userAddress, tx, id } = item
 
         const usdValue = valueUSD.toString() ?? ''
         const tokens: PoolActivityTokens[] = []
@@ -128,7 +128,7 @@ function _usePoolActivity() {
         const elToPush = [
           timestamp,
           isExpanded ? usdValue : '0',
-          { userAddress, tokens, usdValue, tx, action: 'swap' }, // action will be overwritten again below
+          { userAddress, tokens, usdValue, tx, action: 'swap', id }, // action will be overwritten again below
         ] as PoolActivityEl
 
         switch (type) {

--- a/packages/lib/modules/pool/PoolDetail/PoolActivityTable/PoolActivityTable.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivityTable/PoolActivityTable.tsx
@@ -33,7 +33,7 @@ export function PoolActivityTable() {
 
   const items = sortedPoolEvents.map(item => ({
     ...item,
-    id: item[0],
+    id: item[2].id,
   }))
 
   return (


### PR DESCRIPTION
fix broken sorting in pool events table
check https://balancer.fi/pools/ethereum/v2/0xcfca23ca9ca720b6e98e3eb9b6aa0ffc4a5c08b9000200000000000000000274