### PR TITLE
fix: reset to page 1 on pool filter change

### DIFF
--- a/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
+++ b/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
@@ -77,7 +77,7 @@ export function usePoolListQueryState() {
   useEffect(() => {
     setSkip(0)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [poolTypes, networks, userAddress, minTvl, poolTags])
+  }, [poolTypes, networks, minTvl, poolTags])
 
   // Set internal checked state
   function toggleUserAddress(checked: boolean, address: string) {

--- a/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
+++ b/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
@@ -18,7 +18,7 @@ import {
   SortingState,
 } from '../pool.types'
 import { PaginationState } from '@repo/lib/shared/components/pagination/pagination.types'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ButtonGroupOption } from '@repo/lib/shared/components/btns/button-group/ButtonGroup'
 
 export const PROTOCOL_VERSION_TABS: ButtonGroupOption[] = [
@@ -72,6 +72,12 @@ export function usePoolListQueryState() {
   const [minTvl, setMinTvl] = useQueryState('minTvl', poolListQueryStateParsers.minTvl)
 
   const [poolTags, setPoolTags] = useQueryState('poolTags', poolListQueryStateParsers.poolTags)
+
+  // on toggle always start at the beginning of the list
+  useEffect(() => {
+    setSkip(0)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poolTypes, networks, userAddress, minTvl, poolTags])
 
   // Set internal checked state
   function toggleUserAddress(checked: boolean, address: string) {


### PR DESCRIPTION
fixes #402 

reset to page 1 (set skip to 0) on _any_ pool filter change (except (un)ticking **My Liquidity** as this already does the reset)
