### PR TITLE
fix: avoid modal trapFocus when is success to enable appzi textarea

### DIFF
--- a/apps/beets-frontend-v3/lib/modules/lst/modals/LstStakeModal.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/modals/LstStakeModal.tsx
@@ -55,6 +55,8 @@ export function LstStakeModal({
 
   useOnUserAccountChanged(onClose)
 
+  const isSuccess = !!lstStakeTxHash && !lstStakeReceipt.isLoading
+
   return (
     <Modal
       finalFocusRef={finalFocusRef}
@@ -63,6 +65,7 @@ export function LstStakeModal({
       isOpen={isOpen}
       onClose={onClose}
       preserveScrollBarGap
+      trapFocus={!isSuccess}
       {...rest}
     >
       <SuccessOverlay startAnimation={!!lstStakeTxHash} />
@@ -75,7 +78,7 @@ export function LstStakeModal({
         </ModalBody>
         <ActionModalFooter
           currentStep={stakeTransactionSteps.currentStep}
-          isSuccess={!!lstStakeTxHash && !lstStakeReceipt.isLoading}
+          isSuccess={isSuccess}
           returnAction={onClose}
           returnLabel="Stake again"
         />

--- a/apps/beets-frontend-v3/lib/modules/lst/modals/LstUnstakeModal.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/modals/LstUnstakeModal.tsx
@@ -45,6 +45,8 @@ export function LstUnstakeModal({
 
   useOnUserAccountChanged(onClose)
 
+  const isSuccess = !!lstUnstakeTxHash
+
   return (
     <Modal
       finalFocusRef={finalFocusRef}
@@ -53,6 +55,7 @@ export function LstUnstakeModal({
       isOpen={isOpen}
       onClose={onClose}
       preserveScrollBarGap
+      trapFocus={!isSuccess}
       {...rest}
     >
       <SuccessOverlay startAnimation={!!lstUnstakeTxHash} />
@@ -67,7 +70,7 @@ export function LstUnstakeModal({
         </ModalBody>
         <ActionModalFooter
           currentStep={unstakeTransactionSteps.currentStep}
-          isSuccess={!!lstUnstakeTxHash}
+          isSuccess={isSuccess}
           returnAction={onClose}
           returnLabel="Unstake again"
         />

--- a/apps/beets-frontend-v3/lib/modules/lst/modals/LstWithdrawModal.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/modals/LstWithdrawModal.tsx
@@ -46,8 +46,17 @@ export function LstWithdrawModal({
     onClose()
   }
 
+  const isSuccess = !!lstWithdrawTxHash
+
   return (
-    <Modal isCentered isOpen={isOpen} onClose={handleOnClose} preserveScrollBarGap {...rest}>
+    <Modal
+      isCentered
+      isOpen={isOpen}
+      onClose={handleOnClose}
+      preserveScrollBarGap
+      trapFocus={!isSuccess}
+      {...rest}
+    >
       <SuccessOverlay startAnimation={!!lstWithdrawTxHash} />
       <ModalContent {...getStylesForModalContentWithStepTracker(isDesktop)}>
         {isDesktop && (
@@ -60,7 +69,7 @@ export function LstWithdrawModal({
         </ModalBody>
         <ActionModalFooter
           currentStep={withdrawTransactionSteps.currentStep}
-          isSuccess={!!lstWithdrawTxHash}
+          isSuccess={isSuccess}
           returnAction={handleOnClose}
           returnLabel="Return to withdraw"
         />

--- a/packages/lib/modules/pool/actions/claim/ClaimModal.tsx
+++ b/packages/lib/modules/pool/actions/claim/ClaimModal.tsx
@@ -70,6 +70,8 @@ export function ClaimModal({
 
   const noQuoteRewards = quoteRewards.length === 0
 
+  const isSuccess = !!claimTxHash
+
   return (
     <Modal
       isCentered
@@ -78,6 +80,7 @@ export function ClaimModal({
         onClose(!!claimTxHash)
       }}
       preserveScrollBarGap
+      trapFocus={!isSuccess}
       {...rest}
     >
       <SuccessOverlay startAnimation={!!claimTxHash} />
@@ -108,9 +111,9 @@ export function ClaimModal({
 
         <ActionModalFooter
           currentStep={transactionSteps.currentStep}
-          isSuccess={!!claimTxHash}
+          isSuccess={isSuccess}
           returnAction={() => {
-            onClose(!!claimTxHash)
+            onClose(isSuccess)
             router.push('/portfolio')
           }}
           returnLabel="Return to portfolio"

--- a/packages/lib/modules/pool/actions/migrateStake/MigrateStakeModal.tsx
+++ b/packages/lib/modules/pool/actions/migrateStake/MigrateStakeModal.tsx
@@ -39,6 +39,8 @@ export function MigrateStakeModal({
 
   useResetStepIndexOnOpen(isOpen, transactionSteps)
 
+  const isSuccess = !!restakeTxHash
+
   return (
     <Modal
       finalFocusRef={finalFocusRef}
@@ -47,6 +49,7 @@ export function MigrateStakeModal({
       isOpen={isOpen}
       onClose={onClose}
       preserveScrollBarGap
+      trapFocus={!isSuccess}
       {...rest}
     >
       <SuccessOverlay startAnimation={!!restakeTxHash} />
@@ -69,7 +72,7 @@ export function MigrateStakeModal({
         </ModalBody>
         <ActionModalFooter
           currentStep={transactionSteps.currentStep}
-          isSuccess={!!restakeTxHash}
+          isSuccess={isSuccess}
           returnAction={redirectToPoolPage}
           returnLabel="Return to pool"
         />

--- a/packages/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquidityModal.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquidityModal.tsx
@@ -68,6 +68,8 @@ export function RemoveLiquidityModal({
 
   useOnUserAccountChanged(redirectToPoolPage)
 
+  const isSuccess = !!removeLiquidityTxHash && !receiptProps.isLoading
+
   return (
     <Modal
       finalFocusRef={finalFocusRef}
@@ -76,6 +78,7 @@ export function RemoveLiquidityModal({
       isOpen={isOpen}
       onClose={onClose}
       preserveScrollBarGap
+      trapFocus={!isSuccess}
       {...rest}
     >
       <SuccessOverlay startAnimation={!!removeLiquidityTxHash && hasQuoteContext} />
@@ -99,7 +102,7 @@ export function RemoveLiquidityModal({
         </ModalBody>
         <ActionModalFooter
           currentStep={transactionSteps.currentStep}
-          isSuccess={!!removeLiquidityTxHash && !receiptProps.isLoading}
+          isSuccess={isSuccess}
           returnAction={redirectToPoolPage}
           returnLabel="Return to pool"
           urlTxHash={urlTxHash}

--- a/packages/lib/modules/pool/actions/stake/StakeModal.tsx
+++ b/packages/lib/modules/pool/actions/stake/StakeModal.tsx
@@ -39,6 +39,8 @@ export function StakeModal({
 
   useResetStepIndexOnOpen(isOpen, transactionSteps)
 
+  const isSuccess = !!stakeTxHash
+
   return (
     <Modal
       finalFocusRef={finalFocusRef}
@@ -47,6 +49,7 @@ export function StakeModal({
       isOpen={isOpen}
       onClose={onClose}
       preserveScrollBarGap
+      trapFocus={!isSuccess}
       {...rest}
     >
       <SuccessOverlay startAnimation={!!stakeTxHash} />
@@ -65,7 +68,7 @@ export function StakeModal({
         </ModalBody>
         <ActionModalFooter
           currentStep={transactionSteps.currentStep}
-          isSuccess={!!stakeTxHash}
+          isSuccess={isSuccess}
           returnAction={redirectToPoolPage}
           returnLabel="Return to pool"
         />

--- a/packages/lib/modules/pool/actions/unstake/UnstakeModal.tsx
+++ b/packages/lib/modules/pool/actions/unstake/UnstakeModal.tsx
@@ -39,6 +39,8 @@ export function UnstakeModal({
 
   useResetStepIndexOnOpen(isOpen, transactionSteps)
 
+  const isSuccess = !!unstakeTxHash
+
   return (
     <Modal
       finalFocusRef={finalFocusRef}
@@ -47,6 +49,7 @@ export function UnstakeModal({
       isOpen={isOpen}
       onClose={onClose}
       preserveScrollBarGap
+      trapFocus={!isSuccess}
       {...rest}
     >
       <SuccessOverlay startAnimation={!!unstakeTxHash} />
@@ -69,7 +72,7 @@ export function UnstakeModal({
         </ModalBody>
         <ActionModalFooter
           currentStep={transactionSteps.currentStep}
-          isSuccess={!!unstakeTxHash}
+          isSuccess={isSuccess}
           returnAction={redirectToPoolPage}
           returnLabel="Return to pool"
         />

--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimProtocolRevenueModal.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimProtocolRevenueModal.tsx
@@ -58,8 +58,10 @@ export default function ClaimProtocolRevenueModal({ isOpen, onClose }: Props) {
       humanAmount: reward.humanBalance,
     }))
 
+  const isSuccess = !!claimTxHash
+
   return (
-    <Modal isCentered isOpen={isOpen} onClose={onClose} preserveScrollBarGap>
+    <Modal isCentered isOpen={isOpen} onClose={onClose} preserveScrollBarGap trapFocus={!isSuccess}>
       <SuccessOverlay startAnimation={!!claimTxHash} />
 
       <ModalContent {...getStylesForModalContentWithStepTracker(isDesktop)}>
@@ -90,7 +92,7 @@ export default function ClaimProtocolRevenueModal({ isOpen, onClose }: Props) {
         </ModalBody>
         <ActionModalFooter
           currentStep={transactionSteps.currentStep}
-          isSuccess={!!claimTxHash}
+          isSuccess={isSuccess}
           returnAction={onClose}
           returnLabel="Return to portfolio"
         />

--- a/packages/lib/modules/swap/modal/SwapModal.tsx
+++ b/packages/lib/modules/swap/modal/SwapModal.tsx
@@ -79,6 +79,8 @@ export function SwapPreviewModal({
 
   useOnUserAccountChanged(onClose)
 
+  const isSuccess = !!swapTxHash && !swapReceipt.isLoading
+
   return (
     <Modal
       finalFocusRef={finalFocusRef}
@@ -87,6 +89,7 @@ export function SwapPreviewModal({
       isOpen={isOpen}
       onClose={onClose}
       preserveScrollBarGap
+      trapFocus={!isSuccess}
       {...rest}
     >
       <SuccessOverlay startAnimation={!!swapTxHash && hasQuoteContext} />
@@ -108,7 +111,7 @@ export function SwapPreviewModal({
         </ModalBody>
         <ActionModalFooter
           currentStep={transactionSteps.currentStep}
-          isSuccess={!!swapTxHash && !swapReceipt.isLoading}
+          isSuccess={isSuccess}
           returnAction={onClose}
           returnLabel={isPoolSwapUrl ? 'Return to pool' : 'Swap again'}
           urlTxHash={urlTxHash}

--- a/packages/lib/modules/vebal/cross-chain/CrossChainSyncModal.tsx
+++ b/packages/lib/modules/vebal/cross-chain/CrossChainSyncModal.tsx
@@ -123,8 +123,16 @@ export function CrossChainSyncModal({ isOpen, onClose, networks }: Props) {
     }
   }
 
+  const isSuccess = !!transactionHash
+
   return (
-    <Modal isCentered isOpen={isOpen} onClose={onModalClose} preserveScrollBarGap>
+    <Modal
+      isCentered
+      isOpen={isOpen}
+      onClose={onModalClose}
+      preserveScrollBarGap
+      trapFocus={!isSuccess}
+    >
       <SuccessOverlay startAnimation={!!transactionHash} />
 
       <ModalContent {...getStylesForModalContentWithStepTracker(isDesktop)}>
@@ -162,7 +170,7 @@ export function CrossChainSyncModal({ isOpen, onClose, networks }: Props) {
         {showTransactionSteps ? (
           <ActionModalFooter
             currentStep={transactionSteps.currentStep}
-            isSuccess={!!transactionHash}
+            isSuccess={isSuccess}
             returnAction={onClose}
             returnLabel="Return to vebal"
           />

--- a/packages/lib/modules/vebal/lock/modal/VebalLockModal.tsx
+++ b/packages/lib/modules/vebal/lock/modal/VebalLockModal.tsx
@@ -95,6 +95,8 @@ export function VebalLockModal({
 
   const isUnlocking = lockMode === LockMode.Unlock && !extendExpired
 
+  const isSuccess = !!lockTxHash
+
   return (
     <Modal
       isCentered
@@ -103,6 +105,7 @@ export function VebalLockModal({
         onClose(!!lockTxHash)
       }}
       preserveScrollBarGap
+      trapFocus={!isSuccess}
       {...rest}
     >
       <SuccessOverlay startAnimation={!!lockTxHash} />
@@ -193,9 +196,9 @@ export function VebalLockModal({
 
         <ActionModalFooter
           currentStep={transactionSteps.currentStep}
-          isSuccess={!!lockTxHash}
+          isSuccess={isSuccess}
           returnAction={() => {
-            onClose(!!lockTxHash)
+            onClose(isSuccess)
             router.push('/vebal/manage')
           }}
           returnLabel="Return to veBAL manage"


### PR DESCRIPTION
Focus trapping in chakra modals was affecting appzi modal behaviour (textarea could not be focused):

https://v2.chakra-ui.com/docs/components/modal#prevent-focus-trapping

We only set `trapFocus={false}` where the modal is in `isSuccess` state to reduce accessibility impacts.