### PR TITLE
chore: bump sdk to 1.0.1

### DIFF
--- a/packages/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
@@ -42,7 +42,7 @@ export class RecoveryRemoveLiquidityHandler {
     const removeLiquidity = new RemoveLiquidity()
     const removeLiquidityInput = this.constructSdkInput(bptIn, userAddress)
 
-    const sdkQueryOutput = await removeLiquidity.queryRemoveLiquidityRecovery(
+    const sdkQueryOutput = await removeLiquidity.query(
       removeLiquidityInput,
       this.helpers.poolStateWithBalances
     )

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.11.8",
-    "@balancer/sdk": "0.33.5",
+    "@balancer/sdk": "1.0.1",
     "@chakra-ui/anatomy": "^2.2.2",
     "@chakra-ui/clickable": "^2.1.0",
     "@chakra-ui/hooks": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,8 +338,8 @@ importers:
         specifier: ^3.11.8
         version: 3.11.8(@types/react@18.2.34)(graphql-ws@5.16.0(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@balancer/sdk':
-        specifier: 0.33.5
-        version: 0.33.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.1)
+        specifier: 1.0.1
+        version: 1.0.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@chakra-ui/anatomy':
         specifier: ^2.2.2
         version: 2.2.2
@@ -1746,8 +1746,8 @@ packages:
     resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
-  '@balancer/sdk@0.33.5':
-    resolution: {integrity: sha512-aQbDZ7HUk9mD0BZWKYNDhbF5hDcipYg7AT7YcD9eb6jPkkq6YXN2/uqTDwdcZ/mkllHzjdjGdrmFKadSZqF6yw==}
+  '@balancer/sdk@1.0.1':
+    resolution: {integrity: sha512-/nbqzTWZdZjoHr8MKMBLOQewojdwqmIFYdVVv3NXUmnAi3Va27bo5mAKZ2n5yo/bJ4w5wtkXDEm2BixkUXWRvw==}
     engines: {node: '>=18.x'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -12849,7 +12849,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@balancer/sdk@0.33.5(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@balancer/sdk@1.0.1(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
       decimal.js-light: 2.5.1
       lodash.clonedeep: 4.5.0


### PR DESCRIPTION
Bump version to unblock sonic launch. 

TODO: 
we will use added sdk features (wethIsEth for Boosted and so on) in a separate PR.