### PR TITLE
chore: Use txs for approvals if setting disabled

### DIFF
--- a/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -40,9 +40,11 @@ import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { TooltipWithTouch } from '@repo/lib/shared/components/tooltips/TooltipWithTouch'
 import { useUserSettings } from '@repo/lib/modules/user/settings/UserSettingsProvider'
 import { isBoosted } from '../../../pool.helpers'
+import { BalAlert } from '@repo/lib/shared/components/alerts/BalAlert'
 
 export function RemoveLiquidityForm() {
   const { pool } = usePool()
+  const { shouldUseSignatures } = useUserSettings()
 
   const TABS: ButtonGroupOption[] = [
     {
@@ -141,6 +143,13 @@ export function RemoveLiquidityForm() {
           </CardHeader>
           <VStack align="start" spacing="md">
             <SafeAppAlert />
+            {!shouldUseSignatures && (
+              <BalAlert
+                content="All approvals will require gas transactions. You can enable signatures in your settings."
+                status="warning"
+                title="Signatures disabled"
+              />
+            )}
             {!requiresProportionalInput(pool) && (
               <HStack>
                 <ButtonGroup

--- a/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquiditySteps.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquiditySteps.tsx
@@ -24,6 +24,7 @@ export function useRemoveLiquiditySteps(params: RemoveLiquidityStepParams): Tran
   const { chainId, pool, chain } = usePool()
   const { slippage } = useUserSettings()
   const relayerMode = useRelayerMode(pool)
+  const { shouldUseSignatures } = useUserSettings()
   const shouldSignRelayerApproval = useShouldSignRelayerApproval(chainId, relayerMode)
   const signRelayerStep = useSignRelayerStep(chain)
   const { step: approveRelayerStep, isLoading: isLoadingRelayerApproval } =
@@ -50,7 +51,7 @@ export function useRemoveLiquiditySteps(params: RemoveLiquidityStepParams): Tran
 
   function getRemoveLiquiditySteps(): TransactionStep[] {
     if (isV3Pool(pool)) {
-      if (isSafeAccount) {
+      if (isSafeAccount || !shouldUseSignatures) {
         // Standard permit signatures are not supported by Safe accounts (signer != owner) so we use an Approval BPT Tx step instead
         return [...tokenApprovalSteps, removeLiquidityStep]
       }


### PR DESCRIPTION
If signature setting is disabled, force transactions for approvals in the remove flow. Also, show warning in remove form if setting is disabled.  