### PR TITLE
feat: isBufferAllowed logic

### DIFF
--- a/apps/frontend-v3/.env.test
+++ b/apps/frontend-v3/.env.test
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_APP_ENV=test
-NEXT_PUBLIC_BALANCER_API_URL=https://api-v3.balancer.fi/graphql
+NEXT_PUBLIC_BALANCER_API_URL=https://tes-api-v3.balancer.fi/graphql

--- a/apps/frontend-v3/.env.test
+++ b/apps/frontend-v3/.env.test
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_APP_ENV=test
-NEXT_PUBLIC_BALANCER_API_URL=https://tes-api-v3.balancer.fi/graphql
+NEXT_PUBLIC_BALANCER_API_URL=https://api-v3.balancer.fi/graphql

--- a/packages/lib/modules/pool/PoolDetail/PoolInfo/PoolContracts.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolInfo/PoolContracts.tsx
@@ -163,10 +163,14 @@ export function PoolContracts({ ...props }: CardProps) {
 
   const erc4626Tokens = useMemo(() => {
     if (!isV3Pool(pool)) return []
+    // Avoid showing tokenized vaults when no token has isBufferAllowed
+    if (isV3Pool(pool) && !pool.hasAnyAllowedBuffer) return []
 
-    const erc4626Tokens = pool.poolTokens.filter(token => token.isErc4626)
+    const erc4626Tokens = pool.poolTokens.filter(token => token.isErc4626 && token.hasBufferAllowed)
     const erc4626NestedTokens = pool.poolTokens.flatMap(token =>
-      token.nestedPool ? token.nestedPool.tokens.filter(token => token.isErc4626) : []
+      token.nestedPool
+        ? token.nestedPool.tokens.filter(token => token.isErc4626 && token.hasBufferAllowed)
+        : []
     )
     return [...(erc4626Tokens ? erc4626Tokens : []), ...erc4626NestedTokens]
   }, [pool])

--- a/packages/lib/modules/pool/PoolDetail/PoolInfo/PoolContracts.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolInfo/PoolContracts.tsx
@@ -166,10 +166,10 @@ export function PoolContracts({ ...props }: CardProps) {
     // Avoid showing tokenized vaults when no token has isBufferAllowed
     if (isV3Pool(pool) && !pool.hasAnyAllowedBuffer) return []
 
-    const erc4626Tokens = pool.poolTokens.filter(token => token.isErc4626 && token.hasBufferAllowed)
+    const erc4626Tokens = pool.poolTokens.filter(token => token.isErc4626 && token.isBufferAllowed)
     const erc4626NestedTokens = pool.poolTokens.flatMap(token =>
       token.nestedPool
-        ? token.nestedPool.tokens.filter(token => token.isErc4626 && token.hasBufferAllowed)
+        ? token.nestedPool.tokens.filter(token => token.isErc4626 && token.isBufferAllowed)
         : []
     )
     return [...(erc4626Tokens ? erc4626Tokens : []), ...erc4626NestedTokens]

--- a/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
@@ -193,7 +193,7 @@ export function PoolListTokenPills({
   // TODO: Move this into a general 'displayTokens' helper function.
   if (isV3Pool(pool) && pool.hasErc4626 && pool.hasAnyAllowedBuffer) {
     poolTokens = poolTokens.map(token =>
-      !token?.underlyingToken?.isBufferAllowed
+      token.isErc4626 && token.isBufferAllowed
         ? ({ ...token, ...token.underlyingToken } as unknown as GqlPoolTokenDetail)
         : token
     )

--- a/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
@@ -190,11 +190,13 @@ export function PoolListTokenPills({
     token => token.address !== pool.address
   ) as GqlPoolTokenDetail[]
 
-  if (isV3Pool(pool) && pool.hasErc4626 && !pool.hasNestedErc4626) {
-    // TODO: Move this into a general 'displayTokens' helper function.
+  // if (isV3Pool(pool) && pool.hasErc4626 && pool.hasAnyAllowedBuffer) {
+  // TODO: Move this into a general 'displayTokens' helper function.
+  if (isV3Pool(pool) && pool.hasErc4626 && pool.hasAnyAllowedBuffer) {
     poolTokens = poolTokens.map(token =>
-      token.underlyingToken
-        ? ({ ...token, ...token.underlyingToken } as unknown as GqlPoolTokenDetail)
+      !token?.underlyingToken?.isBufferAllowed
+        ? // && token.address !== '0xc824a08db624942c5e5f330d56530cd1598859fd' // uncomment to debug until when api is synced
+          ({ ...token, ...token.underlyingToken } as unknown as GqlPoolTokenDetail)
         : token
     )
   }

--- a/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
@@ -190,13 +190,11 @@ export function PoolListTokenPills({
     token => token.address !== pool.address
   ) as GqlPoolTokenDetail[]
 
-  // if (isV3Pool(pool) && pool.hasErc4626 && pool.hasAnyAllowedBuffer) {
   // TODO: Move this into a general 'displayTokens' helper function.
   if (isV3Pool(pool) && pool.hasErc4626 && pool.hasAnyAllowedBuffer) {
     poolTokens = poolTokens.map(token =>
       !token?.underlyingToken?.isBufferAllowed
-        ? // && token.address !== '0xc824a08db624942c5e5f330d56530cd1598859fd' // uncomment to debug until when api is synced
-          ({ ...token, ...token.underlyingToken } as unknown as GqlPoolTokenDetail)
+        ? ({ ...token, ...token.underlyingToken } as unknown as GqlPoolTokenDetail)
         : token
     )
   }

--- a/packages/lib/modules/pool/__mocks__/notAllowedPoolMock.ts
+++ b/packages/lib/modules/pool/__mocks__/notAllowedPoolMock.ts
@@ -110,6 +110,7 @@ export const notAllowedPoolMock: Pool = {
       nestedPool: null,
       __typename: 'GqlPoolTokenDetail',
       isErc4626: false,
+      isBufferAllowed: false,
       underlyingToken: null,
     },
     {
@@ -130,6 +131,7 @@ export const notAllowedPoolMock: Pool = {
       nestedPool: null,
       __typename: 'GqlPoolTokenDetail',
       isErc4626: false,
+      isBufferAllowed: false,
       underlyingToken: null,
     },
   ],

--- a/packages/lib/modules/pool/actions/LiquidityActionHelpers.integration.spec.ts
+++ b/packages/lib/modules/pool/actions/LiquidityActionHelpers.integration.spec.ts
@@ -484,13 +484,18 @@ describe('Liquidity helpers for GNOSIS V3 Boosted pools', async () => {
           "symbol": "GNO",
         },
         {
-          "address": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
-          "chainId": 100,
+          "address": "0x7c16f0185a26db0ae7a9377f23bc18ea7ce5d644",
+          "decimals": 18,
+          "index": 0,
+          "name": "Wrapped Aave Gnosis GNO",
+          "symbol": "waGnoGNO",
+        },
+        {
+          "address": "0xaf204776c7245bf4147c2612bf6e5972ee483701",
           "decimals": 18,
           "index": 1,
-          "isBufferAllowed": true,
-          "name": "Wrapped XDAI",
-          "symbol": "WXDAI",
+          "name": "Savings xDAI",
+          "symbol": "sDAI",
         },
       ]
     `)

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -68,7 +68,7 @@ export function isFx(poolType: GqlPoolType | string): boolean {
 }
 
 export function isBoosted(pool: PoolListItem | Pool) {
-  return isV3Pool(pool) && (pool.hasErc4626 || pool.hasNestedErc4626)
+  return isV3Pool(pool) && pool.hasAnyAllowedBuffer // this means that the pool has at least one ERC4626 token with allowed buffer
 }
 
 export function isGyro(poolType: GqlPoolType) {
@@ -581,13 +581,14 @@ export function allPoolTokens(pool: Pool | GqlPoolBase): TokenCore[] {
 }
 
 function shouldUseUnderlyingToken(token: PoolToken, pool: Pool | GqlPoolBase): boolean {
-  if (isV3Pool(pool) && token.isErc4626 && !token.underlyingToken) {
+  if (isV3Pool(pool) && token.isErc4626 && token.isBufferAllowed && !token.underlyingToken) {
+    // This should never happen unless the API some some inconsistency
     throw new Error(
       `Underlying token is missing for ERC4626 token with address ${token.address} in chain ${pool.chain}`
     )
   }
   // Only v3 pools should underlying tokens
-  return isV3Pool(pool) && token.isErc4626 && !!token.underlyingToken
+  return isV3Pool(pool) && token.isErc4626 && token.isBufferAllowed && !!token.underlyingToken
 }
 
 // Returns top level standard tokens + Erc4626 (only v3) underlying tokens

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -566,8 +566,16 @@ export function allPoolTokens(pool: Pool | GqlPoolBase): TokenCore[] {
     token.nestedPool ? extractNestedUnderlyingTokens(token.nestedPool as GqlNestedPool) : []
   )
 
+  const isTopLevelToken = (token: PoolToken): boolean => {
+    if (token.hasNestedPool) return false
+    if (!isV3Pool(pool)) return true
+    if (!token.isErc4626) return true
+    if (token.isErc4626 && !token.isBufferAllowed) return true
+    return true
+  }
+
   const standardTopLevelTokens: PoolToken[] = pool.poolTokens.flatMap(token =>
-    !token.hasNestedPool && (!isV3Pool(pool) || !token.isErc4626) ? token : []
+    isTopLevelToken(token) ? token : []
   )
 
   const allTokens = underlyingTokens.concat(

--- a/packages/lib/shared/services/api/pool-tokens.graphql
+++ b/packages/lib/shared/services/api/pool-tokens.graphql
@@ -60,6 +60,7 @@ fragment PoolTokens on GqlPoolTokenDetail {
       symbol
       weight
       isErc4626
+      isBufferAllowed
       underlyingToken {
         ...UnderlyingToken
       }
@@ -72,6 +73,7 @@ fragment PoolTokens on GqlPoolTokenDetail {
     }
   }
   isErc4626
+  isBufferAllowed
   underlyingToken {
     ...UnderlyingToken
   }


### PR DESCRIPTION
Pool to test:
https://mono-test-v3-git-feat-isbufferallowed-balancer.vercel.app/pools/ethereum/v3/0x6649a010cbcf5742e7a13a657df358556b3e55cf

Now token pills are correct (no underlying tokens): 

<img width="562" alt="Screenshot 2024-12-16 at 16 35 15" src="https://github.com/user-attachments/assets/1ecab3c3-2289-42da-a7ca-10c3f07b2419" />

Tokens in adds are correct: 

<img width="676" alt="Screenshot 2024-12-16 at 16 47 29" src="https://github.com/user-attachments/assets/5e43a9d9-ea61-4e77-b39e-5765b3137407" />

No tokenized vaults: 

<img width="563" alt="Screenshot 2024-12-16 at 16 48 09" src="https://github.com/user-attachments/assets/cb600624-0dc4-4714-8806-271addadfded" />





