### PR TITLE
chore: avoid sentry setup in CI

### DIFF
--- a/apps/beets-frontend-v3/next.config.js
+++ b/apps/beets-frontend-v3/next.config.js
@@ -36,7 +36,9 @@ const nextConfig = {
   },
 }
 
-module.exports = withSentryConfig(nextConfig, sentryOptions)
+// Avoid sentry setup in CI
+module.exports =
+  process.env.CI === 'true' ? nextConfig : withSentryConfig(nextConfig, sentryOptions)
 
 /**
  * Add specific CORS headers to the manifest.json file

--- a/apps/frontend-v3/next.config.js
+++ b/apps/frontend-v3/next.config.js
@@ -27,7 +27,9 @@ const nextConfig = {
   headers: manifestHeaders,
 }
 
-module.exports = withSentryConfig(nextConfig, sentryOptions)
+// Avoid sentry setup in CI
+module.exports =
+  process.env.CI === 'true' ? nextConfig : withSentryConfig(nextConfig, sentryOptions)
 
 /**
  * Add specific CORS headers to the manifest.json file

--- a/turbo.json
+++ b/turbo.json
@@ -18,9 +18,9 @@
     "NEXT_PRIVATE_ALCHEMY_KEY",
     "CI",
     "NEXT_PUBLIC_UPDATE_API_MOCKS",
-    "VERCEL_GIT_COMMIT_REF",
-    "SENTRY_AUTH_TOKEN"
+    "VERCEL_GIT_COMMIT_REF"
   ],
+  "globalPassThroughEnv": ["SENTRY_AUTH_TOKEN"],
   "tasks": {
     "dev": {
       "cache": false,


### PR DESCRIPTION
Skipping setry setup in CI builds should save some time. 