### PR TITLE
fix: transaction action button

### DIFF
--- a/packages/lib/shared/components/modals/ActionModalFooter.tsx
+++ b/packages/lib/shared/components/modals/ActionModalFooter.tsx
@@ -103,7 +103,7 @@ export function ActionModalFooter({
             transition={{ duration: 0.3 }}
           >
             <VStack w="full">
-              <RenderActionButton currentStep={currentStep} />
+              <RenderActionButton currentStep={currentStep} key={currentStep.id} />
             </VStack>
           </motion.div>
         )}


### PR DESCRIPTION
bug [context](https://balancerecosystem.slack.com/archives/C02F9EMRKQA/p1736221312345609)

we need to provide key to create new RenderActionButton's instance depending on currentStep.id otherwise it may take previous transaction result from `useManagedTransaction`