### PR TITLE
Avoid approvals when unwrapping WETH

### DIFF
--- a/packages/lib/modules/swap/useSwapSteps.tsx
+++ b/packages/lib/modules/swap/useSwapSteps.tsx
@@ -67,6 +67,7 @@ export function useSwapSteps({
       approvalAmounts: tokenInAmounts,
       actionType: approvalActionType,
       isPermit2,
+      wethIsEth,
       enabled: hasSimulationQuery,
     })
 


### PR DESCRIPTION
Unwrapping native asset does not require approvals anymore: 

<img width="726" alt="unwrap" src="https://github.com/user-attachments/assets/6d6239ca-ee1b-4daa-a99e-76c9f345b6df" />
