### PR TITLE
fix: hasAnyAllowedBuffer check

### DIFF
--- a/packages/lib/modules/pool/pool.helpers.spec.ts
+++ b/packages/lib/modules/pool/pool.helpers.spec.ts
@@ -10,6 +10,8 @@ import {
   getStandardRootTokens,
   isStandardOrUnderlyingRootToken,
 } from './pool-tokens.utils'
+import { sDAIWeighted } from './__mocks__/pool-examples/flat'
+import { getPoolAddBlockedReason, shouldBlockAddLiquidity } from './pool.helpers'
 
 describe('getPoolActionableTokens', () => {
   it('when nested pool supports nested actions (default behavior)', () => {
@@ -89,5 +91,20 @@ describe('pool helper', async () => {
 
   it('getActionableTokenSymbol ', async () => {
     expect(getActionableTokenSymbol(wethAddress, pool)).toEqual('WETH')
+  })
+})
+
+describe('shouldBlockAddLiquidity', () => {
+  it('v2 pool with ERC4626 token', () => {
+    const pool = getApiPoolMock(sDAIWeighted)
+
+    // Should block liquidity if one of the tokens is not allowed
+    pool.poolTokens[0].isAllowed = false
+    expect(shouldBlockAddLiquidity(pool)).toBe(true)
+    expect(getPoolAddBlockedReason(pool)).toBe('Token: wstETH is not allowed')
+
+    // Should not block liquidity if all tokens are allowed
+    pool.poolTokens[0].isAllowed = true
+    expect(shouldBlockAddLiquidity(pool)).toBe(false)
   })
 })

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -310,9 +310,6 @@ export function shouldBlockAddLiquidity(pool: Pool) {
     return true
   }
 
-  // when hasAnyAllowedBuffer is false any erc4626 tokens in the pool don't have to be checked for reviews
-  if (!pool.hasAnyAllowedBuffer) return false
-
   const poolTokens = pool.poolTokens as GqlPoolTokenDetail[]
 
   return poolTokens.some(token => {
@@ -332,6 +329,8 @@ export function shouldBlockAddLiquidity(pool: Pool) {
       return true
     }
 
+    // when hasAnyAllowedBuffer is false any erc4626 tokens in the pool don't have to be checked for reviews
+    if (!pool.hasAnyAllowedBuffer) return false
     // only for v3 pools, if ERC4626 is not reviewed or summary is not safe - we should block adding liquidity
     if (
       isV3Pool(pool) &&

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -329,11 +329,12 @@ export function shouldBlockAddLiquidity(pool: Pool) {
       return true
     }
 
-    // when hasAnyAllowedBuffer is false any erc4626 tokens in the pool don't have to be checked for reviews
-    if (!pool.hasAnyAllowedBuffer) return false
-    // only for v3 pools, if ERC4626 is not reviewed or summary is not safe - we should block adding liquidity
+    /* Only for actual v3 boosted pools (ERC4626 with allowed buffer):
+      if ERC4626 is not reviewed or summary is not safe - we should block adding liquidity
+    */
     if (
       isV3Pool(pool) &&
+      pool.hasAnyAllowedBuffer &&
       token.isErc4626 &&
       token.isBufferAllowed &&
       (!hasReviewedErc4626(token) || token.erc4626ReviewData?.summary !== 'safe')


### PR DESCRIPTION
`pool.hasAnyAllowedBuffer` check must be applied later to avoid shadowing other checks