### PR TITLE
feat: impersonate account

### DIFF
--- a/apps/frontend-v3/app/(app)/debug/impersonate/page.tsx
+++ b/apps/frontend-v3/app/(app)/debug/impersonate/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ImpersonateAccount } from '@repo/lib/modules/web3/ImpersonateAccount'
+
+export default function Impersonate() {
+  return <ImpersonateAccount />
+}

--- a/apps/frontend-v3/app/(app)/debug/page.tsx
+++ b/apps/frontend-v3/app/(app)/debug/page.tsx
@@ -9,6 +9,9 @@ export default function Debug() {
     <FadeInOnView>
       <VStack margin="lg" padding="lg">
         <Heading size="md">Demos</Heading>
+        <Link as={NextLink} href="/debug/impersonate">
+          Impersonate
+        </Link>
         <Link as={NextLink} href="/debug/pools">
           Pools
         </Link>

--- a/apps/frontend-v3/public/images/logos/mock.svg
+++ b/apps/frontend-v3/public/images/logos/mock.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="48" height="48" fill="white" fill-opacity="0.01"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.019 4V15.0386L6.27437 39.3014C5.48686 40.9283 6.16731 42.8855 7.79421 43.673C8.23876 43.8882 8.72624 44 9.22013 44H38.7874C40.5949 44 42.0602 42.5347 42.0602 40.7273C42.0602 40.2348 41.949 39.7488 41.7351 39.3052L30.0282 15.0386V4H18.019Z" stroke="#000000" stroke-width="4" stroke-linejoin="round"/>
+<path d="M10.9604 29.9998C13.1241 31.3401 15.2893 32.0103 17.4559 32.0103C19.6226 32.0103 21.7908 31.3401 23.9605 29.9998C26.1088 28.6735 28.2664 28.0103 30.433 28.0103C32.5997 28.0103 34.7755 28.6735 36.9604 29.9998" stroke="#000000" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/packages/lib/modules/web3/ImpersonateAccount.tsx
+++ b/packages/lib/modules/web3/ImpersonateAccount.tsx
@@ -1,0 +1,43 @@
+import { VStack, Text, Input, Button } from '@chakra-ui/react'
+import { useWagmiConfig } from './WagmiConfigProvider'
+import { useState } from 'react'
+import { useConnect } from 'wagmi'
+import { isAddress } from 'viem'
+import { updateMockConnectorAddress } from './WagmiConfig'
+
+export function ImpersonateAccount() {
+  const { setWagmiConfig } = useWagmiConfig()
+  const [isValidAddress, setIsValidAddress] = useState<boolean>(false)
+  const { connectors, connectAsync } = useConnect()
+
+  function onAddressChange(address: string) {
+    if (isAddress(address)) {
+      setIsValidAddress(true)
+      return setWagmiConfig(updateMockConnectorAddress(address))
+    }
+    setIsValidAddress(false)
+  }
+
+  async function connectMockAccount() {
+    await connectAsync({ connector: connectors[connectors.length - 1] })
+  }
+
+  return (
+    <VStack>
+      <Text>Impersonate Account</Text>
+      <Input
+        aria-label="Mock address"
+        onChange={e => onAddressChange(e.target.value)}
+        type="text"
+        width="40%"
+      />
+      <Button
+        aria-label="Impersonate"
+        disabled={!isValidAddress}
+        onClick={() => connectMockAccount()}
+      >
+        Connect
+      </Button>
+    </VStack>
+  )
+}

--- a/packages/lib/modules/web3/WagmiConfig.tsx
+++ b/packages/lib/modules/web3/WagmiConfig.tsx
@@ -15,6 +15,9 @@ import { chains } from './ChainConfig'
 import { transports } from './transports'
 import { createWalletConnectConnector } from './wallet-connect/createWalletConnectConnector'
 import { isConnectedToWC } from './wallet-connect/useWCConnectionLocalStorage'
+import { createMockConnector } from './wallet-connect/createMockConnector'
+import { Address } from 'viem'
+import { isProd } from '@repo/lib/config/app.config'
 
 const walletConnectProjectId = process.env.NEXT_PUBLIC_WALLET_CONNECT_ID
 if (!walletConnectProjectId) throw new Error('Missing NEXT_PUBLIC_WALLET_CONNECT_ID env')
@@ -54,9 +57,25 @@ if (!isConnectedToWC()) {
   }
 }
 
+// Add mock connector for development/staging environments
+if (!isProd) connectors.push(createMockConnector({ index: connectors.length }))
+
 export const wagmiConfig = createConfig({
   chains,
   transports,
   connectors,
   ssr: true,
 })
+
+// Update the mock connector address to impersonate a different account
+export function updateMockConnectorAddress(address?: Address) {
+  connectors.pop()
+  connectors.push(createMockConnector({ index: connectors.length, address }))
+
+  return createConfig({
+    chains,
+    transports,
+    connectors,
+    ssr: true,
+  })
+}

--- a/packages/lib/modules/web3/WagmiConfigProvider.tsx
+++ b/packages/lib/modules/web3/WagmiConfigProvider.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
+import { createContext, PropsWithChildren, useState } from 'react'
+import { wagmiConfig as _wagmiConfig } from './WagmiConfig'
+
+export type UseWagmiConfigResult = ReturnType<typeof _useWagmiConfig>
+export const WagmiConfigContext = createContext<UseWagmiConfigResult | null>(null)
+
+export function _useWagmiConfig() {
+  const [wagmiConfig, setWagmiConfig] = useState(_wagmiConfig)
+
+  return { wagmiConfig, setWagmiConfig }
+}
+
+/*
+  Provider to store the wagmi config inside a react state so that it can be overridden to impersonate accounts
+  Useful for manual and E2E testing
+*/
+export function WagmiConfigProvider({ children }: PropsWithChildren) {
+  const config = _useWagmiConfig()
+
+  return <WagmiConfigContext.Provider value={config}>{children}</WagmiConfigContext.Provider>
+}
+
+export const useWagmiConfig = (): UseWagmiConfigResult =>
+  useMandatoryContext(WagmiConfigContext, 'WagmiConfig')

