### PR TITLE
fix: validate inputs after userAddress changes

### DIFF
--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -281,13 +281,19 @@ export function _useSwap({ poolActionableTokens, pool, pathParams }: SwapProvide
     amount: string,
     { userTriggered = true }: { userTriggered?: boolean } = {}
   ) {
+    console.log('Voy a settear tronco: ', { tokenInInfo })
+
     const state = swapStateVar()
     const newState = {
       ...state,
       tokenIn: {
         ...state.tokenIn,
-        amount,
-        scaledAmount: scaleTokenAmount(amount, tokenInInfo),
+        /*
+          When copy-pasting a swap URL with a token amount, the tokenInInfo can be undefined
+          so we set amount as zero instead of crashing the app
+        */
+        amount: tokenInInfo ? amount : '0',
+        scaledAmount: tokenInInfo ? scaleTokenAmount(amount, tokenInInfo) : 0n,
       },
     }
 
@@ -313,8 +319,12 @@ export function _useSwap({ poolActionableTokens, pool, pathParams }: SwapProvide
       ...state,
       tokenOut: {
         ...state.tokenOut,
-        amount,
-        scaledAmount: scaleTokenAmount(amount, tokenOutInfo),
+        /*
+          When copy-pasting a swap URL with a token amount, the tokenOutInfo can be undefined
+          so we set amount as zero instead of crashing the app
+        */
+        amount: tokenOutInfo ? amount : '0',
+        scaledAmount: tokenOutInfo ? scaleTokenAmount(amount, tokenOutInfo) : 0n,
       },
     }
 
@@ -398,9 +408,8 @@ export function _useSwap({ poolActionableTokens, pool, pathParams }: SwapProvide
     window.history.replaceState({}, '', newPath.join(''))
   }
 
-  function scaleTokenAmount(amount: string, token: ApiToken | undefined): bigint {
+  function scaleTokenAmount(amount: string, token: ApiToken): bigint {
     if (amount === '') return parseUnits('0', 18)
-    if (!token) throw new Error('Cant scale amount without token metadata')
     return parseUnits(amount, token.decimals)
   }
 

--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -281,8 +281,6 @@ export function _useSwap({ poolActionableTokens, pool, pathParams }: SwapProvide
     amount: string,
     { userTriggered = true }: { userTriggered?: boolean } = {}
   ) {
-    console.log('Voy a settear tronco: ', { tokenInInfo })
-
     const state = swapStateVar()
     const newState = {
       ...state,

--- a/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
+++ b/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
@@ -32,6 +32,7 @@ import { useIsMounted } from '@repo/lib/shared/hooks/useIsMounted'
 import { isNativeAsset } from '@repo/lib/shared/utils/addresses'
 import { getPriceImpactLabel } from '../../price-impact/price-impact.utils'
 import { ApiToken } from '../token.types'
+import { useUserAccount } from '../../web3/UserAccountProvider'
 
 type TokenInputSelectorProps = {
   token: ApiToken | undefined
@@ -205,6 +206,7 @@ export const TokenInput = forwardRef(
     }: InputProps & Props,
     ref
   ) => {
+    const { userAddress } = useUserAccount()
     const { isBalancesLoading } = useTokenBalances()
 
     const [inputTitle, setInputTitle] = useState<string>('')
@@ -234,7 +236,7 @@ export const TokenInput = forwardRef(
         validateInput(value || '')
         setInputTitle(value || '')
       }
-    }, [value, token?.address, isBalancesLoading])
+    }, [value, token?.address, isBalancesLoading, userAddress])
 
     return (
       <Box


### PR DESCRIPTION
Fixes 2 swap issues:

1. validate inputs after userAddress changes
2. avoid app crashing when a url with tokenAmountIn is copy-pasted


Example loading this URL: swap/zkevm/rETH/wstETH/0.0136547066055

Before: 
<img width="1171" alt="before" src="https://github.com/user-attachments/assets/1afeb21e-407a-4426-92dd-5bc930ac675b" />

After:
<img width="587" alt="after" src="https://github.com/user-attachments/assets/94bcdae2-e6fb-4896-92ba-fcdcfe91b0e3" />

