### PR TITLE
fix: add base layout

### DIFF
--- a/apps/beets-frontend-v3/app/(app)/layout.tsx
+++ b/apps/beets-frontend-v3/app/(app)/layout.tsx
@@ -1,0 +1,6 @@
+import { PropsWithChildren } from 'react'
+import { BaseLayout } from '../layouts/base-layout'
+
+export default function AppLayout({ children }: PropsWithChildren) {
+  return <BaseLayout>{children}</BaseLayout>
+}

--- a/apps/beets-frontend-v3/app/(app)/pools/layout.tsx
+++ b/apps/beets-frontend-v3/app/(app)/pools/layout.tsx
@@ -1,3 +1,4 @@
+import { PoolsNetworkWatcher } from '@/lib/components/navs/PoolsNetworkWatcher'
 import { Metadata } from 'next'
 import { PropsWithChildren } from 'react'
 
@@ -11,5 +12,10 @@ export const metadata: Metadata = {
 }
 
 export default async function Pools({ children }: PropsWithChildren) {
-  return <>{children}</>
+  return (
+    <>
+      {children}
+      <PoolsNetworkWatcher />
+    </>
+  )
 }

--- a/apps/beets-frontend-v3/app/(marketing)/layout.tsx
+++ b/apps/beets-frontend-v3/app/(marketing)/layout.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable max-len */
 import { Box } from '@chakra-ui/react'
 import { PropsWithChildren } from 'react'
+import { BaseLayout } from '../layouts/base-layout'
 
 export default function MarketingLayout({ children }: PropsWithChildren) {
-  return <Box>{children}</Box>
+  return (
+    <BaseLayout renderLzBeetsModal={false}>
+      <Box>{children}</Box>
+    </BaseLayout>
+  )
 }

--- a/apps/beets-frontend-v3/app/layout.tsx
+++ b/apps/beets-frontend-v3/app/layout.tsx
@@ -1,22 +1,18 @@
 /* eslint-disable max-len */
 import { Metadata } from 'next'
-import { satoshiFont } from '@repo/lib/assets/fonts/satoshi/satoshi'
-import NextTopLoader from 'nextjs-toploader'
-import { SpeedInsights } from '@vercel/speed-insights/next'
-import '@repo/lib/assets/css/global.css'
 import { PropsWithChildren } from 'react'
-import { Providers } from '@repo/lib/shared/components/site/providers'
+import { satoshiFont } from '@repo/lib/assets/fonts/satoshi/satoshi'
+import '@repo/lib/assets/css/global.css'
 import { DEFAULT_THEME_COLOR_MODE } from '@repo/lib/shared/services/chakra/themes/base/foundations'
 import { ThemeProvider as ColorThemeProvider } from 'next-themes'
 import { ThemeProvider } from '@/lib/services/chakra/ThemeProvider'
