### PR TITLE
fix: transaction button loading label for smart accounts

### DIFF
--- a/packages/lib/modules/transactions/transaction-steps/TransactionStepButton.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/TransactionStepButton.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react'
 import { ensureError } from '@repo/lib/shared/utils/errors'
 import { LabelWithIcon } from '@repo/lib/shared/components/btns/button-group/LabelWithIcon'
 import { getTransactionButtonLabel } from './transaction-button.helpers'
+import { useIsSafeAccount } from '../../web3/safe.hooks'
 
 interface Props {
   step: { labels: TransactionLabels } & ManagedResult
@@ -21,6 +22,7 @@ export function TransactionStepButton({ step }: Props) {
   const { chainId, simulation, labels, executeAsync } = step
   const [executionError, setExecutionError] = useState<Error>()
   const { isConnected } = useUserAccount()
+  const isSafeAccount = useIsSafeAccount()
   const { shouldChangeNetwork } = useChainSwitch(chainId)
   const isTransactButtonVisible = isConnected
   const transactionState = getTransactionState(step)
@@ -52,7 +54,7 @@ export function TransactionStepButton({ step }: Props) {
 
   function getButtonLabel() {
     if (executionError) return labels.init
-    return getTransactionButtonLabel({ transactionState, labels })
+    return getTransactionButtonLabel({ transactionState, labels, isSmartAccount: isSafeAccount })
   }
 
   return (

--- a/packages/lib/modules/transactions/transaction-steps/safe/TransactionBatchButton.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/safe/TransactionBatchButton.tsx
@@ -140,6 +140,7 @@ export function TransactionBatchButton({
     return getTransactionButtonLabel({
       transactionState: mapSafeTxStatusToBalancerTxState(safeTxStatus),
       labels,
+      isSmartAccount: true,
     })
   }
 

--- a/packages/lib/modules/transactions/transaction-steps/transaction-button.helpers.ts
+++ b/packages/lib/modules/transactions/transaction-steps/transaction-button.helpers.ts
@@ -3,8 +3,13 @@ import { TransactionLabels, TransactionState } from './lib'
 type Props = {
   transactionState: TransactionState
   labels: TransactionLabels
+  isSmartAccount?: boolean
 }
-export function getTransactionButtonLabel({ transactionState, labels }: Props) {
+export function getTransactionButtonLabel({
+  transactionState,
+  labels,
+  isSmartAccount = false,
+}: Props) {
   // sensible defaults for loading / confirm if not provided
   const relevantLabel = labels[transactionState as keyof typeof labels]
   if (!relevantLabel) {
@@ -12,7 +17,7 @@ export function getTransactionButtonLabel({ transactionState, labels }: Props) {
       case TransactionState.Preparing:
         return 'Preparing'
       case TransactionState.Loading:
-        return 'Confirm in smart account wallet'
+        return isSmartAccount ? 'Confirm in smart account wallet' : 'Confirm in wallet'
       case TransactionState.Confirming:
         return 'Confirming transaction'
       case TransactionState.Error:


### PR DESCRIPTION
We were showing a wrong smart account related loading label when using an EOA.