### PR TITLE
fix: token image optimization

### DIFF
--- a/packages/lib/modules/tokens/TokenRow/TokenRow.tsx
+++ b/packages/lib/modules/tokens/TokenRow/TokenRow.tsx
@@ -85,6 +85,8 @@ function TokenInfo({
         <TokenIcon
           address={address}
           alt={token?.symbol || address}
+          bg="background.level2"
+          borderRadius="md"
           chain={chain}
           logoURI={logoURI}
           overflow="visible"

--- a/packages/lib/modules/tokens/TokenRow/TokenRow.tsx
+++ b/packages/lib/modules/tokens/TokenRow/TokenRow.tsx
@@ -87,6 +87,7 @@ function TokenInfo({
           alt={token?.symbol || address}
           chain={chain}
           logoURI={logoURI}
+          overflow="visible"
           size={iconSize}
         />
       )}


### PR DESCRIPTION
- allow overflow for logo-in-logo images
- round square images a bit