### PR TITLE
fix: wrong disconnections in AcceptPolicies modal

### DIFF
--- a/packages/lib/modules/web3/AcceptPoliciesModal.tsx
+++ b/packages/lib/modules/web3/AcceptPoliciesModal.tsx
@@ -39,19 +39,14 @@ export function AcceptPoliciesModal() {
   useEffect(() => {
     if (!isLoading && isConnected && !isAddressInAcceptedPolicies && !isBlocked) {
       onOpen()
-    } else {
-      handleOnClose()
     }
   }, [acceptedPolicies, isBlocked, isLoading, isConnected, userAddress])
 
-  //disconnect wallet if modal is closed without accepting & clicking 'Proceed'
-  useEffect(() => {
-    if (!isOpen && !acceptedPolicies.includes(userAddress.toLowerCase())) {
+  function handleOnClose() {
+    //disconnect wallet if modal is closed without accepting & clicking 'Proceed'
+    if (!acceptedPolicies.includes(userAddress.toLowerCase())) {
       disconnect()
     }
-  }, [isOpen])
-
-  function handleOnClose() {
     setIsChecked(false)
     onClose()
   }

--- a/packages/lib/modules/web3/AcceptPoliciesModal.tsx
+++ b/packages/lib/modules/web3/AcceptPoliciesModal.tsx
@@ -44,7 +44,7 @@ export function AcceptPoliciesModal() {
 
   function handleOnClose() {
     //disconnect wallet if modal is closed without accepting & clicking 'Proceed'
-    if (!acceptedPolicies.includes(userAddress.toLowerCase())) {
+    if (!isChecked || !acceptedPolicies.includes(userAddress.toLowerCase())) {
       disconnect()
     }
     setIsChecked(false)

--- a/packages/lib/modules/web3/AcceptPoliciesModal.tsx
+++ b/packages/lib/modules/web3/AcceptPoliciesModal.tsx
@@ -42,10 +42,11 @@ export function AcceptPoliciesModal() {
     }
   }, [acceptedPolicies, isBlocked, isLoading, isConnected, userAddress])
 
-  function handleOnClose() {
+  function handleOnClose(isProceeding = false) {
+    const shouldDisconnect = !isChecked || !acceptedPolicies.includes(userAddress.toLowerCase())
     //disconnect wallet if modal is closed without accepting & clicking 'Proceed'
-    if (!isChecked || !acceptedPolicies.includes(userAddress.toLowerCase())) {
-      disconnect()
+    if (!isProceeding && shouldDisconnect) {
+      if (isConnected) disconnect()
     }
     setIsChecked(false)
     onClose()
@@ -56,7 +57,7 @@ export function AcceptPoliciesModal() {
       setAcceptedPolicies([...acceptedPolicies, userAddress.toLowerCase()])
     }
 
-    handleOnClose()
+    handleOnClose(true)
   }
 
   return (


### PR DESCRIPTION
The old useEffect was triggering disconnections in cases where they were not needed causing different issues like: 

https://github.com/balancer/frontend-monorepo/issues/61#issue-2587970801