### PR TITLE
feat: add pool version filter to pool voting list

### DIFF
--- a/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -313,6 +313,8 @@ export interface FilterTagsPops {
   poolTypes: PoolFilterType[]
   togglePoolType: (checked: boolean, value: PoolFilterType) => void
   poolTypeLabel: (poolType: PoolFilterType) => string
+  protocolVersion: number | null
+  setProtocolVersion: (value: number | null) => void
   minTvl?: number
   setMinTvl?: (value: number | null) => void
   poolTags?: PoolTagType[]
@@ -323,8 +325,6 @@ export interface FilterTagsPops {
   poolHookTags?: PoolHookTagType[]
   togglePoolHookTag?: (checked: boolean, value: PoolHookTagType) => void
   poolHookTagLabel?: (poolHookTag: PoolHookTagType) => string
-  protocolVersion?: number | null
-  setProtocolVersion?: (value: number | null) => void // TODO: check why this is not used in VoteListLayout
 }
 
 function AnimatedTag({ label, onClose }: { label: React.ReactNode; onClose: () => void }) {
@@ -482,7 +482,7 @@ export const FilterButton = forwardRef<ButtonProps & { totalFilterCount: number 
 )
 
 export interface ProtocolVersionFilterProps {
-  setProtocolVersion: React.Dispatch<React.SetStateAction<number | null>>
+  setProtocolVersion: (version: number | null) => any
   protocolVersion: number | null
   poolTypes: PoolFilterType[]
   activeProtocolVersionTab: ButtonGroupOption

--- a/packages/lib/modules/vebal/vote/VoteList/VoteListFilters.tsx
+++ b/packages/lib/modules/vebal/vote/VoteList/VoteListFilters.tsx
@@ -22,6 +22,7 @@ import {
   FilterButton,
   PoolNetworkFilters,
   PoolTypeFilters,
+  ProtocolVersionFilter,
 } from '@repo/lib/modules/pool/PoolList/PoolListFilters'
 import { useVoteList } from '@repo/lib/modules/vebal/vote/VoteList/VoteListProvider'
 import { VoteListSearch } from '@repo/lib/modules/vebal/vote/VoteList/VoteListSearch'
@@ -29,13 +30,15 @@ import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
 export function useFilterTagsVisible() {
   const {
-    filtersState: { networks, poolTypes, includeExpiredPools },
+    filtersState: { networks, poolTypes, includeExpiredPools, protocolVersion },
   } = useVoteList()
   const [isVisible, setIsVisible] = useState(false)
 
   useEffect(() => {
-    setIsVisible(networks.length > 0 || poolTypes.length > 0 || includeExpiredPools)
-  }, [networks, poolTypes, includeExpiredPools])
+    setIsVisible(
+      networks.length > 0 || poolTypes.length > 0 || includeExpiredPools || !!protocolVersion
+    )
+  }, [networks, poolTypes, includeExpiredPools, protocolVersion])
 
   return isVisible
 }
@@ -54,6 +57,10 @@ export function VoteListFilters() {
       setPoolTypes,
       includeExpiredPools,
       toggleIncludeExpiredPools,
+      protocolVersion,
+      setProtocolVersion,
+      activeProtocolVersionTab,
+      setActiveProtocolVersionTab,
     },
   } = useVoteList()
 
@@ -122,6 +129,19 @@ export function VoteListFilters() {
                           setNetworks={setNetworks}
                           toggleNetwork={toggleNetwork}
                           toggledNetworks={toggledNetworks}
+                        />
+                      </Box>
+                      <Box as={motion.div} variants={staggeredFadeInUp}>
+                        <Heading as="h3" mb="sm" size="sm">
+                          Protocol version
+                        </Heading>
+                        <ProtocolVersionFilter
+                          activeProtocolVersionTab={activeProtocolVersionTab}
+                          hideProtocolVersion={PROJECT_CONFIG.options.hideProtocolVersion}
+                          poolTypes={poolTypes}
+                          protocolVersion={protocolVersion}
+                          setActiveProtocolVersionTab={setActiveProtocolVersionTab}
+                          setProtocolVersion={setProtocolVersion}
                         />
                       </Box>
                       <Box as={motion.div} variants={staggeredFadeInUp}>

--- a/packages/lib/modules/vebal/vote/VoteList/VoteListLayout.tsx
+++ b/packages/lib/modules/vebal/vote/VoteList/VoteListLayout.tsx
@@ -29,7 +29,9 @@ export function VoteListLayout() {
       poolTypes,
       togglePoolType,
       includeExpiredPools,
+      protocolVersion,
       toggleIncludeExpiredPools,
+      setProtocolVersion,
     },
   } = useVoteList()
   const { selectedVotingPools, scrollToMyVotes } = useVotes()
