### PR TITLE
Fix pool chart date display

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsProvider.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsProvider.tsx
@@ -360,7 +360,13 @@ export function _usePoolCharts() {
       }
     }
 
-    return processedElements
+    // timestamps from chartData are UTC midnight, but echarts defaults to interpreting timestamp values in local timezone, so adjust by offset to display correct day on chart
+    return processedElements.map(([timestamp, value]) => {
+      const date = new Date(timestamp * 1000)
+      const timezoneOffset = date.getTimezoneOffset() * 60 // in seconds
+      const adjustedTimestamp = timestamp + timezoneOffset
+      return [adjustedTimestamp, value]
+    })
   }, [
     activePeriod.value,
     activeTab.value,

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsProvider.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsProvider.tsx
@@ -15,6 +15,7 @@ import { useTheme as useNextTheme } from 'next-themes'
 import { isCowAmmPool } from '../../../pool.helpers'
 import { PoolChartTab, usePoolChartTabs } from './PoolChartTabsProvider'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
+import { alignUtcWithLocalDay } from '@repo/lib/shared/utils/time'
 
 const MIN_DISPLAY_PERIOD_DAYS = 30
 
@@ -360,13 +361,9 @@ export function _usePoolCharts() {
       }
     }
 
-    // timestamps from chartData are UTC midnight, but echarts defaults to interpreting timestamp values in local timezone, so adjust by offset to display correct day on chart
-    return processedElements.map(([timestamp, value]) => {
-      const date = new Date(timestamp * 1000)
-      const timezoneOffset = date.getTimezoneOffset() * 60 // in seconds
-      const adjustedTimestamp = timestamp + timezoneOffset
-      return [adjustedTimestamp, value]
-    })
+    // timestamps from chartData are UTC midnight, but echarts interprets timestamp using local timezone
+    // so we adjust by offset to display correct day on chart
+    return processedElements.map(([timestamp, value]) => [alignUtcWithLocalDay(timestamp), value])
   }, [
     activePeriod.value,
     activeTab.value,

--- a/packages/lib/shared/utils/time.ts
+++ b/packages/lib/shared/utils/time.ts
@@ -1,4 +1,4 @@
-import { sub, millisecondsToSeconds } from 'date-fns'
+import { sub, millisecondsToSeconds, secondsToMilliseconds } from 'date-fns'
 
 export const oneSecondInMs = 1000
 export const oneMinInMs = 60 * oneSecondInMs
@@ -141,4 +141,16 @@ export function startOfDayUtc(dateUTC: Date) {
 
 export function toISOString(timestamp: number): string {
   return new Date(timestamp).toISOString()
+}
+
+/**
+ * Align a UTC timestamp with the local day.
+ */
+
+export function alignUtcWithLocalDay(timestamp: number) {
+  const timezoneOffset = mins(new Date().getTimezoneOffset()).toSecs()
+  return (
+    timestamp -
+    (timezoneOffset < 0 ? Math.abs(timezoneOffset) + twentyFourHoursInSecs : timezoneOffset)
+  )
 }

--- a/packages/lib/shared/utils/time.ts
+++ b/packages/lib/shared/utils/time.ts
@@ -1,4 +1,4 @@
-import { sub, millisecondsToSeconds } from 'date-fns'
+import { sub, millisecondsToSeconds, secondsToMilliseconds } from 'date-fns'
 
 export const oneSecondInMs = 1000
 export const oneMinInMs = 60 * oneSecondInMs
@@ -145,11 +145,12 @@ export function toISOString(timestamp: number): string {
 
 /**
  * Fixes date shown on pool charts
+ *
+ * @param {number} unixTimestamp - Unix timestamp from API uses seconds
+ * @returns {number} - Timestamp aligned with local day
  */
-export function alignUtcWithLocalDay(timestamp: number) {
-  const timezoneOffset = mins(new Date().getTimezoneOffset()).toSecs()
-  return (
-    timestamp -
-    (timezoneOffset < 0 ? Math.abs(timezoneOffset) + twentyFourHoursInSecs : timezoneOffset)
-  )
+export function alignUtcWithLocalDay(unixTimestamp: number) {
+  const utcDate = new Date(secondsToMilliseconds(unixTimestamp))
+  const timezoneOffset = utcDate.getTimezoneOffset() * oneMinInSecs // convert getTimezoneOffset from minutes to seconds
+  return unixTimestamp + timezoneOffset
 }

--- a/packages/lib/shared/utils/time.ts
+++ b/packages/lib/shared/utils/time.ts
@@ -1,4 +1,4 @@
-import { sub, millisecondsToSeconds, secondsToMilliseconds } from 'date-fns'
+import { sub, millisecondsToSeconds } from 'date-fns'
 
 export const oneSecondInMs = 1000
 export const oneMinInMs = 60 * oneSecondInMs
@@ -144,9 +144,8 @@ export function toISOString(timestamp: number): string {
 }
 
 /**
- * Align a UTC timestamp with the local day.
+ * Fixes date shown on pool charts
  */
-
 export function alignUtcWithLocalDay(timestamp: number) {
   const timezoneOffset = mins(new Date().getTimezoneOffset()).toSecs()
   return (


### PR DESCRIPTION
Fixes #419

### Summary
- timestamps from API are UTC midnight 
  - example: `1743750000` which is `Fri, 04 Apr 2025 00:00:00 GMT`
- echarts defaults to interpreting timestamp values in local timezone of user
  -  converts `1743750000` to `Thu Apr 03 2025 17:00:00 GMT-0700 (Pacific Daylight Time)`
- adjusted timestamp by the offset from UTC to account for echarts limitation
