### PR TITLE
fix: Don't allow eth adds for erc4626 pools

### DIFF
--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -435,7 +435,7 @@ export function supportsWethIsEth(pool: Pool): boolean {
     Currently all SDK handlers support wethIsEth
     and Cow AMM pools is the only scenario that doesn't support wethIsEth
   */
-  return !isCowAmmPool(pool.type)
+  return !isCowAmmPool(pool.type) && !pool.hasErc4626 && !pool.hasNestedErc4626
 }
 
 export function requiresPermit2Approval(pool: Pool): boolean {


### PR DESCRIPTION
We currently allow the weth/eth choice in the add liquidity form for pools that contain erc4626 tokens. Apparently the router doesn't support this so we need to restrict that functionality to pools that do not contain erc4626 tokens.