### PR TITLE
fix: simplify stable surge error handling

### DIFF
--- a/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -240,6 +240,7 @@ export function RemoveLiquidityForm() {
             </VStack>
             <RemoveSimulationError
               goToProportionalRemoves={setProportionalTab}
+              priceImpactQuery={priceImpactQuery}
               simulationQuery={simulationQuery}
             />
             <TooltipWithTouch label={isDisabled ? disabledReason : ''}>

--- a/packages/lib/shared/components/errors/RemoveSimulationError.tsx
+++ b/packages/lib/shared/components/errors/RemoveSimulationError.tsx
@@ -8,17 +8,25 @@ import { ErrorAlert } from './ErrorAlert'
 import { GenericError } from './GenericError'
 
 type Props = {
+  priceImpactQuery: {
+    isError: boolean
+    error: unknown
+  }
   simulationQuery: {
     isError: boolean
     error: unknown
   }
   goToProportionalRemoves: () => void
 }
-export function RemoveSimulationError({ simulationQuery, goToProportionalRemoves }: Props) {
+export function RemoveSimulationError({
+  priceImpactQuery,
+  simulationQuery,
+  goToProportionalRemoves,
+}: Props) {
   const { pool } = usePool()
-  if (!simulationQuery.isError) return
+  if (!simulationQuery.isError && !priceImpactQuery.error) return
 
-  const error = ensureError(simulationQuery.error)
+  const error = ensureError(simulationQuery.error || priceImpactQuery.error)
 
   function goToProportionalMode() {
     goToProportionalRemoves()

--- a/packages/lib/shared/utils/error-filters.ts
+++ b/packages/lib/shared/utils/error-filters.ts
@@ -114,18 +114,10 @@ export function isPoolSurgingError(errorMessage: string, hasStableSurgeHook: boo
 
 function isAfterAddUnbalancedHookError(errorMessage: string): boolean {
   if (!errorMessage) return false
-  return (
-    errorMessage.includes(
-      'The contract function "queryAddLiquidityUnbalancedToERC4626Pool" reverted'
-    ) && errorMessage.includes('AfterAddLiquidityHookFailed()')
-  )
+  return errorMessage.includes('AfterAddLiquidityHookFailed()')
 }
 
 function isSingleRemoveHookError(errorMessage: string): boolean {
   if (!errorMessage) return false
-  return (
-    errorMessage.includes(
-      'The contract function "queryRemoveLiquiditySingleTokenExactIn" reverted'
-    ) && errorMessage.includes('AfterRemoveLiquidityHookFailed()')
-  )
+  return errorMessage.includes('AfterRemoveLiquidityHookFailed()')
 }


### PR DESCRIPTION
Relax `isAfterAddUnbalancedHookError` and `isSingleRemoveHookError` conditions to ensure that we don't miss any surging error. 