### PR TITLE
feat: split Merkl incentives by token

### DIFF
--- a/packages/lib/modules/pool/__mocks__/pool-examples/boosted.ts
+++ b/packages/lib/modules/pool/__mocks__/pool-examples/boosted.ts
@@ -53,6 +53,8 @@ export const boostedCoinshiftUsdcUsdl: PoolExample = {
   poolId: '0x10a04efba5b880e169920fd4348527c64fb29d4d',
   poolChain: GqlChain.Mainnet,
   version: 3,
+  // Freeze pool mock to avoid breaking useAprTooltip tests
+  isFrozen: true,
 }
 
 export const boostedPoolExamples = [

--- a/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
@@ -94,6 +94,7 @@ function BaseAprTooltip({
     yieldBearingTokensAprDisplayed,
     stakingIncentivesAprDisplayed,
     merklIncentivesAprDisplayed,
+    merklTokensDisplayed,
     hasMerklIncentives,
     surplusIncentivesAprDisplayed,
     swapFeesDisplayed,
@@ -205,8 +206,20 @@ function BaseAprTooltip({
           apr={merklIncentivesAprDisplayed}
           displayValueFormatter={usedDisplayValueFormatter}
           title="Merkl.xyz incentives"
-          tooltipText={merklIncentivesTooltipText}
-        />
+        >
+          {merklTokensDisplayed.map(item => {
+            return (
+              <TooltipAprItem
+                {...subitemPopoverAprItemProps}
+                apr={item.apr}
+                displayValueFormatter={usedDisplayValueFormatter}
+                key={`merkl-${item.title}-${item.apr}`}
+                title={item.title}
+                tooltipText={merklIncentivesTooltipText}
+              />
+            )
+          })}
+        </TooltipAprItem>
       ) : null}
       {isCowAmmPool(poolType) && (
         <TooltipAprItem

--- a/packages/lib/shared/hooks/useAprTooltip.spec.tsx
+++ b/packages/lib/shared/hooks/useAprTooltip.spec.tsx
@@ -4,6 +4,8 @@ import { useAprTooltip } from './useAprTooltip'
 import { aprTooltipDataMock } from './_mocks_/aprTooltipDataMock'
 import BigNumber from 'bignumber.js'
 import { GqlPoolAprItem, GqlPoolAprItemType, GqlChain } from '../services/api/generated/graphql'
+import { getApiPoolMock } from '@repo/lib/modules/pool/__mocks__/api-mocks/api-mocks'
+import { boostedCoinshiftUsdcUsdl } from '@repo/lib/modules/pool/__mocks__/pool-examples/boosted'
 
 const defaultNumberFormatter = (value: string) => bn(bn(value).toFixed(4, BigNumber.ROUND_HALF_UP))
 
@@ -102,4 +104,49 @@ it('When the pool has BAL staking incentives (inside the veBAL system)', () => {
   const result = testUseAprTooltip({ aprItems })
 
   expect(result.current.hasVeBalBoost).toBeFalsy()
+})
+
+it('When the pool has multiple Yield bearing token APRs', () => {
+  const pool = getApiPoolMock(boostedCoinshiftUsdcUsdl)
+
+  const result = testUseAprTooltip({ aprItems: pool.dynamicData.aprItems })
+
+  /* APR should tooltip should display:
+    - Yield bearing tokens 3.72%
+                    csUSDL 1.72%
+                    csUSDC 2%
+  */
+  expect(result.current.yieldBearingTokensAprDisplayed).toMatchInlineSnapshot(`"0.0372"`)
+  expect(result.current.yieldBearingTokensDisplayed).toMatchInlineSnapshot(`
+    [
+      {
+        "apr": "0.0172",
+        "title": "csUSDL",
+      },
+      {
+        "apr": "0.02",
+        "title": "csUSDC",
+      },
+    ]
+  `)
+})
+
+it('When the pool has multiple MERKL token incentives', () => {
+  const pool = getApiPoolMock(boostedCoinshiftUsdcUsdl)
+
+  const result = testUseAprTooltip({ aprItems: pool.dynamicData.aprItems })
+
+  /* APR should tooltip should display
+    - Merkl.xyz incentives: 1.80%
+                     MORPHO 1.80%
+  */
+  expect(result.current.merklIncentivesAprDisplayed).toMatchInlineSnapshot(`"0.01778366853303084"`)
+  expect(result.current.merklTokensDisplayed).toMatchInlineSnapshot(`
+    [
+      {
+        "apr": "0.0178",
+        "title": "MORPHO",
+      },
+    ]
+  `)
 })

--- a/packages/lib/shared/hooks/useAprTooltip.ts
+++ b/packages/lib/shared/hooks/useAprTooltip.ts
@@ -18,12 +18,12 @@ prevents this loss (also called LVR), thereby increasing LP returns.`
 export const extraBalTooltipText = `veBAL holders can get an extra boost of up to 2.5x on their staking yield.
 The more veBAL held, the higher the boost.`
 
-export const lockingIncentivesTooltipText = `The protocol revenue share for Liquidity Providers 
+export const lockingIncentivesTooltipText = `The protocol revenue share for Liquidity Providers
                                             with 1-year locked Balancer ve8020 tokens.`
 
-export const votingIncentivesTooltipText = `Vote incentives are offered to veBAL holders who 
-                        participate in weekly gauge voting by third parties on platforms like Hidden Hand. 
-                        Your incentives are determined by your veBAL voting power compared to other voters. 
+export const votingIncentivesTooltipText = `Vote incentives are offered to veBAL holders who
+                        participate in weekly gauge voting by third parties on platforms like Hidden Hand.
+                        Your incentives are determined by your veBAL voting power compared to other voters.
                         The listed APR represents an average rather than a guaranteed return for active participants.`
 
 const stakingBalTooltipText = `LPs who stake earn extra ‘BAL’ liquidity mining incentives. The displayed APR is the base amount that all Stakers in this pool get (determined by weekly gauge voting). In addition, veBAL holders can get an extra boost of up to 2.5x.`
@@ -126,6 +126,15 @@ export function useAprTooltip({
   const hasMerklIncentives = merklIncentives.length > 0
   const merklIncentivesAprDisplayed = calculateSingleIncentivesAprDisplayed(merklIncentives)
 
+  const merklTokens = aprItems.filter(item => {
+    return item.type === GqlPoolAprItemType.Merkl
+  })
+
+  const merklTokensDisplayed = merklTokens.map(item => ({
+    title: item.rewardTokenSymbol || '',
+    apr: numberFormatter(item.apr.toString()),
+  }))
+
   // Surplus incentives
   const surplusIncentives = filterByType(aprItems, GqlPoolAprItemType.Surplus_24H)
   const surplusIncentivesAprDisplayed = calculateSingleIncentivesAprDisplayed(surplusIncentives)
@@ -220,6 +229,7 @@ export function useAprTooltip({
     yieldBearingTokensDisplayed,
     stakingIncentivesDisplayed,
     merklIncentivesAprDisplayed,
+    merklTokensDisplayed,
     hasMerklIncentives,
     surplusIncentivesAprDisplayed,
     votingAprDisplayed,


### PR DESCRIPTION
Example: 
https://mono-test-v3-git-feat-merkelincentivesbytoken-balancer.vercel.app/pools/ethereum/v3/0x10a04efba5b880e169920fd4348527c64fb29d4d

![screenshot_2025-02-27_at_16 14 00](https://github.com/user-attachments/assets/66abf4e4-5916-41de-9d84-9210753a354f)