@@ -103,6 +105,8 @@ export function VoteListLayout() {
             networks={networks}
             poolTypeLabel={poolTypeLabel}
             poolTypes={poolTypes}
+            protocolVersion={protocolVersion}
+            setProtocolVersion={setProtocolVersion}
             toggleIncludeExpiredPools={toggleIncludeExpiredPools}
             toggleNetwork={toggleNetwork}
             togglePoolType={togglePoolType}

--- a/packages/lib/modules/vebal/vote/VoteList/VoteListProvider.tsx
+++ b/packages/lib/modules/vebal/vote/VoteList/VoteListProvider.tsx
@@ -37,7 +37,8 @@ function filterVoteList(
   textSearch: string,
   networks: GqlChain[],
   poolTypes: PoolFilterType[],
-  includeExpiredPools: boolean
+  includeExpiredPools: boolean,
+  protocolVersion: number | null
 ) {
   let result = voteList
 
@@ -66,6 +67,10 @@ function filterVoteList(
 
   if (!includeExpiredPools) {
     result = result.filter(pool => !pool.gauge.isKilled)
+  }
+
+  if (protocolVersion) {
+    result = result.filter(pool => pool.protocolVersion === protocolVersion)
   }
 
   return result
@@ -107,7 +112,8 @@ export function _useVoteList({}: UseVoteListArgs) {
       filtersState.searchText,
       filtersState.networks,
       filtersState.poolTypes,
-      filtersState.includeExpiredPools
+      filtersState.includeExpiredPools,
+      filtersState.protocolVersion
     )
   }, [
     votingPoolsList,
@@ -115,6 +121,7 @@ export function _useVoteList({}: UseVoteListArgs) {
     filtersState.networks,
     filtersState.poolTypes,
     filtersState.includeExpiredPools,
+    filtersState.protocolVersion,
   ])
 
   const sortedVoteList = useMemo(() => {

--- a/packages/lib/modules/vebal/vote/VoteList/useVoteListFiltersState.tsx
+++ b/packages/lib/modules/vebal/vote/VoteList/useVoteListFiltersState.tsx
@@ -5,6 +5,7 @@ import { Sorting } from '@repo/lib/shared/components/tables/SortableHeader'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { uniq } from 'lodash'
 import { PoolFilterType } from '@repo/lib/modules/pool/pool.types'
+import { PROTOCOL_VERSION_TABS } from '@repo/lib/modules/pool/PoolList/usePoolListQueryState'
 
 const EMPTY_ARRAY: never[] = []
 
@@ -36,12 +37,16 @@ export function useVoteListFiltersState() {
   const [poolTypes, setPoolTypes] = useState<PoolFilterType[] | null>(null)
   const [includeExpiredPools, setIncludeExpiredPools] = useState(false)
 
+  const [activeProtocolVersionTab, setActiveProtocolVersionTab] = useState(PROTOCOL_VERSION_TABS[0])
+  const [protocolVersion, setProtocolVersion] = useState<number | null>(null)
+
   const [textSearch, setTextSearch] = useState('')
 
   function resetFilters() {
     setNetworks(null)
     setPoolTypes(null)
     setIncludeExpiredPools(false)
+    setProtocolVersion(null)
 
     setPagination({ pageSize: 20, pageIndex: 0 })
     setSorting(Sorting.desc)
@@ -96,10 +101,14 @@ export function useVoteListFiltersState() {
     networks: networks ?? EMPTY_ARRAY,
     poolTypes: poolTypes ?? EMPTY_ARRAY,
     includeExpiredPools,
+    protocolVersion,
+    activeProtocolVersionTab,
     toggleNetwork,
     togglePoolType,
     toggleIncludeExpiredPools,
     setNetworks,
     setPoolTypes,
+    setProtocolVersion,
+    setActiveProtocolVersionTab,
   }
 }


### PR DESCRIPTION
Closes #802 by adding pool protocol version filter to voting list. 

There are other potential filters (like hooks & `minTVL`) to be copied from pool list but I think this is enough. 

https://github.com/user-attachments/assets/724cd974-d179-498c-a73a-db7187239f6f

