### PR TITLE
fix: Update metadata type to match repo

### DIFF
--- a/packages/lib/modules/pool/tags/getPoolTags.ts
+++ b/packages/lib/modules/pool/tags/getPoolTags.ts
@@ -12,7 +12,7 @@ export type PoolTag = {
   description: string
   value?: string
   url?: string
-  fileIcon?: string
+  icon?: string
   iconUrl?: string
   pools?: string[]
 }
@@ -27,7 +27,7 @@ export async function getPoolTags(): Promise<PoolTag[] | undefined> {
     return tags.map(tag => {
       return {
         ...tag,
-        iconUrl: tag.fileIcon ? `${POOL_TAGS_ICON_BASE_URL}/${tag.fileIcon}` : undefined,
+        iconUrl: tag.icon ? `${POOL_TAGS_ICON_BASE_URL}/${tag.icon}` : undefined,
       }
     })
   } catch (error) {


### PR DESCRIPTION
Before:
![cs 2025-02-12 at 14 39 14@2x](https://github.com/user-attachments/assets/4599bd61-5e2b-4299-868c-e0fde7b4ee97)

After:
<img width="510" alt="Screenshot 2025-02-12 at 16 29 31" src="https://github.com/user-attachments/assets/8cd43342-c5bc-47bc-8973-1463f22590e1" />
