### PR TITLE
fix: add use overflowX auto in voting page to always allow horizontal…

### DIFF
--- a/packages/lib/modules/vebal/vote/Votes/VotesContainer.tsx
+++ b/packages/lib/modules/vebal/vote/Votes/VotesContainer.tsx
@@ -37,7 +37,7 @@ export async function VotesContainer() {
       votingIncentivesErrorMessage={parseError(votingIncentivesError)}
       votingIncentivesLoading={false} /* RSC (SSR) mode, no loading needed */
     >
-      <VStack spacing="3xl" w="full">
+      <VStack overflowX="auto" spacing="3xl" w="full">
         {/* todo: (votes) work in progress */}
         {false && <VotesIntroductionLayout />}
         <TransactionStateProvider>


### PR DESCRIPTION
… scroll

It is not easy to find a perfect fix so I just added overflowX auto to be able to always use horizontal scroll in the voting lists. 

I guess voting is not something that users will do in mobile devices. 