### PR TITLE
fix: add redirect for old pool links

### DIFF
--- a/apps/beets-frontend-v3/next.config.js
+++ b/apps/beets-frontend-v3/next.config.js
@@ -32,6 +32,12 @@ const nextConfig = {
         destination: 'https://discord.gg/kbPnYJjvwZ',
         permanent: false,
       },
+      // temporary redirect for urls to OP pools from the old app (mainly for Aura)
+      {
+        source: '/pool/:path*',
+        destination: '/pools/optimism/v2/:path*',
+        permanent: false,
+      },
     ]
   },
 }


### PR DESCRIPTION
only redirects to OP pools because Aura will probably be the main referer here

will be removed when Aura updates their links to these pools