### PR TITLE
feat: add cow supported networks

### DIFF
--- a/packages/lib/config/config.types.ts
+++ b/packages/lib/config/config.types.ts
@@ -154,4 +154,5 @@ export interface ProjectConfig {
   options: OptionsConfig
   links: Links
   footer: { linkSections: LinkSection[] }
+  cowSupportedNetworks: GqlChain[]
 }

--- a/packages/lib/config/projects/balancer.ts
+++ b/packages/lib/config/projects/balancer.ts
@@ -145,4 +145,5 @@ export const ProjectConfigBalancer: ProjectConfig = {
       },
     ],
   },
+  cowSupportedNetworks: [GqlChain.Mainnet, GqlChain.Arbitrum, GqlChain.Base, GqlChain.Gnosis],
 }

--- a/packages/lib/config/projects/beets.ts
+++ b/packages/lib/config/projects/beets.ts
@@ -95,4 +95,5 @@ export const ProjectConfigBeets: ProjectConfig = {
       },
     ],
   },
+  cowSupportedNetworks: [],
 }

--- a/packages/lib/modules/swap/SwapSimulationError.tsx
+++ b/packages/lib/modules/swap/SwapSimulationError.tsx
@@ -14,20 +14,29 @@ type Props = {
 export function SwapSimulationError({ errorMessage }: Props) {
   const { tokenIn, tokenOut, selectedChain } = useSwap()
 
+  const showCowSwapLink = PROJECT_CONFIG.cowSupportedNetworks.includes(selectedChain)
+
   if (errorMessage?.includes('must contain at least 1 path')) {
     return (
       <ErrorAlert title={`Not enough liquidity on ${PROJECT_CONFIG.projectName}`}>
-        Your swap amount is too high to find a route through the available liquidity on
-        {PROJECT_CONFIG.projectName}. Try reducing your swap size or try{' '}
-        <BalAlertLink
-          href={buildCowSwapUrl({
-            chain: selectedChain,
-            tokenInAddress: tokenIn.address,
-            tokenOutAddress: tokenOut.address,
-          })}
-        >
-          CoW Swap.
-        </BalAlertLink>
+        Your swap amount is too high to find a route through the available liquidity on{' '}
+        {PROJECT_CONFIG.projectName}. Try reducing your swap size
+        {showCowSwapLink && (
+          <>
+            {' '}
+            or try{' '}
+            <BalAlertLink
+              href={buildCowSwapUrl({
+                chain: selectedChain,
+                tokenInAddress: tokenIn.address,
+                tokenOutAddress: tokenOut.address,
+              })}
+            >
+              CoW Swap
+            </BalAlertLink>
+          </>
+        )}
+        .
       </ErrorAlert>
     )
   }


### PR DESCRIPTION
- add supported networks for cow swap to project config
- show cow swap link only for pools on a cow supported network

network (SONIC) _is not supported_ by cow:
![image](https://github.com/user-attachments/assets/e0de8efd-a522-4ddd-834f-0a4e88a515ab)

network (MAINNET) _is supported_ by cow:
![image](https://github.com/user-attachments/assets/6d829d1c-9d95-4a71-900d-ab02ea5855d1)


