### PR TITLE
fix: Account disconnect on theme change

### DIFF
--- a/apps/frontend-v3/lib/services/chakra/ThemeProvider.tsx
+++ b/apps/frontend-v3/lib/services/chakra/ThemeProvider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ChakraProvider, ThemeTypings } from '@chakra-ui/react'
-import { ReactNode } from 'react'
+import { ReactNode, useMemo } from 'react'
 import { theme as balTheme } from './themes/bal/bal.theme'
 import { theme as cowTheme } from './themes/cow/cow.theme'
 import { useCow } from '@repo/lib/modules/cow/useCow'
@@ -17,14 +17,16 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     return balTheme
   }
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const theme = useMemo(() => getTheme(), [isCowPath, isCowVariant])
+
   // Avoid hydration error in turbopack mode
   if (!isMounted) return null
 
   return (
     <ChakraProvider
       cssVarsRoot="body"
-      key={isCowPath ? 'cow' : 'bal'}
-      theme={getTheme()}
+      theme={theme}
       toastOptions={{ defaultOptions: { position: 'bottom-left' } }}
     >
       {children}


### PR DESCRIPTION
It appears that using a key on the ChakraProvider that changes, when the theme changes causes some kind of full rerender that, causes the wallet to disconnect. I guess that somehow that rerender messes with the wagmi providers that are nested below.

To test:
1. connect a wallet on the portfolio page that has a CoW pool position. 
2. Click the table row to navigate to the CoW pool.
3. The wallet should not disconnect.

Currently on production if you follow the same flow the wallet disconnects.