### PR TITLE
fix: Only show one CTA for BAL8020

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
@@ -97,24 +97,24 @@ export function AddLiquiditySummary({
 
       {shouldShowReceipt ? (
         <CardPopAnim key="staking-options">
-          {pool.staking ? (
-            <Card variant="modalSubSection" w="full">
-              <StakingOptions />
+          {isVebalPool(pool.id) ? (
+            <Card variant="modalSubSection">
+              <VStack align="start" spacing="md" w="full">
+                <Text>Get extra incentives with veBAL</Text>
+                <Button onClick={vebalRedirectModal.onOpen} size="lg" variant="primary" w="full">
+                  Lock to get veBAL
+                </Button>
+              </VStack>
+
+              <VebalRedirectModal
+                isOpen={vebalRedirectModal.isOpen}
+                onClose={vebalRedirectModal.onClose}
+              />
             </Card>
           ) : (
-            isVebalPool(pool.id) && (
-              <Card variant="modalSubSection">
-                <VStack align="start" spacing="md" w="full">
-                  <Text>Get extra incentives with veBAL</Text>
-                  <Button onClick={vebalRedirectModal.onOpen} size="lg" variant="primary" w="full">
-                    Lock to get veBAL
-                  </Button>
-                </VStack>
-
-                <VebalRedirectModal
-                  isOpen={vebalRedirectModal.isOpen}
-                  onClose={vebalRedirectModal.onClose}
-                />
+            pool.staking && (
+              <Card variant="modalSubSection" w="full">
+                <StakingOptions />
               </Card>
             )
           )}

--- a/packages/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
@@ -97,25 +97,26 @@ export function AddLiquiditySummary({
 
       {shouldShowReceipt ? (
         <CardPopAnim key="staking-options">
-          {pool.staking && (
+          {pool.staking ? (
             <Card variant="modalSubSection" w="full">
               <StakingOptions />
             </Card>
-          )}
-          {isVebalPool(pool.id) && (
-            <Card variant="modalSubSection">
-              <VStack align="start" spacing="md" w="full">
-                <Text>Get extra incentives with veBAL</Text>
-                <Button onClick={vebalRedirectModal.onOpen} size="lg" variant="primary" w="full">
-                  Lock to get veBAL
-                </Button>
-              </VStack>
+          ) : (
+            isVebalPool(pool.id) && (
+              <Card variant="modalSubSection">
+                <VStack align="start" spacing="md" w="full">
+                  <Text>Get extra incentives with veBAL</Text>
+                  <Button onClick={vebalRedirectModal.onOpen} size="lg" variant="primary" w="full">
+                    Lock to get veBAL
+                  </Button>
+                </VStack>
 
-              <VebalRedirectModal
-                isOpen={vebalRedirectModal.isOpen}
-                onClose={vebalRedirectModal.onClose}
-              />
-            </Card>
+                <VebalRedirectModal
+                  isOpen={vebalRedirectModal.isOpen}
+                  onClose={vebalRedirectModal.onClose}
+                />
+              </Card>
+            )
           )}
         </CardPopAnim>
       ) : hasQuoteContext ? (


### PR DESCRIPTION
In add liquidity success state on the BAL 8020 pool we are showing two CTAs.
<img width="494" alt="Screenshot 2025-01-17 at 16 18 37" src="https://github.com/user-attachments/assets/8dd7b904-c798-4821-badf-7d0797f0c86d" />

We should only show the one that references locking for the bal pool.