### PR TITLE
chore: Update tooltips

### DIFF
--- a/packages/lib/shared/hooks/useAprTooltip.ts
+++ b/packages/lib/shared/hooks/useAprTooltip.ts
@@ -5,12 +5,9 @@ import { bn } from '../utils/numbers'
 import BigNumber from 'bignumber.js'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
-export const swapFeesTooltipText = `LPs get swap fees anytime a swap is routed through this pool.
-These fees automatically accumulate into the LP's position, so there is no need to periodically claim.`
+export const swapFeesTooltipText = `LPs earn fees when swaps are routed through this pool. The displayed APR is net earnings for LPs (with all protocol fees already deducted). Fees automatically compound into positions—no claiming needed.`
 
-export const inherentTokenYieldTooltipText = `Inherent token yield,
- accounting for the token's share of the overall pool,
- minus any protocol fees.`
+export const inherentTokenYieldTooltipText = `LPs earn the inherent yield from yield bearing tokens. The displayed APR is net earnings for LPs, accounting for the token’s share of the pool (with all protocol fees already deducted). Fees automatically compound into positions—no claiming needed.`
 
 export const merklIncentivesTooltipText = `Merkl is a platform that allows 3rd party Incentive Providers
  to offer campaigns with additional yield for Liquidity Providers.`
@@ -29,8 +26,7 @@ export const votingIncentivesTooltipText = `Vote incentives are offered to veBAL
                         Your incentives are determined by your veBAL voting power compared to other voters. 
                         The listed APR represents an average rather than a guaranteed return for active participants.`
 
-const stakingBalTooltipText = `The base APR all stakers in this pool get (determined by weekly gauge voting).
-In addition, veBAL holders can get an extra boost of up to 2.5x.`
+const stakingBalTooltipText = `LPs who stake earn extra ‘BAL’ liquidity mining incentives. The displayed APR is the base amount that all Stakers in this pool get (determined by weekly gauge voting). In addition, veBAL holders can get an extra boost of up to 2.5x.`
 
 const maBeetsVotingRewardsTooltipText =
   'To receive Voting APR you must vote for incentivized pools in the bi-weekly gauge vote. APR is dependent on your vote distribution.'
@@ -116,7 +112,7 @@ export function useAprTooltip({
   const stakingIncentivesDisplayed = stakingIncentives.map(item => ({
     title: item.rewardTokenSymbol || '',
     apr: numberFormatter(item.apr.toString()),
-    tooltipText: `3rd party incentives (outside the ${showVeBal || chain === GqlChain.Optimism ? 'veBAL' : 'gauge bounty'} system)`,
+    tooltipText: `3rd party incentives for LPs who stake. These token incentives are outside the ${showVeBal || chain === GqlChain.Optimism ? 'veBAL' : 'gauge bounty'} system.`,
   }))
 
   const votingApr = aprItems.find(item => item.type === GqlPoolAprItemType.Voting)


### PR DESCRIPTION
Implements all text changes suggested in the designs linked here #563.

- Does not include links in tooltips. For some reason links are not clickable within these tooltips and if you click on them within the pool list they redirect to the pool page regardless of the href.
- Does not include Core pool attribute in pool info, this is not available in the API yet.