### PR TITLE
fix: exclude phantom btp in composable stable pool display

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolComposition.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolComposition.tsx
@@ -30,7 +30,11 @@ import { usePool } from '../PoolProvider'
 import { Pool } from '../pool.types'
 import { PoolTypeTag } from './PoolTypeTag'
 import { PoolWeightChart } from './PoolWeightCharts/PoolWeightChart'
-import { getCompositionTokens, getFlatCompositionTokens } from '../pool-tokens.utils'
+import {
+  getCompositionTokens,
+  getFlatCompositionTokens,
+  getNestedPoolTokens,
+} from '../pool-tokens.utils'
 
 type CardContentProps = {
   totalLiquidity: string
@@ -85,7 +89,7 @@ function CardContent({ totalLiquidity, poolTokens, chain, pool }: CardContentPro
               />
               {poolToken.hasNestedPool && poolToken.nestedPool && (
                 <VStack pl="8" w="full">
-                  {poolToken.nestedPool.tokens.map(nestedPoolToken => {
+                  {getNestedPoolTokens(poolToken).map(nestedPoolToken => {
                     const calculatedWeight = bn(nestedPoolToken.balanceUSD).div(
                       bn(poolToken.balanceUSD)
                     )

--- a/packages/lib/modules/pool/pool-tokens.utils.spec.ts
+++ b/packages/lib/modules/pool/pool-tokens.utils.spec.ts
@@ -16,6 +16,7 @@ import {
   getUserReferenceTokens,
   getFlatUserReferenceTokens,
   getPoolActionableTokens,
+  getNestedPoolTokens,
 } from './pool-tokens.utils'
 import { ApiToken } from '../tokens/token.types'
 import { PoolToken } from './pool.types'
@@ -163,7 +164,6 @@ describe('getDisplayTokens for NESTED pools', () => {
       'WBTC',
       'WETH',
       'WXDAI',
-      'staBAL3',
     ])
 
     expect(getPoolActionableTokenSymbols(staBALv2Nested)).toEqual([
@@ -173,6 +173,16 @@ describe('getDisplayTokens for NESTED pools', () => {
       'WETH',
       'WBTC',
     ])
+
+    const pool = getApiPoolMock(staBALv2Nested)
+    const staBalBPT = pool.poolTokens.find(t => t.hasNestedPool)
+    expect(getNestedPoolTokens(staBalBPT as PoolToken).map(t => t.symbol)).toMatchInlineSnapshot(`
+      [
+        "USDT",
+        "USDC",
+        "WXDAI",
+      ]
+    `)
   })
 
   it('aura bal (Nested with supportsNestedActions false)', () => {

--- a/packages/lib/modules/pool/pool-tokens.utils.ts
+++ b/packages/lib/modules/pool/pool-tokens.utils.ts
@@ -61,7 +61,7 @@ function excludeNestedBptTokens(tokens: PoolToken[], poolAddress: string): PoolT
 
 // Returns user reference tokens with nested tokens flattened
 export function getFlatUserReferenceTokens(pool: PoolCore): PoolToken[] {
-  return flatNestedTokens(getUserReferenceTokens(pool)) as PoolToken[]
+  return flatNestedTokens(getUserReferenceTokens(pool))
 }
 
 // Returns composition tokens with nested tokens flattened
@@ -78,7 +78,7 @@ function flatNestedTokens(tokens: PoolToken[]): PoolToken[] {
 
   tokens.forEach(token => {
     if (token.hasNestedPool) {
-      token.nestedPool?.tokens.forEach(nestedPoolToken => {
+      getNestedPoolTokens(token).forEach(nestedPoolToken => {
         tokensWithNestedPools.push(nestedPoolToken as PoolToken)
       })
     } else {
@@ -87,6 +87,15 @@ function flatNestedTokens(tokens: PoolToken[]): PoolToken[] {
   })
 
   return tokensWithNestedPools
+}
+
+/*
+  Given a BPT, it returns it's nested tokens excluding the BPT itself
+  Used in PoolComposition to render token composition of nested pools
+*/
+export function getNestedPoolTokens(poolToken: PoolToken) {
+  if (!poolToken.nestedPool) return []
+  return excludeNestedBptTokens(poolToken.nestedPool.tokens as PoolToken[], poolToken.address)
 }
 
 /*


### PR DESCRIPTION
Pools to test: 
`pools/gnosis/v2/0x66888e4f35063ad8bb11506a6fde5024fb4f1db0000100000000000000000053`
`pools/ethereum/v2/0x49cbd67651fbabce12d1df18499896ec87bef46f00000000000000000000064a
`

**Before**: 

<img width="672" alt="Screenshot 2025-02-04 at 10 51 10" src="https://github.com/user-attachments/assets/7b0aa1e4-a3b1-4a34-893a-b76a35aecc2b" />

**After**:

<img width="689" alt="after" src="https://github.com/user-attachments/assets/60fb5a29-a26c-4c43-936b-6aa7344bdffa" />


