### PR TITLE
fix: lock step token approvals and onSuccess callback

### DIFF
--- a/packages/lib/modules/vebal/lock/steps/useLockStep.integration.spec.tsx
+++ b/packages/lib/modules/vebal/lock/steps/useLockStep.integration.spec.tsx
@@ -13,10 +13,20 @@ import { mainnetTestPublicClient } from '@repo/lib/test/utils/wagmi/wagmi-test-c
 import { Address, parseUnits } from 'viem'
 import { LockActionType } from './lock-steps.utils'
 import { useLockStep } from './useLockStep'
+import { PropsWithChildren } from 'react'
+import { TokenBalancesProvider } from '@repo/lib/modules/tokens/TokenBalancesProvider'
 
 const lockAmount: bigint = parseUnits('3000', 18)
 const veBalContractAddress = mainnetNetworkConfig.contracts.veBAL as Address
 const veBalBpt = mainnetNetworkConfig.tokens.addresses.veBalBpt as Address
+
+function Providers({ children }: PropsWithChildren) {
+  return (
+    <TransactionStateProvider>
+      <TokenBalancesProvider initTokens={[]}>{children}</TokenBalancesProvider>
+    </TransactionStateProvider>
+  )
+}
 
 function testUseLockStep() {
   const { result } = testHook(
@@ -30,7 +40,7 @@ function testUseLockStep() {
 
       return useManagedTransaction(_txInput as ManagedTransactionInput)
     },
-    { wrapper: TransactionStateProvider }
+    { wrapper: Providers }
   )
 
   return result

--- a/packages/lib/modules/vebal/lock/steps/useLockStep.tsx
+++ b/packages/lib/modules/vebal/lock/steps/useLockStep.tsx
@@ -20,8 +20,7 @@ import {
   getLockContractFunctionName,
 } from './lock-steps.utils'
 import { useTransactionState } from '@repo/lib/modules/transactions/transaction-steps/TransactionStateProvider'
-import { useVeBALBalance } from '../../vote/useVeBALBalance'
-import { queryClient } from '@repo/lib/shared/app/react-query.provider'
+import { useTokenBalances } from '@repo/lib/modules/tokens/TokenBalancesProvider'
 
 type UseLockStepArgs = {
   lockAmount: bigint
@@ -31,7 +30,7 @@ type UseLockStepArgs = {
 
 export function useLockStep({ lockAmount, lockEndDate, lockActionType }: UseLockStepArgs) {
   const { userAddress } = useUserAccount()
-  const { queryKey: veBALBalanceQueryKey } = useVeBALBalance(userAddress)
+  const { refetchBalances } = useTokenBalances()
   const labels: TransactionLabels = useMemo(
     () => ({
       init: getInitLabel(lockActionType),
@@ -81,8 +80,9 @@ export function useLockStep({ lockAmount, lockEndDate, lockActionType }: UseLock
   }, [lockAmount, lockEndDate, lockActionType, labels, txSimulationMeta])
 
   const onSuccess = useCallback(async () => {
-    queryClient.invalidateQueries(veBALBalanceQueryKey)
-  }, [veBALBalanceQueryKey])
+    // Refetches veBAL BPT balance which also affects veBal balance queries
+    await refetchBalances()
+  }, [refetchBalances])
 
   const { getTransaction } = useTransactionState()
 

--- a/packages/lib/modules/vebal/lock/steps/useLockStep.tsx
+++ b/packages/lib/modules/vebal/lock/steps/useLockStep.tsx
@@ -20,6 +20,8 @@ import {
   getLockContractFunctionName,
 } from './lock-steps.utils'
 import { useTransactionState } from '@repo/lib/modules/transactions/transaction-steps/TransactionStateProvider'
+import { useVeBALBalance } from '../../vote/useVeBALBalance'
+import { queryClient } from '@repo/lib/shared/app/react-query.provider'
 
 type UseLockStepArgs = {
   lockAmount: bigint
@@ -29,6 +31,7 @@ type UseLockStepArgs = {
 
 export function useLockStep({ lockAmount, lockEndDate, lockActionType }: UseLockStepArgs) {
   const { userAddress } = useUserAccount()
+  const { queryKey: veBALBalanceQueryKey } = useVeBALBalance(userAddress)
   const labels: TransactionLabels = useMemo(
     () => ({
       init: getInitLabel(lockActionType),
@@ -66,7 +69,7 @@ export function useLockStep({ lockAmount, lockEndDate, lockActionType }: UseLock
     }
 
     return {
-      enabled: !!lockAmount && !!lockEndDate,
+      enabled: !!lockEndDate,
       labels,
       chainId: mainnetNetworkConfig.chainId,
       contractAddress: mainnetNetworkConfig.contracts.veBAL as Address,
@@ -77,9 +80,9 @@ export function useLockStep({ lockAmount, lockEndDate, lockActionType }: UseLock
     }
   }, [lockAmount, lockEndDate, lockActionType, labels, txSimulationMeta])
 
-  const onSuccess = useCallback(() => {
-    // Handle success actions
-  }, [])
+  const onSuccess = useCallback(async () => {
+    queryClient.invalidateQueries(veBALBalanceQueryKey)
+  }, [veBALBalanceQueryKey])
 
   const { getTransaction } = useTransactionState()
 

--- a/packages/lib/modules/vebal/lock/steps/useLockSteps.tsx
+++ b/packages/lib/modules/vebal/lock/steps/useLockSteps.tsx
@@ -55,6 +55,13 @@ export function useLockSteps({
     const selectedLockSteps = lockActionTypes
       .map(lockActionType => lockSteps.find(lockStep => lockStep.stepType === lockActionType))
       .filter(Boolean) as TransactionStep[]
+
+    const isOnlyExtending = lockActionTypes.includes(LockActionType.ExtendLock) && lockAmount === 0n
+    if (isOnlyExtending) {
+      // Avoid token approvals when extending lock date without increasing amount
+      return [...selectedLockSteps]
+    }
+
     return [...tokenApprovalSteps, ...selectedLockSteps]
   }, [
     tokenApprovalSteps,
@@ -63,6 +70,7 @@ export function useLockSteps({
     extendLockStep,
     increaseLockStep,
     lockActionTypes,
+    lockAmount,
   ])
 
   return {

--- a/packages/lib/modules/vebal/vote/useVeBALBalance.ts
+++ b/packages/lib/modules/vebal/vote/useVeBALBalance.ts
@@ -2,9 +2,10 @@ import { mainnet } from 'viem/chains'
 import { useReadContract } from 'wagmi'
 import mainnetNetworkConfig from '@repo/lib/config/networks/mainnet'
 import { veBalAbi } from '../../web3/contracts/abi/generated'
+import { InvalidateQueryFilters } from '@tanstack/react-query'
 
 export function useVeBALBalance(accountAddress: `0x${string}`) {
-  const { data, isLoading, refetch } = useReadContract({
+  const { data, isLoading, refetch, queryKey } = useReadContract({
     chainId: mainnet.id,
     abi: veBalAbi,
     address: mainnetNetworkConfig.contracts.veBAL,
@@ -17,5 +18,6 @@ export function useVeBALBalance(accountAddress: `0x${string}`) {
     veBALBalance: data || 0n,
     isLoading,
     refetch,
+    queryKey: queryKey as InvalidateQueryFilters,
   }
 }

--- a/packages/lib/modules/web3/UserAccountProvider.tsx
+++ b/packages/lib/modules/web3/UserAccountProvider.tsx
@@ -13,7 +13,7 @@ import { captureError, ensureError } from '@repo/lib/shared/utils/errors'
 import { useIsMounted } from '@repo/lib/shared/hooks/useIsMounted'
 import { useSafeAppConnectionGuard } from './useSafeAppConnectionGuard'
 import { useWCConnectionLocalStorage } from './wallet-connect/useWCConnectionLocalStorage'
-import { clearWalletConnectConnected } from '@repo/lib/test/utils/wagmi/fork.helpers'
+import { clearImpersonatedAddressLS } from '@repo/lib/test/utils/wagmi/fork.helpers'
 
 async function isAuthorizedAddress(address: Address): Promise<boolean> {
   try {
@@ -90,7 +90,7 @@ export function _useUserAccount() {
   useAccountEffect({
     onDisconnect: () => {
       if (shouldUseAnvilFork) {
-        clearWalletConnectConnected()
+        clearImpersonatedAddressLS()
       }
       if (isConnectedToWC) {
         // When disconnecting from WC connector we need a full page reload to enforce a new WC connector instance created

--- a/packages/lib/modules/web3/impersonation/TimeMocker.tsx
+++ b/packages/lib/modules/web3/impersonation/TimeMocker.tsx
@@ -28,6 +28,7 @@ function TimeMocker({ setIsFakeTime }: Props) {
   return (
     <HStack>
       <Button onClick={() => mockTime(1)}>+1 day</Button>
+      <Button onClick={() => mockTime(5)}>+5 days</Button>
       <Button onClick={() => resetTime()}>Reset time</Button>
     </HStack>
   )

--- a/packages/lib/modules/web3/impersonation/useImpersonateAccount.ts
+++ b/packages/lib/modules/web3/impersonation/useImpersonateAccount.ts
@@ -85,7 +85,7 @@ export function useImpersonateAccount() {
       return console.log('Cannot reset cause there is no stored impersonated address')
     }
     // We don't pass jsonrpcUrl so it will reset to the initial used state
-    forkClient.reset()
+    await forkClient.reset()
     await setForkBalances({
       impersonatedAddress: storedImpersonatedAddress.current as Address,
       wagmiConfig,

--- a/packages/lib/test/utils/wagmi/fork.helpers.ts
+++ b/packages/lib/test/utils/wagmi/fork.helpers.ts
@@ -95,7 +95,7 @@ export function getSavedImpersonatedAddressLS(): Address | undefined {
   return result && isAddress(result) ? result : undefined
 }
 
-export function clearWalletConnectConnected() {
+export function clearImpersonatedAddressLS() {
   if (!isLocalStorageAvailable()) return
   localStorage.removeItem(storageKey)
 }


### PR DESCRIPTION
Fixes 2 issues with lock step flows: 

1. When only extending lock date but not increasing locked amount we must ignore token approval steps. 
2. refetches balances (veBal pool balance in this context) query on lock step success. 

Also adds small improvements to impersonator hook.