### PR TITLE
feat: allow pool swaps even when pool adds are blocked

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolHeader/PoolAdvancedOptions.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolHeader/PoolAdvancedOptions.tsx
@@ -31,8 +31,7 @@ export function PoolAdvancedOptions() {
   const { pool } = usePool()
   const poolMetadata = usePoolMetadata(pool)
   const isCowPool = isCowAmmPool(pool.type)
-  const isPoolSwapDisabled =
-    !isMaBeetsPool(pool.id) && (shouldBlockAddLiquidity(pool, poolMetadata) || isCowPool)
+  const isPoolSwapDisabled = !isMaBeetsPool(pool.id) && isCowPool
 
   const disabledLinkProps = isPoolSwapDisabled
     ? {

--- a/packages/lib/modules/pool/PoolDetail/PoolHeader/PoolAdvancedOptions.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolHeader/PoolAdvancedOptions.tsx
@@ -19,17 +19,15 @@ import NextLink from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
 import { MoreVertical } from 'react-feather'
-import { isCowAmmPool, isMaBeetsPool, shouldBlockAddLiquidity } from '../../pool.helpers'
+import { isCowAmmPool, isMaBeetsPool } from '../../pool.helpers'
 import { usePool } from '../../PoolProvider'
 import { buildCowSwapUrlFromPool } from '@repo/lib/modules/cow/cow.utils'
 import { CowIcon } from '@repo/lib/shared/components/icons/logos/CowIcon'
-import { usePoolMetadata } from '../../metadata/usePoolMetadata'
 
 export function PoolAdvancedOptions() {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   const pathname = usePathname()
   const { pool } = usePool()
-  const poolMetadata = usePoolMetadata(pool)
   const isCowPool = isCowAmmPool(pool.type)
   const isPoolSwapDisabled = !isMaBeetsPool(pool.id) && isCowPool
 


### PR DESCRIPTION
Now the user will be able to get to the swap page no matter if add liquidity action is blocked. 

If the pool is not yet available for swap in the SOR, they will get a swap error but that's independent of the add liquidity state.

Slack conversation with more context: 
https://balancerecosystem.slack.com/archives/C02F9EMRKQA/p1744219528580369?thread_ts=1744053305.178429&cid=C02F9EMRKQA