### PR TITLE
fix: switch clp price

### DIFF
--- a/packages/lib/modules/eclp/useGetECLPLiquidityProfile.tsx
+++ b/packages/lib/modules/eclp/useGetECLPLiquidityProfile.tsx
@@ -1,5 +1,5 @@
 import { useGetTokenRates } from './useGetTokenRates'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { bn } from '@repo/lib/shared/utils/numbers'
 import { drawLiquidityECLP } from './drawLiquidityECLP'
 import { Pool } from '../pool/pool.types'
@@ -9,6 +9,11 @@ import { formatUnits } from 'viem'
 
 export function useGetECLPLiquidityProfile(pool: Pool) {
   const { data: tokenRates } = useGetTokenRates(pool)
+  const [isReversed, setIsReversed] = useState(false)
+
+  function toggleIsReversed() {
+    setIsReversed(!isReversed)
+  }
 
   const tokenRateScalingFactorString = useMemo(() => {
     if (!tokenRates) return
@@ -16,13 +21,31 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
     return bn(tokenRates[0]).div(bn(tokenRates[1])).toFixed(4)
   }, [tokenRates])
 
-  const data = drawLiquidityECLP(pool, tokenRateScalingFactorString)
+  const liquidityData = useMemo(
+    () => drawLiquidityECLP(pool, tokenRateScalingFactorString),
+    [pool, tokenRateScalingFactorString]
+  )
 
   const params = pool && pool.poolTokens ? destructureRequiredPoolParams(pool, tokenRates) : null
 
-  const poolSpotPrice = params
+  const originalPoolSpotPrice = params
     ? formatUnits(calculateSpotPrice(pool.type as GqlPoolType.Gyroe, params), 18)
     : null
+
+  const poolSpotPrice = useMemo(() => {
+    if (!originalPoolSpotPrice) return null
+    return isReversed ? String(1 / Number(originalPoolSpotPrice)) : originalPoolSpotPrice
+  }, [originalPoolSpotPrice, isReversed])
+
+  const data = useMemo(() => {
+    if (!liquidityData) return null
+
+    const transformedData = liquidityData.map(([price, liquidity]) =>
+      isReversed ? [1 / price, liquidity] : [price, liquidity]
+    )
+
+    return transformedData.sort((a, b) => a[0] - b[0]) as [[number, number]]
+  }, [liquidityData, isReversed])
 
   const xMin = useMemo(() => (data ? Math.min(...data.map(([x]) => x)) : 0), [data])
   const xMax = useMemo(() => (data ? Math.max(...data.map(([x]) => x)) : 0), [data])
@@ -45,5 +68,7 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
     xMin,
     xMax,
     yMax,
+    isReversed,
+    toggleIsReversed,
   }
 }

