### PR TITLE
chore: Use pool icon if provided

### DIFF
--- a/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListTokenPills.tsx
@@ -204,10 +204,11 @@ type PoolListTokenPillsProps = {
   nameSize?: string
 } & BadgeProps
 export function PoolListTokenPills({ pool, ...props }: PoolListTokenPillsProps) {
-  const { name } = usePoolMetadata(pool)
+  const { name, iconUrl } = usePoolMetadata(pool)
   return (
     <PoolTokenPills
       chain={pool.chain}
+      iconUrl={iconUrl}
       poolName={name}
       poolType={pool.type}
       tokens={getUserReferenceTokens(pool)}
@@ -221,6 +222,7 @@ type PoolTokenPillsProps = {
   chain: GqlChain
   tokens: PoolToken[]
   poolName: string | undefined
+  iconUrl?: string
   iconSize?: number
   nameSize?: string
 } & BadgeProps
@@ -230,6 +232,7 @@ function PoolTokenPills({
   poolName,
   tokens,
   iconSize = 24,
+  iconUrl,
   nameSize = 'md',
   ...badgeProps
 }: PoolTokenPillsProps) {
@@ -239,7 +242,11 @@ function PoolTokenPills({
   if (poolName) {
     return (
       <HStack>
-        <TokenIconStack chain={chain} size={iconSize} tokens={tokens} />
+        {iconUrl ? (
+          <TokenIcon alt={poolName} logoURI={iconUrl} size={iconSize} />
+        ) : (
+          <TokenIconStack chain={chain} size={iconSize} tokens={tokens} />
+        )}
         <Heading size={nameSize}>{poolName}</Heading>
       </HStack>
     )


### PR DESCRIPTION
Uses pool icon from metadata if provided with a pool name.

Example pool: https://mono-frontend-v3-git-chore-use-pool-icon-balancer.vercel.app/pools/ethereum/v3/0x10a04efba5b880e169920fd4348527c64fb29d4d