### PR TITLE
fix: ignore js files in lint staged

### DIFF
--- a/apps/beets-frontend-v3/.lintstagedrc.mjs
+++ b/apps/beets-frontend-v3/.lintstagedrc.mjs
@@ -1,7 +1,6 @@
 export default {
-  '*.{js,jsx,ts,tsx}': "eslint --fix --cache --max-warnings 0",
+  '*.{jsx,ts,tsx}': 'eslint --fix --cache --max-warnings 0',
   '**/*.ts?(x)': 'bash -c "pnpm typecheck"',
   '*.{md,json,yaml,ts,tsx}': 'prettier --write',
   '*.css': 'stylelint --fix',
 }
-

--- a/apps/frontend-v3/.lintstagedrc.mjs
+++ b/apps/frontend-v3/.lintstagedrc.mjs
@@ -1,7 +1,6 @@
 export default {
-  '*.{js,jsx,ts,tsx}': "eslint --fix --cache --max-warnings 0",
+  '*.{jsx,ts,tsx}': 'eslint --fix --cache --max-warnings 0',
   '**/*.ts?(x)': 'bash -c "pnpm typecheck"',
   '*.{md,json,yaml,ts,tsx}': 'prettier --write',
   '*.css': 'stylelint --fix',
 }
-

--- a/packages/lib/.eslintrc.js
+++ b/packages/lib/.eslintrc.js
@@ -6,4 +6,7 @@ module.exports = {
   parserOptions: {
     project: true,
   },
+  rules: {
+    '@next/next/no-html-link-for-pages': 'off',
+  },
 }

--- a/packages/lib/.lintstagedrc.mjs
+++ b/packages/lib/.lintstagedrc.mjs
@@ -1,7 +1,6 @@
 export default {
-  '*.{js,jsx,ts,tsx}': "eslint --fix --cache --max-warnings 0",
+  '*.{jsx,ts,tsx}': 'eslint --fix --cache --max-warnings 0',
   '**/*.ts?(x)': 'bash -c "pnpm typecheck"',
   '*.{md,json,yaml,ts,tsx}': 'prettier --write',
   '*.css': 'stylelint --fix',
 }
-


### PR DESCRIPTION
The next.js eslint setup is explicitly ignoring linting for `*.js` files. 

This PR also ignores `*.js` files in `.lintstagedrc` config files. 

Also adds  rule  '@next/next/no-html-link-for-pages': 'off', to lib eslint to avoid another issue.
