### PR TITLE
fix: avoid mapPoolType for V3 pools

### DIFF
--- a/packages/lib/modules/pool/actions/LiquidityActionHelpers.spec.ts
+++ b/packages/lib/modules/pool/actions/LiquidityActionHelpers.spec.ts
@@ -37,7 +37,9 @@ import {
   roundDecimals,
   shouldUseRecoveryRemoveLiquidity,
   supportsNestedActions,
+  toPoolState,
 } from './LiquidityActionHelpers'
+import { GqlPoolType } from '@repo/lib/shared/services/api/generated/graphql'
 
 describe('Calculates toInputAmounts from allPoolTokens', () => {
   it('for v2 weighted pool with no nested tokens', () => {
@@ -246,7 +248,7 @@ describe('Liquidity helpers for V3 Boosted pools', async () => {
           weight: null,
         },
       ],
-      type: 'Stable',
+      type: 'STABLE',
     })
   })
 })
@@ -471,7 +473,7 @@ test('boostedPoolState pool state for V3 BOOSTED POOL', async () => {
         weight: null,
       },
     ],
-    type: 'Stable',
+    type: 'STABLE',
   })
 })
 
@@ -586,7 +588,7 @@ describe('Liquidity helpers for GNOSIS V3 Boosted pools', async () => {
           weight: '0.5',
         },
       ],
-      type: 'Weighted',
+      type: 'WEIGHTED',
     })
   })
 })
@@ -850,4 +852,14 @@ test('trimDecimals', () => {
       tokenAddress: wETHAddress,
     },
   ])
+})
+
+test('toPoolState keeps pool type when pool is V3 (it does not call mapPoolType)', () => {
+  // We don't need a real QuantAMM mock as changing the type is enough
+  const quantAMMPool = {
+    ...getApiPoolMock(usdcUsdtAaveBoosted),
+    type: GqlPoolType.QuantAmmWeighted,
+  }
+
+  expect(toPoolState(quantAMMPool).type).toEqual(GqlPoolType.QuantAmmWeighted)
 })

--- a/packages/lib/modules/pool/actions/LiquidityActionHelpers.ts
+++ b/packages/lib/modules/pool/actions/LiquidityActionHelpers.ts
@@ -105,7 +105,7 @@ export class LiquidityActionHelpers {
       id: this.pool.id as Hex,
       address: this.pool.address as Address,
       protocolVersion: 3,
-      type: mapPoolType(this.pool.type),
+      type: this.pool.type,
       tokens: poolTokensWithUnderlyings,
       totalShares: this.pool.dynamicData.totalShares as HumanAmount,
     }
@@ -296,7 +296,8 @@ export function toPoolState(pool: Pool): PoolState {
     address: pool.address as Address,
     // Destruct to avoid errors when the SDK tries to mutate the poolTokens (read-only from GraphQL)
     tokens: [...pool.poolTokens] as MinimalToken[],
-    type: mapPoolType(pool.type),
+    // v3 pools do not require pool type mapping
+    type: isV3Pool(pool) ? pool.type : mapPoolType(pool.type),
     protocolVersion: pool.protocolVersion as ProtocolVersion,
   }
 }


### PR DESCRIPTION
Closes [#818](https://github.com/balancer/frontend-monorepo/issues/818)

V3 Smart contracts do not depend on pool type so we can skip calling `mapPoolType` from the SDK to avoid exclusive V3 pool types (like `QuantAMMWeigthed`) failing in that method.