### PR TITLE
fix: remove parser for EURe and balancer router removes

### DIFF
--- a/packages/lib/modules/transactions/transaction-steps/receipts/receipt-parsers.ts
+++ b/packages/lib/modules/transactions/transaction-steps/receipts/receipt-parsers.ts
@@ -48,7 +48,7 @@ export function parseAddLiquidityReceipt({
   const receivedBptUnits = formatUnits(receivedBptAmount || 0n, BPT_DECIMALS)
 
   return {
-    sentTokens: filterEdgeCases(sentTokens),
+    sentTokens: filterEdgeCases(sentTokens, chain),
     receivedBptUnits,
   }
 }
@@ -81,7 +81,7 @@ export function parseRemoveLiquidityReceipt({
   const sentBptUnits = formatUnits(sentBptAmount || 0n, BPT_DECIMALS)
 
   return {
-    receivedTokens: filterEdgeCases(receivedTokens),
+    receivedTokens: filterEdgeCases(receivedTokens, chain),
     sentBptUnits,
   }
 }
@@ -237,15 +237,18 @@ function getIncomingLogsLstWithdrawn(logs: Log[], userAddress?: Address) {
   return test[0]?.args?.amountAssets
 }
 
-function filterEdgeCases(tokens: HumanTokenAmount[]) {
+function filterEdgeCases(tokens: HumanTokenAmount[], chain: GqlChain) {
   // ERC-20: Monerium EURe (EURe)
-  const erc20EURe = '0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430'
-
+  const getERC20EUReAddress = () => {
+    if (chain === GqlChain.Gnosis) return '0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430'
+    if (chain === GqlChain.Polygon) return '0xE0aEa583266584DafBB3f9C3211d5588c73fEa8d'
+    return '0x39b8B6385416f4cA36a20319F70D28621895279D' // mainnet
+  }
   /*
       TODO:
         properly implement this filter getting this info from LiquidityAdded/Removed event instead of Transfers
         They use frontend (erc20) <> controller (upgradable proxy) setup - where calls to erc20 are forwarded to the controller.
         Both emit events, which explains the duplicates.
     */
-  return tokens.filter(t => !isSameAddress(t.tokenAddress, erc20EURe))
+  return tokens.filter(t => !isSameAddress(t.tokenAddress, getERC20EUReAddress()))
 }

--- a/packages/lib/modules/transactions/transaction-steps/receipts/receipt-parsers.ts
+++ b/packages/lib/modules/transactions/transaction-steps/receipts/receipt-parsers.ts
@@ -47,17 +47,8 @@ export function parseAddLiquidityReceipt({
   const receivedBptAmount = getIncomingLogs(receiptLogs, userAddress)?.[0]?.args?.value
   const receivedBptUnits = formatUnits(receivedBptAmount || 0n, BPT_DECIMALS)
 
-  // ERC-20: Monerium EURe (EURe)
-  const erc20EURe = '0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430'
-
   return {
-    /*
-      TODO:
-        properly implement this filter getting this info from LiquidityAdded/Removed event instead of Transfers
-        They use frontend (erc20) <> controller (upgradable proxy) setup - where calls to erc20 are forwarded to the controller.
-        Both emit events, which explains the duplicates.
-    */
-    sentTokens: sentTokens.filter(t => !isSameAddress(t.tokenAddress, erc20EURe)),
+    sentTokens: filterEdgeCases(sentTokens),
     receivedBptUnits,
   }
 }
@@ -90,7 +81,7 @@ export function parseRemoveLiquidityReceipt({
   const sentBptUnits = formatUnits(sentBptAmount || 0n, BPT_DECIMALS)
 
   return {
-    receivedTokens,
+    receivedTokens: filterEdgeCases(receivedTokens),
     sentBptUnits,
   }
 }
@@ -205,7 +196,10 @@ function getIncomingWithdrawals(
 
   const from =
     protocolVersion === 3
-      ? networkConfig.contracts.balancer.batchRouter
+      ? [
+          networkConfig.contracts.balancer.batchRouter,
+          networkConfig.contracts.balancer.router,
+        ].filter(address => address !== undefined)
       : networkConfig.contracts.balancer.vaultV2
 
   // Catches when the wNativeAsset is withdrawn from the vault, assumption is
@@ -241,4 +235,17 @@ function getIncomingLogsLstWithdrawn(logs: Log[], userAddress?: Address) {
   })
 
   return test[0]?.args?.amountAssets
+}
+
+function filterEdgeCases(tokens: HumanTokenAmount[]) {
+  // ERC-20: Monerium EURe (EURe)
+  const erc20EURe = '0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430'
+
+  /*
+      TODO:
+        properly implement this filter getting this info from LiquidityAdded/Removed event instead of Transfers
+        They use frontend (erc20) <> controller (upgradable proxy) setup - where calls to erc20 are forwarded to the controller.
+        Both emit events, which explains the duplicates.
+    */
+  return tokens.filter(t => !isSameAddress(t.tokenAddress, erc20EURe))
 }


### PR DESCRIPTION
Fixed 2 issues found in the last QA round: 

1. [stable pool, remove single token] if remove 100% of 1 token, there is an empty token displayed on the Confirm screen (due to the Monerium EURe implementation):

![image (2)](https://github.com/user-attachments/assets/e7958d19-556d-463e-8892-9b445633863c)

7. [Sepolia, [stable pool](https://mono-test-v3-git-feat-safebatchadds-balancer.vercel.app/pools/sepolia/v3/0x64bb1613459c6790cd6c94272dc9d09384d955c9), remove  liquidity] I’ve removed liquidity (USDC and ETH), but the confirm modal shows USDC only.

<img width="696" alt="Screenshot 2025-03-19 at 18 26 42" src="https://github.com/user-attachments/assets/ce46ec55-8272-4906-8665-1b05a4c5ee6b" />

