### PR TITLE
[#742] add exception for Sepolia when blocking pool add liquidity

### DIFF
--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -321,6 +321,8 @@ export function getPoolAddBlockedReason(pool: Pool, metadata?: PoolMetadata): st
   // we allow the metadata to override the default behavior
   if (metadata?.allowAddLiquidity === true) return []
 
+  if (pool.chain === GqlChain.Sepolia) return []
+
   const reasons: string[] = []
 
   if (isV3Pool(pool) && shouldBlockV3PoolAdds) reasons.push('Adds are blocked for all V3 pools')


### PR DESCRIPTION
On https://github.com/balancer/frontend-monorepo/pull/727 a bug was introduced, Sepolia pools that should be exempted of add liquidity blocks were able to be blocked. These changes fix that.