### PR TITLE
Fix popover animations losing frames

### DIFF
--- a/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
@@ -155,6 +155,7 @@ function BaseAprTooltip({
   const popoverContent = customPopoverContent || (
     <PopoverContent
       minWidth={['100px', '300px']}
+      motionProps={{ animate: { scale: 1, opacity: 1 } }}
       overflow="hidden"
       p="0"
       shadow="3xl"


### PR DESCRIPTION
The animations for the APR popover lose performance when too many components inside. Passing animation parameters through _motionProps_ directly seems to fix the issue.