### PR TITLE
Adjust the chart min/max when the activity type is toggled

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolActivity/usePoolActivity.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivity/usePoolActivity.tsx
@@ -76,21 +76,6 @@ function _usePoolActivity() {
 
   const count = response?.poolEvents.length ?? 0
 
-  const minDate = useMemo(() => {
-    if (!response) return 0
-    return Math.min(...response.poolEvents.map(event => event.timestamp))
-  }, [response])
-
-  const maxDate = useMemo(() => {
-    if (!response) return 0
-    return Math.max(...response.poolEvents.map(event => event.timestamp))
-  }, [response])
-
-  const maxYAxisValue = useMemo(() => {
-    if (!response) return 0
-    return Math.max(...response.poolEvents.map(event => event.valueUSD))
-  }, [response])
-
   const poolActivityData = useMemo(() => {
     if (!response) return { adds: [], removes: [], swaps: [] }
     const { poolEvents: events } = response
@@ -200,6 +185,26 @@ function _usePoolActivity() {
       ...(isAllOrSwaps ? poolActivityData.swaps : []),
     ]
   }, [poolActivityData, isAllOrAdds, isAllOrRemoves, isAllOrSwaps])
+
+  const maxYAxisValue = useMemo(() => {
+    if (poolEvents.length === 0) return 0
+
+    return Math.max(
+      ...poolEvents.map(event => {
+        return parseFloat(event[2].usdValue)
+      })
+    )
+  }, [poolEvents])
+
+  const minDate = useMemo(() => {
+    if (poolEvents.length === 0) return 0
+    return Math.min(...poolEvents.map(event => event[0]))
+  }, [poolEvents])
+
+  const maxDate = useMemo(() => {
+    if (poolEvents.length === 0) return 0
+    return Math.max(...poolEvents.map(event => event[0]))
+  }, [poolEvents])
 
   const sortedPoolEvents = useMemo(() => {
     const sortedEvents = sortPoolEvents(poolEvents, sortingBy, sorting)


### PR DESCRIPTION
Fix the activity chart to adjust the min/max values when you toggle the activity type. Currently it does not, so you end up with situations where all swaps are clumped together because there is a big add that is significantly larger than any swap

before:
![Screenshot 2025-03-10 at 10 05 34](https://github.com/user-attachments/assets/39094ff6-113a-49ad-b728-941ae2a03cac)

after:
![Screenshot 2025-03-10 at 10 06 14](https://github.com/user-attachments/assets/5012fb18-66ff-473d-950e-f72cdb192189)

You can see below that the pool has a very large add:
![Screenshot 2025-03-10 at 10 06 19](https://github.com/user-attachments/assets/4125d401-8eb2-4ca5-a9eb-c5c32a0a20ca)
