### PR TITLE
fix: show decimals for points value

### DIFF
--- a/packages/lib/modules/pool/tags/PoolTags.tsx
+++ b/packages/lib/modules/pool/tags/PoolTags.tsx
@@ -16,12 +16,12 @@ import {
 import { PoolTag } from './getPoolTags'
 import { usePool } from '../PoolProvider'
 import NextLink from 'next/link'
-import { isInteger, toNumber } from 'lodash'
+import { isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { usePoolTags } from './PoolTagsProvider'
 
 function TagValue({ tag }: { tag: PoolTag }) {
   if (tag.value) {
-    if (tag.id.includes('points') && isInteger(toNumber(tag.value))) {
+    if (tag.id.includes('points') && isValidNumber(tag.value)) {
       return <Text ml="xs" mr="xs">{`${tag.value}x`}</Text>
     }
   }

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -5,6 +5,7 @@ import BigNumber from 'bignumber.js'
 import numeral from 'numeral'
 import { KeyboardEvent } from 'react'
 import { formatUnits } from 'viem'
+import { isNumber, toNumber } from 'lodash'
 
 // Allows calling JSON.stringify with bigints
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
@@ -266,4 +267,8 @@ export function isSmallUsd(value: Numberish): boolean {
 export function isTooSmallToRemoveUsd(value: Numberish): boolean {
   const USD_LOWER_THRESHOLD = 0.03
   return !isZero(value) && bn(value).lt(USD_LOWER_THRESHOLD)
+}
+
+export const isValidNumber = (value: string): boolean => {
+  return isNumber(toNumber(value)) && !isNaN(toNumber(value))
 }

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -269,6 +269,5 @@ export function isTooSmallToRemoveUsd(value: Numberish): boolean {
   return !isZero(value) && bn(value).lt(USD_LOWER_THRESHOLD)
 }
 
-export const isValidNumber = (value: string): boolean => {
-  return isNumber(toNumber(value)) && !isNaN(toNumber(value))
-}
+export const isValidNumber = (value: string): boolean =>
+  isNumber(toNumber(value)) && !isNaN(toNumber(value))


### PR DESCRIPTION
the current ui checks if the points multiplier value is an integer
however the value for rings is 1.5 so therefore it isn't rendered

before:
![image](https://github.com/user-attachments/assets/cee3648f-6058-4546-8ae2-b10e5c6fee3a)

after:
![image](https://github.com/user-attachments/assets/7637c9ae-a067-47d2-af74-32986b0b7dc0)

