### PR TITLE
feat: detect Apollo 'Failed to fetch' error in swaps

### DIFF
--- a/packages/lib/modules/swap/SwapSimulationError.tsx
+++ b/packages/lib/modules/swap/SwapSimulationError.tsx
@@ -5,6 +5,8 @@ import { ErrorAlert } from '@repo/lib/shared/components/errors/ErrorAlert'
 import { buildCowSwapUrl } from '../cow/cow.utils'
 import { parseSwapError } from './swap.helpers'
 import { useSwap } from './SwapProvider'
+import { getDiscordLink } from '@repo/lib/shared/utils/links'
+import { swapApolloNetworkErrorMessage } from '@repo/lib/shared/utils/errors'
 
 type Props = {
   errorMessage?: string
@@ -26,6 +28,18 @@ export function SwapSimulationError({ errorMessage }: Props) {
         >
           CoW Swap.
         </BalAlertLink>
+      </ErrorAlert>
+    )
+  }
+
+  if (errorMessage === swapApolloNetworkErrorMessage) {
+    const discordUrl = getDiscordLink()
+
+    return (
+      <ErrorAlert title="Network error">
+        It looks like there was a network error while fetching the swap. Please check your internet
+        connection and try again. You can report the problem in{' '}
+        <BalAlertLink href={discordUrl}>our discord</BalAlertLink> if the issue persists.
       </ErrorAlert>
     )
   }

--- a/packages/lib/shared/utils/errors.ts
+++ b/packages/lib/shared/utils/errors.ts
@@ -161,3 +161,17 @@ export function parseError(error: unknown) {
 
   return undefined
 }
+
+// Useful to distinguish this type of error in sentry and error alerts
+export const swapApolloNetworkErrorMessage = 'Apollo network error in DefaultSwapHandler'
+
+/*
+  This kind of error is thrown from apollo client when the request fails without a clear error code.
+  Causes could be:
+  - Connectivity issues
+  - Browser or extensions blocking the request
+  - CORS issues
+*/
+export function isFailedToFetchApolloError(error: Error): boolean {
+  return error.message === 'Failed to fetch'
+}


### PR DESCRIPTION
`Failed to fetch` Apollo error happens in cases where Apollo cannot add extra info like error codes or alike.

We have to assume that these are connectivity or browser issues in the user’s side so we can only detect them and show this specific error alert:

<img width="1396" alt="blockedError" src="https://github.com/user-attachments/assets/d2cb6e65-ab05-4005-b585-b2c7007c27fe" />

Also this specific error from the Swap page will be sent to Sentry as `Apollo network error in DefaultSwapHandler` so that's easier to track.