-import { LzBeetsMigrateModal } from '@/lib/components/modals/LzBeetsMigrateModal'
-import { BaseLayout } from './layouts/base-layout'
+import { Providers } from '@repo/lib/shared/components/site/providers'
 
 export const metadata: Metadata = {
   title: 'Beets',
   description: `The Flagship LST Hub on Sonic. From seamless staking to earning real yield on LST-focused liquidity pools, beets is the ultimate destination for your liquid-staked tokens.`,
   icons: [{ rel: 'icon', type: 'image/x-icon', url: '/favicon.ico' }],
-  metadataBase: new URL('https://zen.beets.fi'),
+  metadataBase: new URL('https://beets.fi'),
 }
 
 export default function RootLayout({ children }: PropsWithChildren) {
@@ -27,25 +23,11 @@ export default function RootLayout({ children }: PropsWithChildren) {
         style={{ marginRight: '0px !important' }} // Required to prevent layout shift introduced by Rainbowkit
         suppressHydrationWarning
       >
-        <div
-          style={{
-            backgroundImage: 'url(/images/misc/pattern-sml-7@2x.webp)',
-            backgroundSize: '8%',
-          }}
-        >
-          <NextTopLoader color="#7f6ae8" showSpinner={false} />
-          <ColorThemeProvider defaultTheme={DEFAULT_THEME_COLOR_MODE}>
-            <ThemeProvider>
-              <Providers>
-                <BaseLayout>
-                  {children}
-                  <LzBeetsMigrateModal />
-                </BaseLayout>
-                <SpeedInsights />
-              </Providers>
-            </ThemeProvider>
-          </ColorThemeProvider>
-        </div>
+        <ColorThemeProvider defaultTheme={DEFAULT_THEME_COLOR_MODE}>
+          <ThemeProvider>
+            <Providers>{children}</Providers>
+          </ThemeProvider>
+        </ColorThemeProvider>
       </body>
     </html>
   )

--- a/apps/beets-frontend-v3/app/layouts/base-layout.tsx
+++ b/apps/beets-frontend-v3/app/layouts/base-layout.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-import { Metadata } from 'next'
 import { satoshiFont } from '@repo/lib/assets/fonts/satoshi/satoshi'
 import NextTopLoader from 'nextjs-toploader'
 import { SpeedInsights } from '@vercel/speed-insights/next'
@@ -9,22 +7,16 @@ import { Providers } from '@repo/lib/shared/components/site/providers'
 import { DEFAULT_THEME_COLOR_MODE } from '@repo/lib/shared/services/chakra/themes/base/foundations'
 import { ThemeProvider as ColorThemeProvider } from 'next-themes'
 import { ThemeProvider } from '@/lib/services/chakra/ThemeProvider'
-import { LzBeetsMigrateModal } from '@/lib/components/modals/LzBeetsMigrateModal'
-import { BaseLayout } from './layouts/base-layout'
+import { NavBarContainer } from '@/lib/components/navs/NavBarContainer'
+import { GlobalAlerts } from '@repo/lib/shared/components/navs/GlobalAlerts'
+import { FooterContainer } from '@/lib/components/footer/FooterContainer'
 
-export const metadata: Metadata = {
-  title: 'Beets',
-  description: `The Flagship LST Hub on Sonic. From seamless staking to earning real yield on LST-focused liquidity pools, beets is the ultimate destination for your liquid-staked tokens.`,
-  icons: [{ rel: 'icon', type: 'image/x-icon', url: '/favicon.ico' }],
-  metadataBase: new URL('https://zen.beets.fi'),
-}
-
-export default function RootLayout({ children }: PropsWithChildren) {
+export function BaseLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body
         className={satoshiFont.className}
-        style={{ marginRight: '0px !important' }} // Required to prevent layout shift introduced by Rainbowkit
+        style={{ marginRight: '0px !important' }}
         suppressHydrationWarning
       >
         <div
@@ -37,10 +29,10 @@ export default function RootLayout({ children }: PropsWithChildren) {
           <ColorThemeProvider defaultTheme={DEFAULT_THEME_COLOR_MODE}>
             <ThemeProvider>
               <Providers>
-                <BaseLayout>
-                  {children}
-                  <LzBeetsMigrateModal />
-                </BaseLayout>
+                <GlobalAlerts />
+                <NavBarContainer />
+                {children}
+                <FooterContainer />
                 <SpeedInsights />
               </Providers>
             </ThemeProvider>

--- a/apps/beets-frontend-v3/app/layouts/base-layout.tsx
+++ b/apps/beets-frontend-v3/app/layouts/base-layout.tsx
@@ -1,44 +1,29 @@
-import { satoshiFont } from '@repo/lib/assets/fonts/satoshi/satoshi'
 import NextTopLoader from 'nextjs-toploader'
 import { SpeedInsights } from '@vercel/speed-insights/next'
-import '@repo/lib/assets/css/global.css'
 import { PropsWithChildren } from 'react'
-import { Providers } from '@repo/lib/shared/components/site/providers'
-import { DEFAULT_THEME_COLOR_MODE } from '@repo/lib/shared/services/chakra/themes/base/foundations'
-import { ThemeProvider as ColorThemeProvider } from 'next-themes'
-import { ThemeProvider } from '@/lib/services/chakra/ThemeProvider'
 import { NavBarContainer } from '@/lib/components/navs/NavBarContainer'
 import { GlobalAlerts } from '@repo/lib/shared/components/navs/GlobalAlerts'
 import { FooterContainer } from '@/lib/components/footer/FooterContainer'
+import { LzBeetsMigrateModal } from '@/lib/components/modals/LzBeetsMigrateModal'
 
-export function BaseLayout({ children }: PropsWithChildren) {
+export function BaseLayout({
+  children,
+  isNotFound = false,
+}: PropsWithChildren & { isNotFound?: boolean }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body
-        className={satoshiFont.className}
-        style={{ marginRight: '0px !important' }}
-        suppressHydrationWarning
-      >
-        <div
-          style={{
-            backgroundImage: 'url(/images/misc/pattern-sml-7@2x.webp)',
-            backgroundSize: '8%',
-          }}
-        >
-          <NextTopLoader color="#7f6ae8" showSpinner={false} />
-          <ColorThemeProvider defaultTheme={DEFAULT_THEME_COLOR_MODE}>
-            <ThemeProvider>
-              <Providers>
-                <GlobalAlerts />
-                <NavBarContainer />
-                {children}
-                <FooterContainer />
-                <SpeedInsights />
-              </Providers>
-            </ThemeProvider>
-          </ColorThemeProvider>
-        </div>
-      </body>
-    </html>
+    <div
+      style={{
+        backgroundImage: 'url(/images/misc/pattern-sml-7@2x.webp)',
+        backgroundSize: '8%',
+      }}
+    >
+      <NextTopLoader color="#7f6ae8" showSpinner={false} />
+      <GlobalAlerts />
+      <NavBarContainer />
+      {children}
+      {!isNotFound && <LzBeetsMigrateModal />}
+      <FooterContainer />
+      <SpeedInsights />
+    </div>
   )
 }

--- a/apps/beets-frontend-v3/app/layouts/base-layout.tsx
+++ b/apps/beets-frontend-v3/app/layouts/base-layout.tsx
@@ -8,8 +8,8 @@ import { LzBeetsMigrateModal } from '@/lib/components/modals/LzBeetsMigrateModal
 
 export function BaseLayout({
   children,
-  isNotFound = false,
-}: PropsWithChildren & { isNotFound?: boolean }) {
+  renderLzBeetsModal = true,
+}: PropsWithChildren & { renderLzBeetsModal?: boolean }) {
   return (
     <div
       style={{
@@ -21,7 +21,7 @@ export function BaseLayout({
       <GlobalAlerts />
       <NavBarContainer />
       {children}
-      {!isNotFound && <LzBeetsMigrateModal />}
+      {renderLzBeetsModal && <LzBeetsMigrateModal />}
       <FooterContainer />
       <SpeedInsights />
     </div>

--- a/apps/beets-frontend-v3/app/not-found.tsx
+++ b/apps/beets-frontend-v3/app/not-found.tsx
@@ -2,10 +2,10 @@ import { DefaultPageContainer } from '@repo/lib/shared/components/containers/Def
 import { Button, Heading, VStack, Text } from '@chakra-ui/react'
 import { headers } from 'next/headers'
 import Link from 'next/link'
+import { BaseLayout } from './layouts/base-layout'
 
 export default async function NotFound() {
   const headersList = headers()
-
   const referer = await headersList.get('referer')
 
   const poolIdSegment = 6
@@ -21,17 +21,19 @@ export default async function NotFound() {
   const redirectText = isPoolPageNotFound ? 'View All Pools' : 'Return Home'
 
   return (
-    <DefaultPageContainer minH="80vh">
-      <VStack align="start" spacing="md">
-        <Heading size="md">{title}</Heading>
-        <VStack align="start" spacing="xs">
-          <Text>{description}</Text>
-        </VStack>
+    <BaseLayout>
+      <DefaultPageContainer minH="80vh">
+        <VStack align="start" spacing="md">
+          <Heading size="md">{title}</Heading>
+          <VStack align="start" spacing="xs">
+            <Text>{description}</Text>
+          </VStack>
 
-        <Button as={Link} href={redirectUrl} size="sm">
-          {redirectText}
-        </Button>
-      </VStack>
-    </DefaultPageContainer>
+          <Button as={Link} href={redirectUrl} size="sm">
+            {redirectText}
+          </Button>
+        </VStack>
+      </DefaultPageContainer>
+    </BaseLayout>
   )
 }

--- a/apps/beets-frontend-v3/app/not-found.tsx
+++ b/apps/beets-frontend-v3/app/not-found.tsx
@@ -21,7 +21,7 @@ export default async function NotFound() {
   const redirectText = isPoolPageNotFound ? 'View All Pools' : 'Return Home'
 
   return (
-    <BaseLayout isNotFound>
+    <BaseLayout renderLzBeetsModal={false}>
       <DefaultPageContainer minH="80vh">
         <VStack align="start" spacing="md">
           <Heading size="md">{title}</Heading>

--- a/apps/beets-frontend-v3/app/not-found.tsx
+++ b/apps/beets-frontend-v3/app/not-found.tsx
@@ -21,14 +21,13 @@ export default async function NotFound() {
   const redirectText = isPoolPageNotFound ? 'View All Pools' : 'Return Home'
 
   return (
-    <BaseLayout>
+    <BaseLayout isNotFound>
       <DefaultPageContainer minH="80vh">
         <VStack align="start" spacing="md">
           <Heading size="md">{title}</Heading>
           <VStack align="start" spacing="xs">
             <Text>{description}</Text>
           </VStack>
-
           <Button as={Link} href={redirectUrl} size="sm">
             {redirectText}
           </Button>

--- a/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
+++ b/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
@@ -75,7 +75,7 @@ export function usePoolListQueryState() {
 
   // on toggle always start at the beginning of the list
   useEffect(() => {
-    setSkip(0)
+    if (skip) setSkip(0)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [poolTypes, networks, minTvl, poolTags])
 


### PR DESCRIPTION
this is a temporary fix for:

1. the beets app is getting a lot of requests that route to `/_not-found`
2. the beets app is loading the lzbeets migration modal on _all_ pages

these 2 combined are generating a lot of rpcs calls

so to exclude the modal when rendering the not-found and marketing page i did this:

- updated root layout to only proved html structure
- created base layout with client components prev in root layout and a flag for conditional rendering of modal 
(imported by app & marketing layout and not-found page)

also fixed always setting skip on pools page to zero and moved `PoolsNetworkWatcher` to pools page 