### PR TITLE
feat: migrate to breaking changing sdk v3.1.0

### DIFF
--- a/apps/beets-frontend-v3/package.json
+++ b/apps/beets-frontend-v3/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.13.1",
-    "@balancer/sdk": "2.7.1",
+    "@balancer/sdk": "3.1.0",
     "@chakra-ui/hooks": "2.4.2",
     "@chakra-ui/react": "2.10.6",
     "@chakra-ui/theme-tools": "2.2.6",

--- a/apps/frontend-v3/package.json
+++ b/apps/frontend-v3/package.json
@@ -21,7 +21,7 @@
     "postinstall": "pnpm run gen:theme-typings"
   },
   "dependencies": {
-    "@balancer/sdk": "2.7.1",
+    "@balancer/sdk": "3.1.0",
     "@chakra-ui/hooks": "2.4.2",
     "@chakra-ui/icons": "2.2.4",
     "@chakra-ui/react": "2.10.6",

--- a/packages/e2e-tests/tests/dev/add-liquidity.spec.ts
+++ b/packages/e2e-tests/tests/dev/add-liquidity.spec.ts
@@ -20,7 +20,7 @@ test('Adds liquidity in balWeth8020', async ({ page }) => {
   // Fill form
   await page.getByRole('button', { name: 'Add liquidity' }).click()
   // Fill 0.01 ETH (default anvil user will always have enough ETH)
-  await expect(page.getByRole('button', { name: 'ETH ETH' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'ETH ETH' })).toBeVisible({ timeout: 20000 })
   await page.getByPlaceholder('0.00').nth(1).fill('0.01')
   await page.getByText('I accept the risks of').click({ timeout: 20000 })
   await page.getByRole('button', { name: 'Next' }).click()

--- a/packages/lib/config/networks/arbitrum.ts
+++ b/packages/lib/config/networks/arbitrum.ts
@@ -3,13 +3,7 @@ import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { PoolIssue } from '@repo/lib/modules/pool/alerts/pool-issues/PoolIssue.type'
 import { CSP_ISSUE_POOL_IDS } from '@repo/lib/shared/data/csp-issue'
-import {
-  BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
-  BALANCER_ROUTER,
-  PERMIT2,
-  VAULT_ADMIN,
-  VAULT_V3,
-} from '@balancer/sdk'
+import { balancerV3Contracts, PERMIT2 } from '@balancer/sdk'
 import { arbitrum } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
@@ -58,13 +52,13 @@ const networkConfig: NetworkConfig = {
     multicall2: '0x80c7dd17b01855a6d2347444a0fcc36136a314de',
     balancer: {
       vaultV2: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-      vaultV3: VAULT_V3[arbitrum.id],
+      vaultV3: balancerV3Contracts.Vault[arbitrum.id],
       relayerV6: '0x9B892E515D2Ab8869F17488d64B3b918731cc70d',
       minter: '0xc3ccacE87f6d3A81724075ADcb5ddd85a8A1bB68',
       WeightedPool2TokensFactory: '0xCF0a32Bbef8F064969F21f7e02328FB577382018',
-      vaultAdminV3: VAULT_ADMIN[arbitrum.id],
-      router: BALANCER_ROUTER[arbitrum.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[arbitrum.id],
+      vaultAdminV3: balancerV3Contracts.VaultAdmin[arbitrum.id],
+      router: balancerV3Contracts.Router[arbitrum.id],
+      compositeLiquidityRouterBoosted: balancerV3Contracts.CompositeLiquidityRouter[arbitrum.id],
     },
     veDelegationProxy: '0x81cFAE226343B24BA12EC6521Db2C79E7aeeb310',
     permit2: PERMIT2[arbitrum.id],

--- a/packages/lib/config/networks/avalanche.ts
+++ b/packages/lib/config/networks/avalanche.ts
@@ -3,7 +3,7 @@ import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { PoolIssue } from '@repo/lib/modules/pool/alerts/pool-issues/PoolIssue.type'
 import { CSP_ISSUE_POOL_IDS } from '@repo/lib/shared/data/csp-issue'
-import { balancerV3Contracts } from '@balancer/sdk'
+import { balancerV3Contracts, PERMIT2 } from '@balancer/sdk'
 import { avalanche } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
@@ -50,6 +50,7 @@ const networkConfig: NetworkConfig = {
       compositeLiquidityRouterBoosted: balancerV3Contracts.CompositeLiquidityRouter[avalanche.id],
     },
     veDelegationProxy: '0x0c6052254551EAe3ECac77B01DFcf1025418828f',
+    permit2: PERMIT2[avalanche.id],
   },
   pools: convertHexToLowerCase({
     issues: {

--- a/packages/lib/config/networks/avalanche.ts
+++ b/packages/lib/config/networks/avalanche.ts
@@ -3,7 +3,7 @@ import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { PoolIssue } from '@repo/lib/modules/pool/alerts/pool-issues/PoolIssue.type'
 import { CSP_ISSUE_POOL_IDS } from '@repo/lib/shared/data/csp-issue'
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED, BALANCER_ROUTER } from '@balancer/sdk'
+import { balancerV3Contracts } from '@balancer/sdk'
 import { avalanche } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
@@ -46,8 +46,8 @@ const networkConfig: NetworkConfig = {
       vaultV2: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
       relayerV6: '0xA084c11cb55e67C9becf9607f1DBB20ec4D5E7b2',
       minter: '0x85a80afee867aDf27B50BdB7b76DA70f1E853062',
-      router: BALANCER_ROUTER[avalanche.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[avalanche.id],
+      router: balancerV3Contracts.Router[avalanche.id],
+      compositeLiquidityRouterBoosted: balancerV3Contracts.CompositeLiquidityRouter[avalanche.id],
     },
     veDelegationProxy: '0x0c6052254551EAe3ECac77B01DFcf1025418828f',
   },

--- a/packages/lib/config/networks/base.ts
+++ b/packages/lib/config/networks/base.ts
@@ -1,13 +1,7 @@
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
-import {
-  BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
-  BALANCER_ROUTER,
-  PERMIT2,
-  VAULT_ADMIN,
-  VAULT_V3,
-} from '@balancer/sdk'
+import { balancerV3Contracts, PERMIT2 } from '@balancer/sdk'
 import { base } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
@@ -51,12 +45,12 @@ const networkConfig: NetworkConfig = {
     multicall2: '0xca11bde05977b3631167028862be2a173976ca11',
     balancer: {
       vaultV2: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-      vaultV3: VAULT_V3[base.id],
+      vaultV3: balancerV3Contracts.Vault[base.id],
       relayerV6: '0x7C3C773C878d2238a9b64d8CEE02377BF07ED06a',
       minter: '0x0c5538098EBe88175078972F514C9e101D325D4F',
-      vaultAdminV3: VAULT_ADMIN[base.id],
-      router: BALANCER_ROUTER[base.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[base.id],
+      vaultAdminV3: balancerV3Contracts.VaultAdmin[base.id],
+      router: balancerV3Contracts.Router[base.id],
+      compositeLiquidityRouterBoosted: balancerV3Contracts.CompositeLiquidityRouter[base.id],
     },
     veDelegationProxy: '0xD87F44Df0159DC78029AB9CA7D7e57E7249F5ACD',
     permit2: PERMIT2[base.id],

--- a/packages/lib/config/networks/fantom.ts
+++ b/packages/lib/config/networks/fantom.ts
@@ -3,8 +3,6 @@ import { NetworkConfig } from '../config.types'
 import { zeroAddress } from 'viem'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { emptyAddress } from '@repo/lib/modules/web3/contracts/wagmi-helpers'
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED, BALANCER_ROUTER } from '@balancer/sdk'
-import { fantom } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
   chainId: 250,
@@ -43,8 +41,6 @@ const networkConfig: NetworkConfig = {
       vaultV2: '0x20dd72Ed959b6147912C2e529F0a0C651c33c9ce',
       relayerV6: '0x0faa25293a36241c214f3760c6ff443e1b731981',
       minter: zeroAddress,
-      router: BALANCER_ROUTER[fantom.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[fantom.id],
     },
     beets: {
       lstStaking: '0x310A1f7bd9dDE18CCFD701A796Ecb83CcbedE21A',

--- a/packages/lib/config/networks/fraxtal.ts
+++ b/packages/lib/config/networks/fraxtal.ts
@@ -3,8 +3,6 @@ import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { CSP_ISSUE_POOL_IDS } from '@repo/lib/shared/data/csp-issue'
 import { PoolIssue } from '@repo/lib/modules/pool/alerts/pool-issues/PoolIssue.type'
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED, BALANCER_ROUTER } from '@balancer/sdk'
-import { fraxtal } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
   chainId: 252,
@@ -41,8 +39,6 @@ const networkConfig: NetworkConfig = {
       vaultV2: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
       relayerV6: '0xb541765F540447646A9545E0A4800A0Bacf9E13D',
       minter: '0x9805dcfD25e6De36bad8fe9D3Fe2c9b44B764102',
-      router: BALANCER_ROUTER[fraxtal.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[fraxtal.id],
     },
     veDelegationProxy: '0xE3881627B8DeeBCCF9c23B291430a549Fc0bE5F7',
   },

--- a/packages/lib/config/networks/gnosis.ts
+++ b/packages/lib/config/networks/gnosis.ts
@@ -3,14 +3,7 @@ import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { CSP_ISSUE_POOL_IDS } from '@repo/lib/shared/data/csp-issue'
 import { PoolIssue } from '@repo/lib/modules/pool/alerts/pool-issues/PoolIssue.type'
-import {
-  BALANCER_BATCH_ROUTER,
-  BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
-  BALANCER_ROUTER,
-  PERMIT2,
-  VAULT_ADMIN,
-  VAULT_V3,
-} from '@balancer/sdk'
+import { balancerV3Contracts, PERMIT2 } from '@balancer/sdk'
 import { gnosis } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
@@ -60,13 +53,13 @@ const networkConfig: NetworkConfig = {
     multicall2: '0xbb6fab6b627947dae0a75808250d8b2652952cb5',
     balancer: {
       vaultV2: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-      vaultV3: VAULT_V3[gnosis.id],
+      vaultV3: balancerV3Contracts.Vault[gnosis.id],
       relayerV6: '0x2163c2FcD0940e84B8a68991bF926eDfB0Cd926C',
       minter: '0xA8920455934Da4D853faac1f94Fe7bEf72943eF1',
-      router: BALANCER_ROUTER[gnosis.id],
-      batchRouter: BALANCER_BATCH_ROUTER[gnosis.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[gnosis.id],
-      vaultAdminV3: VAULT_ADMIN[gnosis.id],
+      router: balancerV3Contracts.Router[gnosis.id],
+      batchRouter: balancerV3Contracts.BatchRouter[gnosis.id],
+      compositeLiquidityRouterBoosted: balancerV3Contracts.CompositeLiquidityRouter[gnosis.id],
+      vaultAdminV3: balancerV3Contracts.VaultAdmin[gnosis.id],
     },
     veDelegationProxy: '0x7A2535f5fB47b8e44c02Ef5D9990588313fe8F05',
     permit2: PERMIT2[gnosis.id],

--- a/packages/lib/config/networks/mainnet.ts
+++ b/packages/lib/config/networks/mainnet.ts
@@ -4,14 +4,7 @@ import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { NetworkConfig } from '../config.types'
 import { CSP_ISSUE_POOL_IDS } from '../../shared/data/csp-issue'
 import { SupportedWrapHandler } from '@repo/lib/modules/swap/swap.types'
-import {
-  BALANCER_BATCH_ROUTER,
-  BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
-  BALANCER_ROUTER,
-  PERMIT2,
-  VAULT_ADMIN,
-  VAULT_V3,
-} from '@balancer/sdk'
+import { PERMIT2, balancerV3Contracts } from '@balancer/sdk'
 import { mainnet } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
@@ -83,14 +76,15 @@ const networkConfig: NetworkConfig = {
     multicall2: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
     balancer: {
       vaultV2: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-      vaultV3: VAULT_V3[mainnet.id],
+      vaultV3: balancerV3Contracts.Vault[mainnet.id],
       relayerV6: '0x35Cea9e57A393ac66Aaa7E25C391D52C74B5648f',
       minter: '0x239e55F427D44C3cc793f49bFB507ebe76638a2b',
-      router: BALANCER_ROUTER[mainnet.id],
-      batchRouter: BALANCER_BATCH_ROUTER[mainnet.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[mainnet.id],
+      router: balancerV3Contracts.Router[mainnet.id],
+      batchRouter: balancerV3Contracts.BatchRouter[mainnet.id],
+
+      compositeLiquidityRouterBoosted: balancerV3Contracts.CompositeLiquidityRouter[mainnet.id],
       WeightedPool2TokensFactory: '0xa5bf2ddf098bb0ef6d120c98217dd6b141c74ee0',
-      vaultAdminV3: VAULT_ADMIN[mainnet.id],
+      vaultAdminV3: balancerV3Contracts.VaultAdmin[mainnet.id],
     },
     feeDistributor: '0xD3cf852898b21fc233251427c2DC93d3d604F3BB',
     veDelegationProxy: '0x6f5a2eE11E7a772AeB5114A20d0D7c0ff61EB8A0',

--- a/packages/lib/config/networks/mode.ts
+++ b/packages/lib/config/networks/mode.ts
@@ -3,8 +3,6 @@ import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { CSP_ISSUE_POOL_IDS } from '@repo/lib/shared/data/csp-issue'
 import { PoolIssue } from '@repo/lib/modules/pool/alerts/pool-issues/PoolIssue.type'
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED, BALANCER_ROUTER } from '@balancer/sdk'
-import { mode } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
   chainId: 34443,
@@ -41,8 +39,6 @@ const networkConfig: NetworkConfig = {
       vaultV2: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
       relayerV6: '0xb541765F540447646A9545E0A4800A0Bacf9E13D',
       minter: '0x5cF4928a3205728bd12830E1840F7DB85c62a4B9',
-      router: BALANCER_ROUTER[mode.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[mode.id],
     },
     veDelegationProxy: '0x9805dcfD25e6De36bad8fe9D3Fe2c9b44B764102',
   },

--- a/packages/lib/config/networks/optimism.ts
+++ b/packages/lib/config/networks/optimism.ts
@@ -3,7 +3,7 @@ import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { CSP_ISSUE_POOL_IDS } from '@repo/lib/shared/data/csp-issue'
 import { PoolIssue } from '@repo/lib/modules/pool/alerts/pool-issues/PoolIssue.type'
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED, BALANCER_ROUTER } from '@balancer/sdk'
+import { balancerV3Contracts } from '@balancer/sdk'
 import { optimism } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
@@ -53,8 +53,8 @@ const networkConfig: NetworkConfig = {
       relayerV6: '0x015ACA20a1422F3c729086c17f15F10e0CfbC75A',
       minter: '0x4fb47126Fa83A8734991E41B942Ac29A3266C968',
       WeightedPool2TokensFactory: '0x0F3e0c4218b7b0108a3643cFe9D3ec0d4F57c54e',
-      router: BALANCER_ROUTER[optimism.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[optimism.id],
+      router: balancerV3Contracts.Router[optimism.id],
+      compositeLiquidityRouterBoosted: balancerV3Contracts.CompositeLiquidityRouter[optimism.id],
     },
     veDelegationProxy: '0x9dA18982a33FD0c7051B19F0d7C76F2d5E7e017c',
   },

--- a/packages/lib/config/networks/polygon.ts
+++ b/packages/lib/config/networks/polygon.ts
@@ -3,8 +3,6 @@ import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { PoolIssue } from '@repo/lib/modules/pool/alerts/pool-issues/PoolIssue.type'
 import { CSP_ISSUE_POOL_IDS } from '@repo/lib/shared/data/csp-issue'
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED, BALANCER_ROUTER } from '@balancer/sdk'
-import { polygon } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
   chainId: 137,
@@ -53,8 +51,6 @@ const networkConfig: NetworkConfig = {
       relayerV6: '0xB1ED8d3b5059b3281D43306cC9D043cE8B22599b',
       minter: '0x47B489bf5836f83ABD928C316F8e39bC0587B020',
       WeightedPool2TokensFactory: '0xA5bf2ddF098bb0Ef6d120C98217dD6B141c74EE0',
-      router: BALANCER_ROUTER[polygon.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[polygon.id],
     },
     veDelegationProxy: '0x0f08eEf2C785AA5e7539684aF04755dEC1347b7c',
   },

--- a/packages/lib/config/networks/sepolia.ts
+++ b/packages/lib/config/networks/sepolia.ts
@@ -1,14 +1,7 @@
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
-import {
-  BALANCER_BATCH_ROUTER,
-  BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
-  BALANCER_ROUTER,
-  PERMIT2,
-  VAULT_ADMIN,
-  VAULT_V3,
-} from '@balancer/sdk'
+import { balancerV3Contracts, PERMIT2 } from '@balancer/sdk'
 import { sepolia } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
@@ -43,13 +36,13 @@ const networkConfig: NetworkConfig = {
     multicall2: '0xca11bde05977b3631167028862be2a173976ca11',
     balancer: {
       vaultV2: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-      vaultV3: VAULT_V3[sepolia.id],
-      router: BALANCER_ROUTER[sepolia.id],
-      batchRouter: BALANCER_BATCH_ROUTER[sepolia.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[sepolia.id],
+      vaultV3: balancerV3Contracts.Vault[sepolia.id],
+      router: balancerV3Contracts.Router[sepolia.id],
+      batchRouter: balancerV3Contracts.BatchRouter[sepolia.id],
+      compositeLiquidityRouterBoosted: balancerV3Contracts.CompositeLiquidityRouter[sepolia.id],
       relayerV6: '0x7852fB9d0895e6e8b3EedA553c03F6e2F9124dF9',
       minter: '0x1783Cd84b3d01854A96B4eD5843753C2CcbD574A',
-      vaultAdminV3: VAULT_ADMIN[sepolia.id],
+      vaultAdminV3: balancerV3Contracts.VaultAdmin[sepolia.id],
     },
     veBAL: '0x150A72e4D4d81BbF045565E232c50Ed0931ad795',
     permit2: PERMIT2[sepolia.id],

--- a/packages/lib/config/networks/sonic.ts
+++ b/packages/lib/config/networks/sonic.ts
@@ -3,14 +3,7 @@ import { NetworkConfig } from '../config.types'
 import { zeroAddress } from 'viem'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { emptyAddress } from '@repo/lib/modules/web3/contracts/wagmi-helpers'
-import {
-  BALANCER_BATCH_ROUTER,
-  BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED,
-  BALANCER_ROUTER,
-  PERMIT2,
-  VAULT_ADMIN,
-  VAULT_V3,
-} from '@balancer/sdk'
+import { balancerV3Contracts, PERMIT2 } from '@balancer/sdk'
 import { sonic } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
@@ -57,13 +50,13 @@ const networkConfig: NetworkConfig = {
     multicall3: '0xcA11bde05977b3631167028862bE2a173976CA11',
     balancer: {
       vaultV2: '0xba12222222228d8ba445958a75a0704d566bf2c8',
-      vaultV3: VAULT_V3[sonic.id],
+      vaultV3: balancerV3Contracts.Vault[sonic.id],
       relayerV6: '0x7b52D5ef006E59e3227629f97F182D6442380bb6',
       minter: zeroAddress,
-      router: BALANCER_ROUTER[sonic.id],
-      batchRouter: BALANCER_BATCH_ROUTER[sonic.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[sonic.id],
-      vaultAdminV3: VAULT_ADMIN[sonic.id],
+      router: balancerV3Contracts.Router[sonic.id],
+      batchRouter: balancerV3Contracts.BatchRouter[sonic.id],
+      compositeLiquidityRouterBoosted: balancerV3Contracts.CompositeLiquidityRouter[sonic.id],
+      vaultAdminV3: balancerV3Contracts.VaultAdmin[sonic.id],
     },
     veDelegationProxy: zeroAddress, // TODO: fix this dependency for Beets
     beets: {

--- a/packages/lib/config/networks/zkevm.ts
+++ b/packages/lib/config/networks/zkevm.ts
@@ -3,8 +3,6 @@ import { NetworkConfig } from '../config.types'
 import { convertHexToLowerCase } from '@repo/lib/shared/utils/objects'
 import { PoolIssue } from '@repo/lib/modules/pool/alerts/pool-issues/PoolIssue.type'
 import { CSP_ISSUE_POOL_IDS } from '@repo/lib/shared/data/csp-issue'
-import { BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED, BALANCER_ROUTER } from '@balancer/sdk'
-import { polygonZkEvm } from 'viem/chains'
 
 const networkConfig: NetworkConfig = {
   chainId: 1101,
@@ -50,8 +48,6 @@ const networkConfig: NetworkConfig = {
       vaultV2: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
       relayerV6: '0x8e620FfCa2580ed87241D7e10F85EE75d0a906F5',
       minter: '0x475D18169BE8a89357A9ee3Ab00ca386d20fA229',
-      router: BALANCER_ROUTER[polygonZkEvm.id],
-      compositeLiquidityRouterBoosted: BALANCER_COMPOSITE_LIQUIDITY_ROUTER_BOOSTED[polygonZkEvm.id],
     },
     veDelegationProxy: '0xc7E5ED1054A24Ef31D827E6F86caA58B3Bc168d7',
   },

--- a/packages/lib/modules/eclp/hooks/useGetTokenRates.tsx
+++ b/packages/lib/modules/eclp/hooks/useGetTokenRates.tsx
@@ -6,17 +6,21 @@ import { Address } from 'viem'
 import { GqlPoolType } from '@repo/lib/shared/services/api/generated/graphql'
 import { isV3Pool } from '../../pool/pool.helpers'
 import { useMemo } from 'react'
-import { VAULT_V3, vaultExtensionAbi_V3 } from '@balancer/sdk'
+import { balancerV3Contracts, vaultExtensionAbi_V3 } from '@balancer/sdk'
 
 export function useGetTokenRates(pool: Pool) {
   const chainId = getChainId(pool.chain)
   const isV3 = isV3Pool(pool)
 
+  const v3Vault: Address =
+    balancerV3Contracts.Vault[chainId as keyof typeof balancerV3Contracts.Vault] || ('' as Address)
+  const contractAddress: Address = isV3 ? v3Vault : (pool.address as Address)
+
   const query = useReadContract({
     chainId,
     abi: isV3 ? vaultExtensionAbi_V3 : gyroEclpPoolAbi,
     functionName: isV3 ? 'getPoolTokenRates' : 'getTokenRates',
-    address: isV3 ? VAULT_V3[chainId] : (pool.address as Address),
+    address: contractAddress,
     query: { enabled: pool.type === GqlPoolType.Gyroe },
     args: isV3 ? [pool.address as Address] : [],
   })

--- a/packages/lib/modules/pool/actions/LiquidityActionHelpers.spec.ts
+++ b/packages/lib/modules/pool/actions/LiquidityActionHelpers.spec.ts
@@ -338,7 +338,7 @@ describe('Liquidity helpers for V3 NESTED boosted pool', async () => {
               underlyingToken: null,
             },
           ],
-          type: 'Weighted',
+          type: 'WEIGHTED',
         },
         {
           address: bb_a_Usd_Sepolia_BptAddress,

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -25,7 +25,7 @@ import { getUserTotalBalanceInt } from './user-balance.helpers'
 import { dateToUnixTimestamp } from '@repo/lib/shared/utils/time'
 import { balancerV2VaultAbi } from '../web3/contracts/abi/generated'
 import { supportsNestedActions } from './actions/LiquidityActionHelpers'
-import { vaultV3Abi } from '@balancer/sdk'
+import { vaultAbi_V3 } from '@balancer/sdk'
 import { Pool, PoolCore } from './pool.types'
 import { getBlockExplorerAddressUrl } from '@repo/lib/shared/utils/blockExplorer'
 import { allPoolTokens, isStandardOrUnderlyingRootToken } from './pool-tokens.utils'
@@ -390,7 +390,7 @@ export function getVaultConfig(pool: Pool) {
         networkConfig.contracts.balancer.vaultV3!
       : networkConfig.contracts.balancer.vaultV2
 
-  const balancerVaultAbi = pool.protocolVersion === 3 ? vaultV3Abi : balancerV2VaultAbi
+  const balancerVaultAbi = pool.protocolVersion === 3 ? vaultAbi_V3 : balancerV2VaultAbi
 
   return { vaultAddress, balancerVaultAbi }
 }

--- a/packages/lib/modules/pool/queries/usePoolEnrichWithOnChainData.tsx
+++ b/packages/lib/modules/pool/queries/usePoolEnrichWithOnChainData.tsx
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash'
-import { Address, formatUnits } from 'viem'
+import { Address, formatUnits, parseAbi } from 'viem'
 import { useReadContracts } from 'wagmi'
 import { useTokens } from '../../tokens/TokensProvider'
 import { Pool } from '../pool.types'
@@ -14,8 +14,10 @@ import {
 } from '../../web3/contracts/abi/generated'
 import { isComposableStablePool } from '../pool.utils'
 import { cowAmmPoolAbi } from '../../web3/contracts/abi/cowAmmAbi'
-import { weightedPoolAbi_V3, vaultExtensionAbi_V3 } from '@balancer/sdk'
+import { vaultExtensionAbi_V3 } from '@balancer/sdk'
 import { getCompositionTokens } from '../pool-tokens.utils'
+
+const totalSupplyAbi = parseAbi(['function totalSupply() view returns (uint256)'])
 
 export function usePoolEnrichWithOnChainData(pool: Pool) {
   const { priceFor } = useTokens()
@@ -70,7 +72,7 @@ function useV3PoolOnchainData(pool: Pool) {
       },
       {
         chainId,
-        abi: weightedPoolAbi_V3,
+        abi: totalSupplyAbi,
         address: pool.address as Address,
         functionName: 'totalSupply',
         args: [],
@@ -97,7 +99,7 @@ function useV3PoolOnchainData(pool: Pool) {
       // second half of nestedPoolData will be totalSupply
       ...nestedPoolTokens.map(token => ({
         chainId,
-        abi: weightedPoolAbi_V3,
+        abi: totalSupplyAbi,
         address: token.address as Address,
         functionName: 'totalSupply',
         args: [],

--- a/packages/lib/modules/pool/queries/useUserUnstakedBalance.tsx
+++ b/packages/lib/modules/pool/queries/useUserUnstakedBalance.tsx
@@ -1,10 +1,9 @@
 import { getChainId } from '@repo/lib/config/app.config'
 import { bn } from '@repo/lib/shared/utils/numbers'
 import { compact, keyBy } from 'lodash'
-import { Address, formatUnits } from 'viem'
+import { Address, formatUnits, parseAbi } from 'viem'
 import { useReadContracts } from 'wagmi'
 import { useUserAccount } from '../../web3/UserAccountProvider'
-import { balancerV2WeightedPoolV4Abi } from '../../web3/contracts/abi/generated'
 import { Pool } from '../pool.types'
 import { BPT_DECIMALS } from '../pool.constants'
 import { useMemo } from 'react'
@@ -18,8 +17,8 @@ export function useUserUnstakedBalance(pools: Pool[] = []) {
   const { userAddress, isConnected } = useUserAccount()
   const { priceFor } = useTokens()
 
-  // All pools should implement balanceOf so we take this abi that should work for v2 and v3 pools
-  const poolAbi = balancerV2WeightedPoolV4Abi
+  // All pool version will implement balanceOf the same ABI function is shared
+  const balanceOfAbi = parseAbi(['function balanceOf(address account) view returns (uint256)'])
 
   const {
     data: unstakedPoolBalances = [],
@@ -35,7 +34,7 @@ export function useUserUnstakedBalance(pools: Pool[] = []) {
     contracts: pools.map(
       pool =>
         ({
-          abi: poolAbi,
+          abi: balanceOfAbi,
           address: pool.address as Address,
           functionName: 'balanceOf',
           args: [userAddress as Address],

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.13.1",
-    "@balancer/sdk": "2.7.1",
+    "@balancer/sdk": "3.1.0",
     "@chakra-ui/anatomy": "^2.2.2",
     "@chakra-ui/clickable": "^2.1.0",
     "@chakra-ui/hooks": "2.4.2",

--- a/packages/lib/test/anvil/customSlots.ts
+++ b/packages/lib/test/anvil/customSlots.ts
@@ -1,11 +1,13 @@
 import { type Address, isAddressEqual } from 'viem'
 
 const BRLA = '0xfecb3f7c54e2caae9dc6ac9060a822d47e053760'
+const sAVAX = '0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be'
 
 export function getBalancerCustomSlot(tokenAddress: Address): bigint {
   /* Some slots cannot be easily guessed so we hardcode them from here:
     https://github.com/balancer/b-sdk/blob/2f8df4f20c9c9e478c58c5169c30055488d227c5/test/lib/utils/addresses.ts#L208
   */
   if (isAddressEqual(BRLA, tokenAddress)) return 51n
+  if (isAddressEqual(sAVAX, tokenAddress)) return 203n
   return 0n
 }

--- a/packages/lib/test/utils/wagmi/fork-default-balances.ts
+++ b/packages/lib/test/utils/wagmi/fork-default-balances.ts
@@ -110,3 +110,19 @@ export const polygonTokenBalances: TokenBalance[] = [
     value: '30000',
   },
 ]
+
+export const avalancheTokenBalances: TokenBalance[] = [
+  // tokens for v3 pool: pools/avalanche/v3/0x99a9a471dbe0dcc6855b4cd4bbabeccb1280f5e8
+  {
+    tokenAddress: '0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be', // sAVAX
+    value: '20000',
+  },
+  {
+    tokenAddress: '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7', // WAVAX
+    value: '30000',
+  },
+  {
+    tokenAddress: '0xa25eaf2906fa1a3a13edac9b9657108af7b703e3', // ggAVAX
+    value: '40000',
+  },
+]

--- a/packages/lib/test/utils/wagmi/fork-options.ts
+++ b/packages/lib/test/utils/wagmi/fork-options.ts
@@ -44,6 +44,6 @@ const defaultForkBalances: TokenBalancesByChain = {
 
 const isBeets = PROJECT_CONFIG.projectId === 'beets'
 export const defaultManualForkOptions = {
-  chainId: isBeets ? sonic.id : avalanche.id, // Change this id for manual tests on different chains
+  chainId: isBeets ? sonic.id : mainnet.id, // Change this id for manual tests on different chains
   forkBalances: defaultForkBalances,
 }

--- a/packages/lib/test/utils/wagmi/fork-options.ts
+++ b/packages/lib/test/utils/wagmi/fork-options.ts
@@ -1,7 +1,8 @@
 import { HumanAmount } from '@balancer/sdk'
 import { Address } from 'viem'
-import { base, gnosis, mainnet, polygon, sonic } from 'viem/chains'
+import { avalanche, base, gnosis, mainnet, polygon, sonic } from 'viem/chains'
 import {
+  avalancheTokenBalances,
   baseTokenBalances,
   gnosisTokenBalances,
   mainnetTokenBalances,
@@ -38,10 +39,11 @@ const defaultForkBalances: TokenBalancesByChain = {
   [gnosis.id]: gnosisTokenBalances,
   [sonic.id]: sonicTokenBalances,
   [polygon.id]: polygonTokenBalances,
+  [avalanche.id]: avalancheTokenBalances,
 }
 
 const isBeets = PROJECT_CONFIG.projectId === 'beets'
 export const defaultManualForkOptions = {
-  chainId: isBeets ? sonic.id : mainnet.id, // Change this id for manual tests on different chains
+  chainId: isBeets ? sonic.id : avalanche.id, // Change this id for manual tests on different chains
   forkBalances: defaultForkBalances,
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
         specifier: ^3.13.1
         version: 3.13.1(@types/react@18.2.34)(graphql-ws@5.16.0(graphql@16.10.0))(graphql@16.10.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@balancer/sdk':
-        specifier: 2.7.1
-        version: 2.7.1(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.24.1)
+        specifier: 3.1.0
+        version: 3.1.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@chakra-ui/hooks':
         specifier: 2.4.2
         version: 2.4.2(react@18.2.0)
@@ -177,8 +177,8 @@ importers:
   apps/frontend-v3:
     dependencies:
       '@balancer/sdk':
-        specifier: 2.7.1
-        version: 2.7.1(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.24.1)
+        specifier: 3.1.0
+        version: 3.1.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@chakra-ui/hooks':
         specifier: 2.4.2
         version: 2.4.2(react@18.2.0)
@@ -373,8 +373,8 @@ importers:
         specifier: ^3.13.1
         version: 3.13.1(@types/react@18.2.34)(graphql-ws@5.16.0(graphql@16.10.0))(graphql@16.10.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@balancer/sdk':
-        specifier: 2.7.1
-        version: 2.7.1(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.24.1)
+        specifier: 3.1.0
+        version: 3.1.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@chakra-ui/anatomy':
         specifier: ^2.2.2
         version: 2.2.2
@@ -1622,8 +1622,8 @@ packages:
     resolution: {integrity: sha512-M6iqcmLfR9CP1mw3R5w0FdtZkUk7M0vCJhloAfhE/xufbAZrCSoapFYlt/NMBKLDQoGNJ2FN5E4zpdLVsxhoow==}
     engines: {node: '>=18.x'}
 
-  '@balancer/sdk@2.7.1':
-    resolution: {integrity: sha512-0N0DF8N3sLtCXoVcGQlKokAHHvxNgRCOoJanmSWQVCt3T9zHfloJFXd9WaVc6GNG3A9FcBm560uHYpKYogcg+g==}
+  '@balancer/sdk@3.1.0':
+    resolution: {integrity: sha512-p6rswNTr8pIxAetDKpjFzpbOzYG690sViuhkZiQkEyv1bMCkdnGZlfJLwFXvauH3/ZhSXmfWYml7hYo456NH4g==}
     engines: {node: '>=18.x'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -12528,7 +12528,7 @@ snapshots:
 
   '@balancer-labs/balancer-maths@0.0.24': {}
 
-  '@balancer/sdk@2.7.1(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@balancer/sdk@3.1.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
       '@balancer-labs/balancer-maths': 0.0.24
       '@types/big.js': 6.2.2


### PR DESCRIPTION
The last sdk version has important breaking changes as it exports addresses in a different way: 

Context: https://github.com/balancer/b-sdk/pull/644