### PR TITLE
Fixed the broken link for veBAL staking

### DIFF
--- a/packages/lib/config/projects/balancer.ts
+++ b/packages/lib/config/projects/balancer.ts
@@ -111,7 +111,11 @@ export const ProjectConfigBalancer: ProjectConfig = {
           { label: 'Explore pools', href: '/pools' },
           { label: 'Swap tokens', href: '/swap' },
           { label: 'View portfolio', href: '/portfolio' },
-          { label: 'Get veBAL', href: 'https://app.balancer.fi/#/vebal', isExternal: true },
+          {
+            label: 'Get veBAL',
+            href: 'https://app.balancer.fi/#/ethereum/vebal',
+            isExternal: true,
+          },
           {
             label: 'Create an LBP',
             href: 'https://www.fjordfoundry.com/?utm_source=balancer&utm_medium=website',


### PR DESCRIPTION
Earlier the veBAL staking link in the footer was redirected to the broken link. 

<img width="681" alt="image" src="https://github.com/user-attachments/assets/1b34d340-b2cd-4628-aa70-b29188b6b881" />

I've fixed that broken link in this PR