### PR TITLE
fix: remove unused props

### DIFF
--- a/packages/lib/modules/tokens/__mocks__/AppGlobalData.builders.ts
+++ b/packages/lib/modules/tokens/__mocks__/AppGlobalData.builders.ts
@@ -15,10 +15,8 @@ export function anAppGlobalData(options?: Partial<GetAppGlobalPollingDataQuery>)
       __typename: 'GqlProtocolMetricsChain',
       swapFee24h: 'test fee',
       swapVolume24h: 'test volume 24h',
-      totalSwapVolume: 'test volume',
       poolCount: '24',
       totalLiquidity: 'test liquidity',
-      totalSwapFee: 'test fee',
     },
   }
   return Object.assign({}, defaultAppGlobalData, options)

--- a/packages/lib/shared/services/api/global.graphql
+++ b/packages/lib/shared/services/api/global.graphql
@@ -5,8 +5,6 @@ query GetAppGlobalPollingData {
   }
   protocolMetricsChain {
     totalLiquidity
-    totalSwapVolume
-    totalSwapFee
     poolCount
     swapFee24h
     swapVolume24h

--- a/packages/lib/shared/services/api/protocol-stats.graphql
+++ b/packages/lib/shared/services/api/protocol-stats.graphql
@@ -16,8 +16,6 @@ query GetProtocolStatsPerChain($chain: GqlChain) {
     swapFee24h
     swapVolume24h
     totalLiquidity
-    totalSwapFee
-    totalSwapVolume
     yieldCapture24h
   }
 }


### PR DESCRIPTION
the api is deprecating 2 fields that aren't actively used in the frontend

- totalSwapVolume
- totalSwapFee