--- a/packages/lib/modules/eclp/useGetECLPLiquidityProfile.tsx
+++ b/packages/lib/modules/eclp/useGetECLPLiquidityProfile.tsx
@@ -8,7 +8,7 @@ import { GqlPoolType } from '@repo/lib/shared/services/api/generated/graphql'
 import { formatUnits } from 'viem'
 
 export function useGetECLPLiquidityProfile(pool: Pool) {
-  const { data: tokenRates } = useGetTokenRates(pool)
+  const { data: tokenRates, isLoading } = useGetTokenRates(pool)
   const [isReversed, setIsReversed] = useState(false)
 
   function toggleIsReversed() {
@@ -34,7 +34,7 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
 
   const poolSpotPrice = useMemo(() => {
     if (!originalPoolSpotPrice) return null
-    return isReversed ? String(1 / Number(originalPoolSpotPrice)) : originalPoolSpotPrice
+    return isReversed ? bn(1).div(bn(originalPoolSpotPrice)).toString() : originalPoolSpotPrice
   }, [originalPoolSpotPrice, isReversed])
 
   const data = useMemo(() => {
@@ -70,5 +70,6 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
     yMax,
     isReversed,
     toggleIsReversed,
+    isLoading,
   }
 }

--- a/packages/lib/modules/eclp/useGetECLPLiquidityProfile.tsx
+++ b/packages/lib/modules/eclp/useGetECLPLiquidityProfile.tsx
@@ -53,7 +53,7 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
   const yMax = useMemo(() => (data ? Math.max(...data.map(([, y]) => y)) : 0), [data])
 
   const poolIsInRange = useMemo(() => {
-    const margin = 0.00000001 // if spot price is within the margin on both sides it's considered out of range
+    const margin = 0.000001 // if spot price is within the margin on both sides it's considered out of range
 
     return (
       bn(poolSpotPrice || 0).gt(xMin * (1 + margin)) &&

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolCharts.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolCharts.tsx
@@ -2,11 +2,13 @@
 import {
   Box,
   BoxProps,
+  Button,
   Card,
   CardProps,
   Flex,
   HStack,
   Heading,
+  Icon,
   Skeleton,
   Stack,
   Text,
@@ -25,6 +27,7 @@ import { GroupBase, OptionBase, Select, SingleValue } from 'chakra-react-select'
 import { getSelectStyles } from '@repo/lib/shared/services/chakra/custom/chakra-react-select'
 import { NoisyCard } from '@repo/lib/shared/components/containers/NoisyCard'
 import { CLPBadge } from './CLPBadge'
+import { Repeat } from 'react-feather'
 
 type PeriodOption = PoolChartPeriod & OptionBase
 
@@ -82,6 +85,7 @@ export function PoolCharts({ ...props }: CardProps) {
     chartValueSum,
     hasChartData,
     poolIsInRange,
+    toggleIsReversed,
   } = usePoolCharts()
 
   function getActiveTabLabel() {
@@ -138,7 +142,7 @@ export function PoolCharts({ ...props }: CardProps) {
                   )}
                 </VStack>
               </Stack>
-              <Box h="full" onMouseLeave={handleMouseLeave} w="full">
+              <Box h="full" onMouseLeave={handleMouseLeave} position="relative" w="full">
                 <ReactECharts
                   onEvents={{
                     updateAxisPointer: handleAxisMoved,
@@ -146,6 +150,21 @@ export function PoolCharts({ ...props }: CardProps) {
                   option={options}
                   style={{ height: '100%', width: '100%' }}
                 />
+                <Button
+                  bottom={0}
+                  fontSize="xs"
+                  fontWeight="medium"
+                  onClick={toggleIsReversed}
+                  position="absolute"
+                  px={2}
+                  py={1}
+                  right={2}
+                  size="xs"
+                  variant="primary"
+                  zIndex={1}
+                >
+                  <Icon as={Repeat} />
+                </Button>
               </Box>
             </VStack>
           </NoisyCard>

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolCharts.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolCharts.tsx
@@ -171,7 +171,7 @@ export function PoolCharts({ ...props }: CardProps) {
             </VStack>
           </NoisyCard>
         ) : (
-          <Flex alignItems="center" h="full">
+          <Flex align="center" h="full" justify="center" w="full">
             <Text fontSize="2xl" p="lg" variant="secondary">
               Not enough data
             </Text>

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolCharts.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolCharts.tsx
@@ -150,21 +150,23 @@ export function PoolCharts({ ...props }: CardProps) {
                   option={options}
                   style={{ height: '100%', width: '100%' }}
                 />
-                <Button
-                  bottom={0}
-                  fontSize="xs"
-                  fontWeight="medium"
-                  onClick={toggleIsReversed}
-                  position="absolute"
-                  px={2}
-                  py={1}
-                  right={2}
-                  size="xs"
-                  variant="primary"
-                  zIndex={1}
-                >
-                  <Icon as={Repeat} />
-                </Button>
+                {activeTab.value === PoolChartTab.LIQUIDITY_PROFILE && (
+                  <Button
+                    bottom={0}
+                    fontSize="xs"
+                    fontWeight="medium"
+                    onClick={toggleIsReversed}
+                    position="absolute"
+                    px={2}
+                    py={1}
+                    right={2}
+                    size="xs"
+                    variant="primary"
+                    zIndex={1}
+                  >
+                    <Icon as={Repeat} />
+                  </Button>
+                )}
               </Box>
             </VStack>
           </NoisyCard>

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/useEclpPoolChart.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/useEclpPoolChart.tsx
@@ -423,7 +423,7 @@ export function useEclpPoolChart() {
 
   return {
     options,
-    hasChartData: !!data,
+    hasChartData: data?.length,
     poolIsInRange,
     toggleIsReversed,
   }

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/useEclpPoolChart.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/useEclpPoolChart.tsx
@@ -9,8 +9,17 @@ import { useMemo } from 'react'
 
 export function useEclpPoolChart() {
   const { pool } = usePool()
-  const { data, poolSpotPrice, poolIsInRange, xMin, xMax, yMax, isReversed, toggleIsReversed } =
-    useGetECLPLiquidityProfile(pool)
+  const {
+    data,
+    poolSpotPrice,
+    poolIsInRange,
+    xMin,
+    xMax,
+    yMax,
+    isReversed,
+    toggleIsReversed,
+    isLoading,
+  } = useGetECLPLiquidityProfile(pool)
   const { theme: nextTheme } = useNextTheme()
   const theme = useChakraTheme()
   const { toCurrency } = useCurrency()
@@ -426,5 +435,6 @@ export function useEclpPoolChart() {
     hasChartData: data?.length,
     poolIsInRange,
     toggleIsReversed,
+    isLoading,
   }
 }

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/useEclpPoolChart.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/useEclpPoolChart.tsx
@@ -6,11 +6,11 @@ import { useTheme as useNextTheme } from 'next-themes'
 import { getDefaultPoolChartOptions } from './usePoolCharts'
 import { useCurrency } from '@repo/lib/shared/hooks/useCurrency'
 import { useMemo } from 'react'
-import { GqlPoolGyro, GqlPoolType } from '@repo/lib/shared/services/api/generated/graphql'
 
 export function useEclpPoolChart() {
   const { pool } = usePool()
-  const { data, poolSpotPrice, poolIsInRange, xMin, xMax, yMax } = useGetECLPLiquidityProfile(pool)
+  const { data, poolSpotPrice, poolIsInRange, xMin, xMax, yMax, isReversed, toggleIsReversed } =
+    useGetECLPLiquidityProfile(pool)
   const { theme: nextTheme } = useNextTheme()
   const theme = useChakraTheme()
   const { toCurrency } = useCurrency()
@@ -18,17 +18,14 @@ export function useEclpPoolChart() {
   const defaultChartOptions = getDefaultPoolChartOptions(toCurrency, nextTheme as ColorMode, theme)
 
   const tokens = useMemo(() => {
-    if (pool.type !== GqlPoolType.Gyroe) return ''
-
     const poolTokens = pool.poolTokens.map(token => token.symbol)
-    const gyroPool = pool as GqlPoolGyro
 
-    if (bn(gyroPool.alpha).lt(gyroPool.beta)) {
-      return poolTokens.join('/')
-    } else {
+    if (isReversed) {
       return poolTokens.reverse().join('/')
+    } else {
+      return poolTokens.join('/')
     }
-  }, [pool])
+  }, [pool, isReversed])
 
   const secondaryFontColor = theme.semanticTokens.colors.font.secondary.default
 
@@ -85,7 +82,7 @@ export function useEclpPoolChart() {
         nameTextStyle: {
           align: 'right',
           verticalAlign: 'bottom',
-          padding: [0, 0, -54, 0],
+          padding: [0, 40, -54, 0],
           color: theme.colors.gray[400],
         },
         min: xMin - 0.1 * (xMax - xMin),
@@ -428,5 +425,6 @@ export function useEclpPoolChart() {
     options,
     hasChartData: !!data,
     poolIsInRange,
+    toggleIsReversed,
   }
 }

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/usePoolCharts.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/usePoolCharts.tsx
@@ -273,8 +273,6 @@ export function usePoolCharts() {
     activePeriod.value
   )
 
-  const isLoading = isLoadingSnapshots
-
   const chartValueSum = useMemo(() => {
     if (!data?.snapshots) return null
 
@@ -525,7 +523,10 @@ export function usePoolCharts() {
     hasChartData: hasEclpChartData,
     poolIsInRange,
     toggleIsReversed,
+    isLoading: isLoadingEclpData,
   } = useEclpPoolChart()
+
+  const isLoading = isLoadingSnapshots || isLoadingEclpData
 
   const options = useMemo(() => {
     const activeTabOptions = poolChartTypeOptions[activeTab.value]

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/usePoolCharts.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/usePoolCharts.tsx
@@ -524,6 +524,7 @@ export function usePoolCharts() {
     options: eclpChartOptions,
     hasChartData: hasEclpChartData,
     poolIsInRange,
+    toggleIsReversed,
   } = useEclpPoolChart()
 
   const options = useMemo(() => {
@@ -601,5 +602,6 @@ export function usePoolCharts() {
     chartValueSum,
     hasChartData: !!chartData.length || hasEclpChartData,
     poolIsInRange,
+    toggleIsReversed,
   }
 }

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -150,6 +150,7 @@ function boostFormat(val: Numberish): string {
 }
 
 function gyroPriceFormat(val: Numberish): string {
+  if (bn(val).lt(0.001)) return numeral(val.toString()).format('0.00000')
   if (bn(val).lt(10)) return numeral(val.toString()).format('0.0000')
   if (bn(val).lt(100)) return numeral(val.toString()).format('0.00')
 


### PR DESCRIPTION
![reverse](https://github.com/user-attachments/assets/f2109321-27b0-4957-bf44-dd7fa1816134)

- invert price button
- styling updates
- no chart data fix
- isloading update
- increase margin slightly for `poolIsInRange` check