### PR TITLE
fix user's transactions links

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolUserEvents/PoolUserEvents.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolUserEvents/PoolUserEvents.tsx
@@ -271,7 +271,7 @@ export default function PoolUserEvents({
                   chain={chain}
                   key={poolEvent.id}
                   poolEvent={poolEvent}
-                  txUrl={getBlockExplorerTxUrl(poolEvent.tx)}
+                  txUrl={getBlockExplorerTxUrl(poolEvent.tx, poolEvent.chain)}
                   usdValue={toCurrency(poolEvent.valueUSD)}
                 />
               ))


### PR DESCRIPTION
From Discord:

> When I try to open the transaction link, it always opens on Etherscan irrespective of the chain of the pool.

![image](https://github.com/user-attachments/assets/8e871a10-7bf3-46e4-af03-ec579cece02b)
