### PR TITLE
fix: only add subpath to pool composer url for balancer

### DIFF
--- a/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -59,7 +59,7 @@ import ButtonGroup, {
 } from '@repo/lib/shared/components/btns/button-group/ButtonGroup'
 import { useCow } from '../../cow/useCow'
 import Link from 'next/link'
-import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
+import { isBalancer, PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
 const SLIDER_MAX_VALUE = 10000000
 const SLIDER_STEP_SIZE = 100000
@@ -569,8 +569,11 @@ export function PoolListFilters() {
   }
 
   const { options, externalLinks } = PROJECT_CONFIG
-  const subPath = !options.showVeBal ? '' : isCowPath ? 'cow' : 'v3'
-  const poolCreatorUrl = `${externalLinks.poolComposerUrl}/${subPath}`
+  const subPath = isCowPath ? 'cow' : 'v3'
+
+  const poolCreatorUrl = isBalancer
+    ? `${externalLinks.poolComposerUrl}/${subPath}`
+    : externalLinks.poolComposerUrl
 
   return (
     <VStack w="full">


### PR DESCRIPTION
this prevents a subpath from being added to beets which then didn't open the url after a button click