### PR TITLE
fix: slippage and rounding issues when using bufferPercentage in proportional adds

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
@@ -33,10 +33,10 @@ import { supportsWethIsEth } from '../../pool.helpers'
 import { getPoolActionableTokens, getWrappedBoostedTokens } from '../../pool-tokens.utils'
 import { useUserSettings } from '@repo/lib/modules/user/settings/UserSettingsProvider'
 import { isUnbalancedAddErrorMessage } from '@repo/lib/shared/utils/error-filters'
-import { getDefaultProportionalSlippagePercentage } from '@repo/lib/shared/utils/slippage'
 import { ApiToken } from '@repo/lib/modules/tokens/token.types'
 import { useIsMinimumDepositMet } from './useIsMinimumDepositMet'
 import { useWrapUnderlying } from '../useWrapUnderlying'
+import { useProportionalSlippage } from './form/useProportionalSlippage'
 
 export type UseAddLiquidityResponse = ReturnType<typeof _useAddLiquidity>
 export const AddLiquidityContext = createContext<UseAddLiquidityResponse | null>(null)
@@ -57,9 +57,11 @@ export function _useAddLiquidity(urlTxHash?: Hash) {
     - the user selected the proportional tab
   */
   const [wantsProportional, setWantsProportional] = useState(requiresProportionalInput(pool))
-  const [proportionalSlippage, setProportionalSlippage] = useState<string>(
-    getDefaultProportionalSlippagePercentage(pool)
-  )
+  const { proportionalSlippage, setProportionalSlippage } = useProportionalSlippage({
+    pool,
+    clearAmountsIn,
+    wantsProportional,
+  })
 
   const { getNativeAssetToken, getWrappedNativeAssetToken, isLoadingTokenPrices } = useTokens()
 

--- a/packages/lib/modules/pool/actions/add-liquidity/form/useProportionalSlippage.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/form/useProportionalSlippage.tsx
@@ -1,0 +1,30 @@
+import { useRef, useState } from 'react'
+import { Pool } from '../../../pool.types'
+import { getDefaultProportionalSlippagePercentage } from '@repo/lib/shared/utils/slippage'
+
+type Props = {
+  pool: Pool
+  clearAmountsIn: () => void
+  wantsProportional: boolean
+}
+export function useProportionalSlippage({ pool, clearAmountsIn, wantsProportional }: Props) {
+  const [proportionalSlippage, setProportionalSlippage] = useState<string>(
+    getDefaultProportionalSlippagePercentage(pool)
+  )
+
+  const prevProportionalSlippage = useRef(proportionalSlippage)
+
+  /*
+    Clear amounts in when proportional slippage changes.
+    This is needed to make sure that bufferPercentage is applied correctly (see TokenBalancesProvider)
+    when the user maximizes the input of a token n proportional mode
+  */
+  if (prevProportionalSlippage.current !== proportionalSlippage) {
+    if (wantsProportional) {
+      clearAmountsIn()
+    }
+    prevProportionalSlippage.current = proportionalSlippage
+  }
+
+  return { proportionalSlippage, setProportionalSlippage }
+}

--- a/packages/lib/modules/tokens/TokenBalancesProvider.tsx
+++ b/packages/lib/modules/tokens/TokenBalancesProvider.tsx
@@ -17,6 +17,7 @@ import { getNetworkConfig } from '@repo/lib/config/app.config'
 import { exclNativeAssetFilter, nativeAssetFilter } from './token.helpers'
 import { HumanAmount, Slippage } from '@balancer/sdk'
 import { ApiToken } from './token.types'
+import { isZero } from '@repo/lib/shared/utils/numbers'
 
 const BALANCE_CACHE_TIME_MS = 30_000
 
@@ -100,6 +101,11 @@ export function _useTokenBalances(
       let amount = balance.status === 'success' ? (balance.result as bigint) : 0n
       const slippage = Slippage.fromPercentage(bufferPercentage as HumanAmount)
       amount = slippage.applyTo(amount, -1)
+      if (!isZero(bufferPercentage) && token.decimals === 6) {
+        // Apply an extra buffer of 5n to avoid precision issues in tokens with 6 decimals
+        const extraBuffer = 5n
+        amount = amount - extraBuffer
+      }
 
       return {
         chainId,

--- a/packages/lib/modules/tokens/TokenBalancesProvider.tsx
+++ b/packages/lib/modules/tokens/TokenBalancesProvider.tsx
@@ -101,8 +101,8 @@ export function _useTokenBalances(
       let amount = balance.status === 'success' ? (balance.result as bigint) : 0n
       const slippage = Slippage.fromPercentage(bufferPercentage as HumanAmount)
       amount = slippage.applyTo(amount, -1)
-      if (!isZero(bufferPercentage) && token.decimals === 6) {
-        // Apply an extra buffer of 5n to avoid precision issues in tokens with 6 decimals
+      if (!isZero(bufferPercentage) && (token.decimals === 6 || token.decimals === 8)) {
+        // Apply an extra buffer of 5n to avoid precision issues in tokens with 6/8 decimals
         const extraBuffer = 5n
         amount = amount - extraBuffer
       }


### PR DESCRIPTION
Some users reported an `TRANSFER_FROM_FAILED` errors when adding liquidity in proportional pools  (using max balance)
https://discord.com/channels/638460494168064021/1340181683172806768/1340181687342202880

There were 2 root causes: 

- The max amount in the case of tokens with 6 decimals requires an extra bufferPercentage margin error to avoid going over the user's balance. Fixed by adding `5n` extra for a bigger error margin.

- When the user changes the slippage in proportional mode,  the bufferPercentage was not being recalculated.  Fixed by clearing the input amounts in this specific edge case.