### PR TITLE
feat: manage unbalanced add errors when pool is surging

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -117,7 +117,10 @@ function AddLiquidityMainForm() {
 
   const nestedAddLiquidityEnabled = supportsNestedActions(pool) // TODO && !userToggledEscapeHatch
 
-  const isUnbalancedError = isUnbalancedAddError(simulationQuery.error || priceImpactQuery.error)
+  const isUnbalancedError = isUnbalancedAddError(
+    simulationQuery.error || priceImpactQuery.error,
+    pool
+  )
 
   const shouldShowUnbalancedError = isUnbalancedError && !nestedAddLiquidityEnabled
 
@@ -204,6 +207,7 @@ function AddLiquidityMainForm() {
               error={(simulationQuery.error || priceImpactQuery.error) as Error}
               goToProportionalAdds={setProportionalTab}
               isProportionalSupported={!nestedAddLiquidityEnabled}
+              pool={pool}
             />
           )}
           <VStack align="start" spacing="sm" w="full">

--- a/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityFormTabs.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityFormTabs.tsx
@@ -12,7 +12,7 @@ import {
 import { useAddLiquidity } from '../AddLiquidityProvider'
 import { TokenInputsMaybeProportional } from './TokenInputsMaybeProportional'
 import { useCurrency } from '@repo/lib/shared/hooks/useCurrency'
-import { isPoolSurging, isV3Pool } from '../../../pool.helpers'
+import { isV3Pool } from '../../../pool.helpers'
 import { useGetPoolTokensWithActualWeights } from '../../../useGetPoolTokensWithActualWeights'
 import { BalAlert } from '@repo/lib/shared/components/alerts/BalAlert'
 import { BalAlertContent } from '@repo/lib/shared/components/alerts/BalAlertContent'
@@ -74,8 +74,7 @@ export function AddLiquidityFormTabs({
     !isDisabledProportionalTab &&
     bn(pool.dynamicData.totalLiquidity).lt(bn(MIN_LIQUIDITY_FOR_BALANCED_ADD))
 
-  const isDisabledFlexibleTab =
-    requiresProportionalInput(pool) || isBelowMinTvlThreshold || isPoolSurging(pool)
+  const isDisabledFlexibleTab = requiresProportionalInput(pool) || isBelowMinTvlThreshold
 
   function getFlexibleTabTooltipLabel(): string | undefined {
     if (requiresProportionalInput(pool)) {
@@ -83,9 +82,6 @@ export function AddLiquidityFormTabs({
     }
     if (isBelowMinTvlThreshold) {
       return `Liquidity must be added proportionally until the pool TVL is greater than ${toCurrency(MIN_LIQUIDITY_FOR_BALANCED_ADD, { abbreviated: false, noDecimals: true })}`
-    }
-    if (isPoolSurging(pool)) {
-      return 'Liquidity must be added proportionally while the pool is surging'
     }
     return
   }

--- a/packages/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.ts
@@ -13,6 +13,7 @@ import { sentryMetaForAddLiquidityHandler } from '@repo/lib/shared/utils/query-e
 import { HumanTokenAmountWithAddress } from '@repo/lib/modules/tokens/token.types'
 import { useBlockNumber } from 'wagmi'
 import { isInvariantRatioPIErrorMessage } from '@repo/lib/shared/utils/error-filters'
+import { hasStableSurgeHook } from '../../../pool.helpers'
 
 type Params = {
   handler: AddLiquidityHandler
@@ -57,6 +58,7 @@ export function useAddLiquidityPriceImpactQuery({ handler, humanAmountsIn, enabl
       ...params,
       chainId,
       blockNumber,
+      hasStableSurgeHook: hasStableSurgeHook(pool),
     }),
     ...onlyExplicitRefetch,
   })

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -492,3 +492,8 @@ export function isPoolSwapAllowed(pool: Pool, token1: Address, token2: Address):
   }
   return true
 }
+
+export function isPoolSurging(pool: Pool): boolean {
+  //TODO: hardcode surging pool ids until SDK/API provides that information
+  return pool.id === '0x7ab124ec4029316c2a42f713828ddf2a192b36db'
+}

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -282,6 +282,10 @@ export function hasHooks(pool: Pool): boolean {
   return !![pool.hook, ...nestedHooks].filter(Boolean).length
 }
 
+export function hasStableSurgeHook(pool: Pool): boolean {
+  return hasHookType(pool, GqlHookType.StableSurge)
+}
+
 export function hasHookType(pool: Pool, hookType: GqlHookType): boolean {
   const nestedHooks = pool.poolTokens.flatMap(token =>
     token.nestedPool ? token.nestedPool.hook : []
@@ -491,9 +495,4 @@ export function isPoolSwapAllowed(pool: Pool, token1: Address, token2: Address):
     return false
   }
   return true
-}
-
-export function isPoolSurging(pool: Pool): boolean {
-  //TODO: hardcode surging pool ids until SDK/API provides that information
-  return pool.id === '0x7ab124ec4029316c2a42f713828ddf2a192b36db'
 }

--- a/packages/lib/modules/price-impact/price-impact.utils.ts
+++ b/packages/lib/modules/price-impact/price-impact.utils.ts
@@ -15,13 +15,11 @@ import { PriceImpactLevel } from './PriceImpactProvider'
 export function isUnhandledAddPriceImpactError(error: Error | null): boolean {
   if (!error) return false
   if (cannotCalculatePriceImpactError(error)) return false
+  if (isAfterAddHookError(error)) return false
   return true
 }
 
 export function cannotCalculatePriceImpactError(error: Error | null): boolean {
-  // TODO: narrow unknown price impact errors when we have better knowledge about them
-  // const hasUnbalancedAddError = isUnbalancedAddErrorMessage(error)
-
   if (!error) return false
 
   // All ContractFunctionExecutionErrors are shown as unknown price impact
@@ -35,6 +33,10 @@ export function cannotCalculatePriceImpactError(error: Error | null): boolean {
   }
 
   return false
+}
+
+export function isAfterAddHookError(error: Error): boolean {
+  return error.message.includes('AfterAddLiquidityHookFailed')
 }
 
 /**

--- a/packages/lib/shared/app/react-query.provider.tsx
+++ b/packages/lib/shared/app/react-query.provider.tsx
@@ -12,6 +12,7 @@ import { ScopeContext } from '@sentry/core'
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { ReactNode } from 'react'
+import { isPoolSurgingError } from '../utils/error-filters'
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -30,7 +31,10 @@ export const queryClient = new QueryClient({
         sentryContext.extra.tenderlyUrl = getTenderlyUrlFromErrorMessage(error, sentryMeta)
       }
 
-      if (sentryMeta) return captureSentryError(error, sentryMeta as SentryMetadata)
+      if (sentryMeta) {
+        if (shouldIgnoreEdgeCaseError(error, sentryMeta)) return
+        return captureSentryError(error, sentryMeta as SentryMetadata)
+      }
 
       // Unexpected error in query (as expected errors should have query.meta)
       captureError(error, { extra: { queryKey: query.queryKey } })
@@ -63,4 +67,14 @@ export function ReactQueryClientProvider({ children }: { children: ReactNode | R
       {isDev && shouldShowReactQueryDevtools && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
   )
+}
+
+/*
+  There are some edge cases where we need to parse specific sentry metadata params
+ */
+function shouldIgnoreEdgeCaseError(error: Error, sentryMeta: SentryMetadata): boolean {
+  const metaParams = sentryMeta?.context?.extra?.params as Record<string, any>
+  const hasStableSurgeHook = metaParams?.hasStableSurgeHook
+  if (isPoolSurgingError(error.message, hasStableSurgeHook)) return true
+  return false
 }

--- a/packages/lib/shared/utils/query-errors.ts
+++ b/packages/lib/shared/utils/query-errors.ts
@@ -32,7 +32,11 @@ export type SentryMetadata = {
   context?: Partial<ScopeContext>
 }
 
-type AddMetaParams = AddLiquidityParams & { chainId: number; blockNumber?: bigint }
+type AddMetaParams = AddLiquidityParams & {
+  chainId: number
+  blockNumber?: bigint
+  hasStableSurgeHook?: boolean
+}
 export function sentryMetaForAddLiquidityHandler(errorMessage: string, params: AddMetaParams) {
   return createAddHandlerMetadata('HandlerQueryError', errorMessage, params)
 }


### PR DESCRIPTION
We cannot know in advance when a pool with stable surge hook is surging, but we can parse SDK error (that in turn, comes from viem) and:
- Show a proper error
- Avoid sending sentry errors in this cases 

Current example of pool surging: 

[/pools/arbitrum/v3/0xc2b0d1a1b4cdda10185859b5a5c543024c2df869/add-liquidity](https://mono-frontend-v3-git-feat-disableflexiblewhensurging-balancer.vercel.app/pools/arbitrum/v3/0xc2b0d1a1b4cdda10185859b5a5c543024c2df869/add-liquidity)

<img width="633" alt="Screenshot 2025-03-06 at 13 04 40" src="https://github.com/user-attachments/assets/f847401b-b87c-43f1-a571-39aea8b46cd5" />

