### PR TITLE
fix: handle allowance refetching delay

### DIFF
--- a/packages/lib/config/networks/sepolia.ts
+++ b/packages/lib/config/networks/sepolia.ts
@@ -32,6 +32,9 @@ const networkConfig: NetworkConfig = {
       symbol: 'ETH',
       decimals: 18,
     },
+    doubleApprovalRequired: [
+      '0x6bf294b80c7d8dc72dee762af5d01260b756a051', // USDT
+    ],
     defaultSwapTokens: {
       tokenIn: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
     },

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -174,9 +174,9 @@ export function useTokenApprovalSteps({
         batchableTxCall: isTxEnabled ? buildBatchableTxCall({ tokenAddress, args }) : undefined,
         onSuccess: async () => {
           const newAllowances = await tokenAllowances.refetchAllowances()
+          // Ignore check if allowances are refetching
           if (newAllowances.isRefetching) return
           const updatedTokenAllowance = newAllowances.allowanceFor(tokenAddress)
-          // Ignore check if allowances are refetching
           const errors = checkEdgeCaseErrors(updatedTokenAllowance)
           if (errors.length > 0) throw new ErrorWithCauses('Edge case errors', errors)
         },

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -8,7 +8,7 @@ import { Address, encodeFunctionData, erc20Abi } from 'viem'
 import { ManagedErc20TransactionButton } from '../../transactions/transaction-steps/TransactionButton'
 import { TransactionStep, TxCall } from '../../transactions/transaction-steps/lib'
 import { ManagedErc20TransactionInput } from '../../web3/contracts/useManagedErc20Transaction'
-import { REFETCHING_ALLOWANCES_BN, useTokenAllowances } from '../../web3/useTokenAllowances'
+import { useTokenAllowances } from '../../web3/useTokenAllowances'
 import { useUserAccount } from '../../web3/UserAccountProvider'
 import { useTokens } from '../TokensProvider'
 import { ApprovalAction, buildTokenApprovalLabels } from './approval-labels'
@@ -173,10 +173,10 @@ export function useTokenApprovalSteps({
         renderAction: () => <ManagedErc20TransactionButton id={id} key={id} {...props} />,
         batchableTxCall: isTxEnabled ? buildBatchableTxCall({ tokenAddress, args }) : undefined,
         onSuccess: async () => {
-          const newAllowanceFor = await tokenAllowances.refetchAllowances()
-          const updatedTokenAllowance = newAllowanceFor(tokenAddress)
+          const newAllowances = await tokenAllowances.refetchAllowances()
+          if (newAllowances.isRefetching) return
+          const updatedTokenAllowance = newAllowances.allowanceFor(tokenAddress)
           // Ignore check if allowances are refetching
-          if (updatedTokenAllowance === REFETCHING_ALLOWANCES_BN) return
           const errors = checkEdgeCaseErrors(updatedTokenAllowance)
           if (errors.length > 0) throw new ErrorWithCauses('Edge case errors', errors)
         },

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -19,7 +19,6 @@ import {
   isTheApprovedAmountEnough,
 } from './approval-rules'
 import { requiresDoubleApproval } from '../token.helpers'
-import { sleep } from '@repo/lib/shared/utils/sleep'
 import { ErrorWithCauses } from '@repo/lib/shared/utils/errors'
 
 export type Params = {
@@ -94,14 +93,6 @@ export function useTokenApprovalSteps({
       const isApprovingZeroForDoubleApproval =
         requiresDoubleApproval(chain, tokenAddress) && requiredRawAmount === 0n
       const id = isApprovingZeroForDoubleApproval ? `${tokenAddress}-0` : tokenAddress
-
-      console.log({
-        requiredRawAmount,
-        requestedRawAmount,
-        isApprovingZeroForDoubleApproval,
-        id,
-        allowanceFor: tokenAllowances.allowanceFor(tokenAddress),
-      })
 
       const token = getToken(tokenAddress, chain)
 

--- a/packages/lib/modules/web3/useTokenAllowances.tsx
+++ b/packages/lib/modules/web3/useTokenAllowances.tsx
@@ -20,8 +20,6 @@ type Props = {
 
 type AllowanceContracts = ReadContractParameters<Erc20Abi, 'allowance'> & { chainId: number }
 
-export const REFETCHING_ALLOWANCES_BN = -1n
-
 export function useTokenAllowances({
   chainId,
   userAddress,
@@ -66,14 +64,12 @@ export function useTokenAllowances({
     const allowances = await refetch()
     if (!allowances.data) throw new Error('Failed to refetch allowances')
 
-    if (allowances.isRefetching) {
-      // While the refetch is in progress, we return REFETCHING_ALLOWANCES (-1n) so that consumers are aware
-      return () => REFETCHING_ALLOWANCES_BN
-    }
-
     const allowancesByTokenAddress = zipObject(tokenAddresses, allowances.data)
-    return (tokenAddress: Address) => {
-      return allowancesByTokenAddress[tokenAddress] ?? 0n
+    return {
+      isRefetching: allowances.isRefetching,
+      allowanceFor: (tokenAddress: Address) => {
+        return allowancesByTokenAddress[tokenAddress] ?? 0n
+      },
     }
   }
 

--- a/packages/lib/modules/web3/useTokenAllowances.tsx
+++ b/packages/lib/modules/web3/useTokenAllowances.tsx
@@ -20,6 +20,8 @@ type Props = {
 
 type AllowanceContracts = ReadContractParameters<Erc20Abi, 'allowance'> & { chainId: number }
 
+export const REFETCHING_ALLOWANCES_BN = -1n
+
 export function useTokenAllowances({
   chainId,
   userAddress,
@@ -60,12 +62,27 @@ export function useTokenAllowances({
     [allowancesByTokenAddress]
   )
 
+  async function refetchAllowances() {
+    const allowances = await refetch()
+    if (!allowances.data) throw new Error('Failed to refetch allowances')
+
+    if (allowances.isRefetching) {
+      // While the refetch is in progress, we return REFETCHING_ALLOWANCES (-1n) so that consumers are aware
+      return () => REFETCHING_ALLOWANCES_BN
+    }
+
+    const allowancesByTokenAddress = zipObject(tokenAddresses, allowances.data)
+    return (tokenAddress: Address) => {
+      return allowancesByTokenAddress[tokenAddress] ?? 0n
+    }
+  }
+
   return {
     isAllowancesLoading: isLoading,
     isAllowancesRefetching: isRefetching,
     allowances: allowancesByTokenAddress,
     spenderAddress,
-    refetchAllowances: refetch,
+    refetchAllowances,
     allowanceFor,
   }
 }


### PR DESCRIPTION
Expose `isRefetching` to indicate that allowance refetch is still in progress so that consumers wait more. 

This was affecting to `onSuccess` callback using refetch allowances before they had finished.