--- a/packages/lib/modules/web3/Web3Provider.tsx
+++ b/packages/lib/modules/web3/Web3Provider.tsx
@@ -13,8 +13,8 @@ import { BlockedAddressModal } from './BlockedAddressModal'
 import { CustomAvatar } from './CustomAvatar'
 import { UserAccountProvider } from './UserAccountProvider'
 import { PropsWithChildren } from 'react'
-import { wagmiConfig } from './WagmiConfig'
 import { useIsMounted } from '@repo/lib/shared/hooks/useIsMounted'
+import { useWagmiConfig } from './WagmiConfigProvider'
 
 export function Web3Provider({ children }: PropsWithChildren) {
   const isMounted = useIsMounted()
@@ -22,6 +22,8 @@ export function Web3Provider({ children }: PropsWithChildren) {
   const { colors, radii, shadows, semanticTokens, fonts } = useTheme()
   const colorMode = useThemeColorMode()
   const colorModeKey = colorMode === 'light' ? 'default' : '_dark'
+
+  const { wagmiConfig } = useWagmiConfig()
 
   /*
     Avoids warning (Warning: Prop `dangerouslySetInnerHTML` did not match. Server...)

--- a/packages/lib/modules/web3/wallet-connect/createMockConnector.ts
+++ b/packages/lib/modules/web3/wallet-connect/createMockConnector.ts
@@ -1,0 +1,36 @@
+import { RainbowKitDetails } from '@rainbow-me/rainbowkit/dist/wallets/Wallet'
+import { Address } from 'viem'
+import { CreateConnectorFn, mock } from 'wagmi'
+
+type Params = { index: number; address?: Address }
+
+export function createMockConnector({ index, address }: Params) {
+  // Default WC RkDetails
+  const rkDetails: RainbowKitDetails = {
+    id: 'mock',
+    name: 'Mock Connector',
+    iconBackground: '#39FF14',
+    iconUrl: async () => '/images/logos/mock.svg',
+    index,
+    groupIndex: 1,
+    groupName: 'Recommended',
+    isRainbowKitConnector: true,
+  }
+
+  const mockConnector: CreateConnectorFn = (config: any) => {
+    return {
+      ...mock({
+        accounts: [
+          address
+            ? address
+            : // Navigate to /debug/impersonate or edit the following address to impersonate with a different account
+              '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', // Default anvil account
+        ],
+        features: {},
+      })(config),
+      rkDetails,
+    }
+  }
+
+  return mockConnector
+}

--- a/packages/lib/shared/components/navs/NavBar.tsx
+++ b/packages/lib/shared/components/navs/NavBar.tsx
@@ -14,6 +14,7 @@ import DarkModeToggle from '../btns/DarkModeToggle'
 import RecentTransactions from '../other/RecentTransactions'
 import { AppLink, useNav } from './useNav'
 import { clamp } from 'lodash'
+import { ImpersonateAccount } from '@repo/lib/modules/web3/ImpersonateAccount'
 
 type Props = {
   mobileNav?: ReactNode
@@ -91,6 +92,8 @@ function NavLinks({
           </Box>
         </>
       )}
+      {/* Display impersonate form only for E2E tests (CI) */}
+      {process.env.CI && <ImpersonateAccount />}
     </HStack>
   )
 }

--- a/packages/lib/shared/components/site/providers.tsx
+++ b/packages/lib/shared/components/site/providers.tsx
@@ -5,19 +5,22 @@ import { RecentTransactionsProvider } from '@repo/lib/modules/transactions/Recen
 import { ApolloGlobalDataProvider } from '@repo/lib/shared/services/api/apollo-global-data.provider'
 import { UserSettingsProvider } from '@repo/lib/modules/user/settings/UserSettingsProvider'
 import { VebalLockDataProvider } from '@repo/lib/modules/vebal/lock/VebalLockDataProvider'
+import { WagmiConfigProvider } from '@repo/lib/modules/web3/WagmiConfigProvider'
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
-    <Web3Provider>
-      <ApolloClientProvider>
-        <ApolloGlobalDataProvider>
-          <UserSettingsProvider>
-            <VebalLockDataProvider>
-              <RecentTransactionsProvider>{children}</RecentTransactionsProvider>
-            </VebalLockDataProvider>
-          </UserSettingsProvider>
-        </ApolloGlobalDataProvider>
-      </ApolloClientProvider>
-    </Web3Provider>
+    <WagmiConfigProvider>
+      <Web3Provider>
+        <ApolloClientProvider>
+          <ApolloGlobalDataProvider>
+            <UserSettingsProvider>
+              <VebalLockDataProvider>
+                <RecentTransactionsProvider>{children}</RecentTransactionsProvider>
+              </VebalLockDataProvider>
+            </UserSettingsProvider>
+          </ApolloGlobalDataProvider>
+        </ApolloClientProvider>
+      </Web3Provider>
+    </WagmiConfigProvider>
   )
 }


### PR DESCRIPTION
Only in dev and test (staging) environments: 
1. New option in Rainbow to impersonate with default anvil wallet:
<img width="764" alt="Balancer DeFi Liquidity Pools 2025-02-25 17-37-16" src="https://github.com/user-attachments/assets/d9531dcf-cca6-4c7e-9b34-839abd35557c" />

2. Custom page to impersonate with any address:
https://github.com/user-attachments/assets/c5a5a623-f028-49d8-bb28-19c5b55bbe8b

