### PR TITLE
fix: avoid passing wagmiConfig as a prop

### DIFF
--- a/packages/lib/modules/web3/WagmiConfig.tsx
+++ b/packages/lib/modules/web3/WagmiConfig.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { connectorsForWallets } from '@rainbow-me/rainbowkit'
-import { Config, createConfig } from 'wagmi'
+import { createConfig } from 'wagmi'
 import {
   coinbaseWallet,
   rabbyWallet,
@@ -15,7 +15,8 @@ import { chains } from './ChainConfig'
 import { transports } from './transports'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
-const projectId = process.env.NEXT_PUBLIC_WALLET_CONNECT_ID || ''
+const walletConnectProjectId = process.env.NEXT_PUBLIC_WALLET_CONNECT_ID
+if (!walletConnectProjectId) throw new Error('Missing NEXT_PUBLIC_WALLET_CONNECT_ID env')
 
 const connectors = connectorsForWallets(
   [
@@ -35,7 +36,7 @@ const connectors = connectorsForWallets(
   ],
   {
     appName: PROJECT_CONFIG.projectName,
-    projectId,
+    projectId: walletConnectProjectId,
     walletConnectParameters: {
       // Enforce wallet connect popup always on top
       // More info: https://github.com/wevm/wagmi/discussions/2775
@@ -48,8 +49,7 @@ const connectors = connectorsForWallets(
   }
 )
 
-export type WagmiConfig = ReturnType<typeof createConfig>
-export const wagmiConfig: Config = createConfig({
+export const wagmiConfig = createConfig({
   chains,
   transports,
   connectors,

--- a/packages/lib/modules/web3/Web3Provider.tsx
+++ b/packages/lib/modules/web3/Web3Provider.tsx
@@ -13,13 +13,10 @@ import { BlockedAddressModal } from './BlockedAddressModal'
 import { CustomAvatar } from './CustomAvatar'
 import { UserAccountProvider } from './UserAccountProvider'
 import { PropsWithChildren } from 'react'
-import { WagmiConfig } from './WagmiConfig'
+import { wagmiConfig } from './WagmiConfig'
 import { useIsMounted } from '@repo/lib/shared/hooks/useIsMounted'
 
-export function Web3Provider({
-  children,
-  wagmiConfig,
-}: PropsWithChildren<{ wagmiConfig: WagmiConfig }>) {
+export function Web3Provider({ children }: PropsWithChildren) {
   const isMounted = useIsMounted()
 
   const { colors, radii, shadows, semanticTokens, fonts } = useTheme()

--- a/packages/lib/shared/components/site/providers.tsx
+++ b/packages/lib/shared/components/site/providers.tsx
@@ -4,12 +4,11 @@ import { ReactNode } from 'react'
 import { RecentTransactionsProvider } from '@repo/lib/modules/transactions/RecentTransactionsProvider'
 import { ApolloGlobalDataProvider } from '@repo/lib/shared/services/api/apollo-global-data.provider'
 import { UserSettingsProvider } from '@repo/lib/modules/user/settings/UserSettingsProvider'
-import { wagmiConfig } from '@repo/lib/modules/web3/WagmiConfig'
 import { VebalLockDataProvider } from '@repo/lib/modules/vebal/lock/VebalLockDataProvider'
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
-    <Web3Provider wagmiConfig={wagmiConfig}>
+    <Web3Provider>
       <ApolloClientProvider>
         <ApolloGlobalDataProvider>
           <UserSettingsProvider>


### PR DESCRIPTION
Hypothesis: 

Using the `wagmiConfig` after checking `useIsMounted` instead of passing it through a prop could avoid some disconnection problems due to re-renders.