### PR TITLE
chore: Minor fixes

### DIFF
--- a/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
+++ b/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
@@ -262,6 +262,7 @@ export const TokenInput = forwardRef(
                 boxShadow="none"
                 fontSize="3xl"
                 fontWeight="medium"
+                isDisabled={!token}
                 min={0}
                 onChange={handleOnChange}
                 onKeyDown={blockInvalidNumberInput}
@@ -279,15 +280,17 @@ export const TokenInput = forwardRef(
                 value={value}
                 {...inputProps}
               />
-              <Box
-                bgGradient="linear(to-r, transparent, background.level0 70%)"
-                h="full"
-                position="absolute"
-                right={0}
-                top={0}
-                w="8"
-                zIndex={9999}
-              />
+              {token && (
+                <Box
+                  bgGradient="linear(to-r, transparent, background.level0 70%)"
+                  h="full"
+                  position="absolute"
+                  right={0}
+                  top={0}
+                  w="8"
+                  zIndex={9999}
+                />
+              )}
             </Box>
 
             {tokenInputSelector && (

--- a/packages/lib/modules/tokens/TokenSelectModal/TokenSelectList/TokenSelectListRow.tsx
+++ b/packages/lib/modules/tokens/TokenSelectModal/TokenSelectList/TokenSelectListRow.tsx
@@ -44,6 +44,8 @@ export function TokenSelectListRow({
     px: 'md',
     cursor: isCurrentToken ? 'not-allowed' : 'pointer',
     opacity: isCurrentToken ? 0.5 : 1,
+    rounded: 'md',
+    mb: 'sm',
     _hover: isCurrentToken
       ? {}
       : {


### PR DESCRIPTION
If you try to input a number before a token is selected you get this error. We can fix this by disabling the input until a token is selected. I'm not sure if this will cause issues elsewhere. It shouldn't.
<img width="481" alt="Screenshot 2024-12-16 at 10 25 38" src="https://github.com/user-attachments/assets/1f003efb-ef92-421f-a276-3b8a6e51aec0" />


We can hide this input gradient when no token is selected to avoid this weird shadow issue.
<img width="288" alt="Screenshot 2024-12-16 at 10 25 30" src="https://github.com/user-attachments/assets/fa17db4d-3829-4864-ab6f-484c0a13b5cd" />
