### PR TITLE
fix: v3 Safe removes approve BPT with approval tx instead of permit signature

### DIFF
--- a/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.spec.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.spec.tsx
@@ -24,6 +24,7 @@ const simulationQueryResult = {
       aTokenAmountMock(balAddress, balTokenOutUnits),
       aTokenAmountMock(wETHAddress, wEthTokenOutUnits),
     ],
+    sdkQueryOutput: { bptIn: { amount: 100000n } },
   },
 }
 // Mock query to avoid onchain SDK call from unit tests

--- a/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquiditySteps.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquiditySteps.tsx
@@ -29,13 +29,12 @@ export function useRemoveLiquiditySteps(params: RemoveLiquidityStepParams): Tran
     useApproveRelayerStep(chainId)
 
   const { wethIsEth, simulationQuery } = params
-  const simulationData = simulationQuery.data as SdkQueryRemoveLiquidityOutput
   // Only used to sign permit for v3 pools (standard permit is supported by all BPTs by contract)
   const signPermitStep = useSignPermitStep({
     pool,
     wethIsEth,
     slippagePercent: slippage,
-    queryOutput: simulationData,
+    queryOutput: simulationQuery.data as SdkQueryRemoveLiquidityOutput,
   })
 
   const isSafeAccount = useIsSafeAccount()

--- a/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquiditySteps.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquiditySteps.tsx
@@ -12,6 +12,12 @@ import { isV3Pool } from '../../pool.helpers'
 import { shouldUseRecoveryRemoveLiquidity } from '../LiquidityActionHelpers'
 import { SdkQueryRemoveLiquidityOutput } from './remove-liquidity.types'
 import { RemoveLiquidityStepParams, useRemoveLiquidityStep } from './useRemoveLiquidityStep'
