### PR TITLE
fix: block certain api requests for beets

### DIFF
--- a/apps/beets-frontend-v3/app/middleware.ts
+++ b/apps/beets-frontend-v3/app/middleware.ts
@@ -5,6 +5,9 @@ export function middleware(request: NextRequest) {
   const blockedPaths = ['/api/rpc/FANTOM/routes', '/api/rpc/OPTIMISM/routes']
 
   if (blockedPaths.some(path => request.nextUrl.pathname.startsWith(path))) {
+    // Add some logging
+    console.log('Accessed Path:', request.url)
+    console.log('User Agent:', request.headers.get('user-agent'))
     return new NextResponse('This path is blocked.', { status: 403 })
   }
 

--- a/apps/beets-frontend-v3/app/middleware.ts
+++ b/apps/beets-frontend-v3/app/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const blockedPaths = ['/api/rpc/FANTOM/routes', '/api/rpc/OPTIMISM/routes']
+
+  if (blockedPaths.some(path => request.nextUrl.pathname.startsWith(path))) {
+    return new NextResponse('This path is blocked.', { status: 403 })
+  }
+
+  return NextResponse.next()
+}
+
+// Apply the middleware to all routes
+export const config = {
+  matcher: ['*'],
+}

--- a/apps/beets-frontend-v3/app/middleware.ts
+++ b/apps/beets-frontend-v3/app/middleware.ts
@@ -2,12 +2,15 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname.startsWith('/api/rpc')) {
+    // Add logging for /api/rpc paths
+    console.log('Accessed Path:', request.url)
+    console.log('User Agent:', request.headers.get('user-agent'))
+  }
+
   const blockedPaths = ['/api/rpc/FANTOM/routes', '/api/rpc/OPTIMISM/routes']
 
   if (blockedPaths.some(path => request.nextUrl.pathname.startsWith(path))) {
-    // Add some logging
-    console.log('Accessed Path:', request.url)
-    console.log('User Agent:', request.headers.get('user-agent'))
     return new NextResponse('This path is blocked.', { status: 403 })
   }
 

--- a/apps/beets-frontend-v3/middleware.ts
+++ b/apps/beets-frontend-v3/middleware.ts
@@ -4,8 +4,7 @@ import type { NextRequest } from 'next/server'
 export function middleware(request: NextRequest) {
   if (request.nextUrl.pathname.startsWith('/api/rpc')) {
     // Add logging for /api/rpc paths
-    console.log('Accessed Path:', request.url)
-    console.log('User Agent:', request.headers.get('user-agent'))
+    console.log('Referrer:', request.headers.get('referer'))
   }
 
   const blockedPaths = ['/api/rpc/FANTOM/routes', '/api/rpc/OPTIMISM/routes']
@@ -17,7 +16,7 @@ export function middleware(request: NextRequest) {
   return NextResponse.next()
 }
 
-// Apply the middleware to all routes
+// Apply the middleware to /api/rpc/* routes
 export const config = {
-  matcher: ['*'],
+  matcher: ['/api/rpc/:path*'],
 }

--- a/apps/beets-frontend-v3/middleware.ts
+++ b/apps/beets-frontend-v3/middleware.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from 'next/server'
 export function middleware(request: NextRequest) {
   if (request.nextUrl.pathname.startsWith('/api/rpc')) {
     // Add logging for /api/rpc paths
-    console.log('Referrer:', request.headers.get('referer'))
+    console.log('Referer:', request.headers.get('referer'))
   }
 
   const blockedPaths = ['/api/rpc/FANTOM/routes', '/api/rpc/OPTIMISM/routes']

--- a/apps/beets-frontend-v3/next.config.js
+++ b/apps/beets-frontend-v3/next.config.js
@@ -32,17 +32,6 @@ const nextConfig = {
         destination: 'https://discord.gg/kbPnYJjvwZ',
         permanent: false,
       },
-      // some cached apps are still trying to access these routes
-      {
-        source: '/api/rpc/FANTOM/routes',
-        destination: 'https://ftm.beets.fi/api/rpc/FANTOM/routes',
-        permanent: true,
-      },
-      {
-        source: '/api/rpc/OPTIMISM/routes',
-        destination: 'https://beets.fi/api/rpc/OPTIMISM',
-        permanent: true,
-      },
     ]
   },
 }


### PR DESCRIPTION
1. block 'old' api requests:

- `/api/rpc/FANTOM/routes`
- `/api/rpc/OPTIMISM/routes`

2. add `referer` msg to rest of the api requests