### PR TITLE
chore: Update eslint rules

### DIFF
--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -38,7 +38,7 @@ module.exports = {
   rules: {
     curly: ['error', 'multi-line'],
     'no-console': ['off'],
-    'max-len': ['warn', { code: 120, ignoreComments: true, ignoreUrls: true }],
+    'max-len': ['warn', { code: 120, ignoreComments: true, ignoreUrls: true, ignoreTemplateLiterals: true, ignoreStrings: true }],
     '@typescript-eslint/no-explicit-any': ['off'],
     'no-html-link-for-pages': ['off'],
     'no-restricted-imports': [


### PR DESCRIPTION
We have a lot of exceptions for warnings of max-len rule in svgs etc where they should really be ignored. This rule change should remove that warning.