### PR TITLE
fix: set beets color mode to dark

### DIFF
--- a/apps/beets-frontend-v3/lib/services/chakra/themes/beets/beets.theme.ts
+++ b/apps/beets-frontend-v3/lib/services/chakra/themes/beets/beets.theme.ts
@@ -17,7 +17,10 @@ semanticTokens.colors.grayText._dark = '#BBBBBB'
 components.Button.variants.buttonGroupActive._dark.color = '#363636'
 
 export const beetsTheme = {
-  config,
+  config: {
+    ...config,
+    initialColorMode: 'dark',
+  },
   fonts,
   styles: {
     global: {


### PR DESCRIPTION
#458 is setting light mode by default for beets
but beets doesn't have a light mode...
so setting dark mode as default here

**_please let me merge it so i can set "Auto-assign Custom Production Domains" back to enabled first (beets deployment is currently rolled back)_**

![image](https://github.com/user-attachments/assets/d730a8c4-34a2-4c82-8770-e9a2f0c55f71)