+import { useTokenApprovalSteps } from '@repo/lib/modules/tokens/approvals/useTokenApprovalSteps'
+import { RawAmount } from '@repo/lib/modules/tokens/approvals/approval-rules'
+import { Address } from 'viem'
+import { RemoveLiquiditySimulationQueryResult } from './queries/useRemoveLiquiditySimulationQuery'
+import { useIsSafeAccount } from '@repo/lib/modules/web3/safe.hooks'
+import { Pool } from '../../pool.types'
 
 export function useRemoveLiquiditySteps(params: RemoveLiquidityStepParams): TransactionStep[] {
   const { chainId, pool, chain } = usePool()
@@ -23,21 +29,39 @@ export function useRemoveLiquiditySteps(params: RemoveLiquidityStepParams): Tran
     useApproveRelayerStep(chainId)
 
   const { wethIsEth, simulationQuery } = params
+  const simulationData = simulationQuery.data as SdkQueryRemoveLiquidityOutput
   // Only used to sign permit for v3 pools (standard permit is supported by all BPTs by contract)
   const signPermitStep = useSignPermitStep({
     pool,
     wethIsEth,
     slippagePercent: slippage,
-    queryOutput: simulationQuery.data as SdkQueryRemoveLiquidityOutput,
+    queryOutput: simulationData,
   })
+
+  const isSafeAccount = useIsSafeAccount()
+
+  //Only used for v3 pools + Safe account scenario
+  const { isLoadingTokenApprovalSteps, tokenApprovalSteps } = useBptTokenApprovals(
+    pool,
+    simulationQuery
+  )
 
   const removeLiquidityStep = useRemoveLiquidityStep(params)
 
-  const removeLiquiditySteps = isV3Pool(pool)
-    ? // Standard Permit signature
-      [signPermitStep, removeLiquidityStep]
-    : // V2 and V1 (CoW AMM) pools use the Vault relayer so they do not require permit signatures
-      [removeLiquidityStep]
+  function getRemoveLiquiditySteps(): TransactionStep[] {
+    if (isV3Pool(pool)) {
+      if (isSafeAccount) {
+        // Standard permit signatures are not supported by Safe accounts (signer != owner) so we use an Approval BPT Tx step instead
+        return [...tokenApprovalSteps, removeLiquidityStep]
+      }
+      // Standard Permit signature
+      return [signPermitStep, removeLiquidityStep]
+    }
+    // V2 and V1 (CoW AMM) pools use the Vault relayer so they do not require permit signatures
+    return [removeLiquidityStep]
+  }
+
+  const removeLiquiditySteps = getRemoveLiquiditySteps()
 
   return useMemo(() => {
     if (relayerMode === 'approveRelayer') {
@@ -55,5 +79,41 @@ export function useRemoveLiquiditySteps(params: RemoveLiquidityStepParams): Tran
     signRelayerStep,
     signPermitStep,
     isLoadingRelayerApproval,
+    isLoadingTokenApprovalSteps,
   ])
+}
+
+function useBptTokenApprovals(
+  pool: Pool,
+  simulationQuery: RemoveLiquiditySimulationQueryResult
+): { isLoadingTokenApprovalSteps: boolean; tokenApprovalSteps: TransactionStep[] } {
+  const { spenderAddress, rawAmount } = getSimulationQueryData(simulationQuery)
+
+  const bptAmount: RawAmount = {
+    rawAmount,
+    address: pool.address as Address,
+    symbol: pool.symbol,
+  }
+  //Only used for v3 pools + Safe account scenario
+  const { isLoading: isLoadingTokenApprovalSteps, steps: tokenApprovalSteps } =
+    useTokenApprovalSteps({
+      spenderAddress,
+      chain: pool.chain,
+      approvalAmounts: [bptAmount],
+      actionType: 'RemoveLiquidity',
+    })
+
+  return { isLoadingTokenApprovalSteps, tokenApprovalSteps }
+}
+
+function getSimulationQueryData(simulationQuery: RemoveLiquiditySimulationQueryResult): {
+  rawAmount: bigint
+  spenderAddress: Address
+} {
+  // Return default values if simulation query is not loaded
+  if (!simulationQuery.data) return { rawAmount: 0n, spenderAddress: '' as Address }
+  const simulationData = simulationQuery.data as SdkQueryRemoveLiquidityOutput
+  const rawAmount = simulationData.sdkQueryOutput.bptIn.amount
+  const spenderAddress = simulationData?.sdkQueryOutput.to
+  return { rawAmount, spenderAddress }
 }

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -117,13 +117,14 @@ export function useTokenApprovalSteps({
         return requiredRawAmount > 0n && isAllowed
       }
 
+      const isTxEnabled = !!spenderAddress && !tokenAllowances.isAllowancesLoading
       const props: ManagedErc20TransactionInput = {
         tokenAddress,
         functionName: 'approve',
         labels,
         chainId: getChainId(chain),
         args: [spenderAddress, requestedRawAmount],
-        enabled: !!spenderAddress && !tokenAllowances.isAllowancesLoading,
+        enabled: isTxEnabled,
         simulationMeta: sentryMetaForWagmiSimulation(
           'Error in wagmi tx simulation: Approving token',
           tokenAmountToApprove
@@ -138,7 +139,7 @@ export function useTokenApprovalSteps({
         labels,
         isComplete,
         renderAction: () => <ManagedErc20TransactionButton id={id} key={id} {...props} />,
-        batchableTxCall: buildBatchableTxCall({ tokenAddress, args }),
+        batchableTxCall: isTxEnabled ? buildBatchableTxCall({ tokenAddress, args }) : undefined,
         onSuccess: () => tokenAllowances.refetchAllowances(),
       } as const satisfies TransactionStep
     })

--- a/packages/lib/modules/transactions/transaction-steps/TransactionStepButton.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/TransactionStepButton.tsx
@@ -43,7 +43,8 @@ export function TransactionStepButton({ step }: Props) {
   async function handleOnClick() {
     setExecutionError(undefined)
     try {
-      await executeAsync?.()
+      if (!executeAsync) return
+      return await executeAsync()
     } catch (e: unknown) {
       setExecutionError(ensureError(e))
     }

--- a/packages/lib/modules/web3/contracts/useManagedErc20Transaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedErc20Transaction.ts
@@ -118,7 +118,7 @@ export function useManagedErc20Transaction({
     if (!simulateQuery.data) return
 
     try {
-      await writeQuery.writeContractAsync(simulateQuery.data.request)
+      return await writeQuery.writeContractAsync(simulateQuery.data.request)
     } catch (e: unknown) {
       captureWagmiExecutionError(e, 'Error in ERC20 transaction execution', {
         chainId,

--- a/packages/lib/modules/web3/contracts/useManagedTransaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedTransaction.ts
@@ -119,7 +119,7 @@ export function useManagedTransaction({
     }
 
     try {
-      await writeQuery.writeContractAsync({
+      return await writeQuery.writeContractAsync({
         ...simulateQuery.data.request,
         chainId: chainId,
       })

--- a/packages/lib/modules/web3/safe.hooks.tsx
+++ b/packages/lib/modules/web3/safe.hooks.tsx
@@ -10,7 +10,16 @@ import { useUserAccount } from './UserAccountProvider'
 import { useSafeTxQuery } from '../transactions/transaction-steps/safe/useSafeTxQuery'
 import { useWalletConnectMetadata } from './useWalletConnectMetadata'
 
-// Returns true if the user is connected with a Safe Account
+// Returns true when using a Safe Smart account:
+// - app running as a Safe App
+// - user connected via WalletConnect to a Safe Account
+export function useIsSafeAccount(): boolean {
+  const isSafeApp = useIsSafeApp()
+  const { isSafeAccountViaWalletConnect } = useWalletConnectMetadata()
+  return isSafeApp || isSafeAccountViaWalletConnect
+}
+
+// Returns true when app is running as a Safe App (it excludes Safe accounts connected via WalletConnect)
 export function useIsSafeApp(): boolean {
   const { connector } = useUserAccount()
 
@@ -65,11 +74,13 @@ type Props = {
 }
 
 export function useTxHash({ wagmiTxHash }: Props) {
+  /*
+  Only Safe Apps use Safe Tx Hash
+  Safe Accounts connected via WalletConnect use wagmiTxHash like a regular account
+  */
   const isSafeApp = useIsSafeApp()
-  const { isSafeAccountViaWalletConnect } = useWalletConnectMetadata()
-
   const { isLoading: isSafeTxLoading, data: safeTxHash } = useSafeTxQuery({
-    enabled: isSafeApp || isSafeAccountViaWalletConnect,
+    enabled: isSafeApp,
     wagmiTxHash,
   })
 


### PR DESCRIPTION
Signing standard permit approvals is not possible with Smart Accounts (including Safe):

>  Regular permits (EIP-2612) cannot be directly signed by Gnosis Safe contracts - they can only be signed by EOAs. This is because EIP-2612 permits specifically require ECDSA signatures (specifically eth_sign/personal_sign type signatures), while Gnosis Safe uses contract-based signatures.
> The main reasons:
> Regular permits expect r, s, v components from ECDSA signatures
> Gnosis Safe uses a different signing scheme (contract-based signatures via EIP-1271)
> EIP-2612's permit function validates signatures using ecrecover
> Permit2 works with Gnosis Safe because it was specifically designed to support both EOA signatures and EIP-1271 contract signatures. When using Permit2, the contract checks if the signer is a contract and if so, uses isValidSignature(hash, signature) for verification instead of ecrecover.
> This is one of the major advantages of Permit2 - it’s more flexible in terms of signature validation and works with both EOAs and smart contract wallets

So, in this specific context (Safe App or Safe via WC) we show an `BPT token approval step` instead.

In the future, as an improvement, we could batch the BPT token approval tx + the remove tx.

