### PR TITLE
chore: ignore metamask pending connection error

### DIFF
--- a/packages/lib/shared/utils/query-errors.ts
+++ b/packages/lib/shared/utils/query-errors.ts
@@ -365,6 +365,19 @@ export function shouldIgnore(message: string, stackTrace = ''): boolean {
     return true
   }
 
+  /*
+    Error thrown from Metamask when:
+    1. The extension popup is ignored by the user
+    2. They close the RainbowKit "Connect a wallet" modal
+    3. They click "Connect wallet" and chose "Metamask" a second time
+
+    As the extension modal was still opened in the background, MM will throw this error, that can be safely ignored as the Rainbowkit modal clearly states:
+    "Confirm connection in the extension"
+   */
+  if (message.includes(`Request of type 'wallet_requestPermissions' already pending for origin`)) {
+    return true
+  }
+
   return false
 }
 


### PR DESCRIPTION
Ignores this frequent issue in sentry: 

https://balancer-labs.sentry.io/issues/5990859796/?project=4506382607712256&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20level%3Afatal&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=0