### PR TITLE
Avoid showing stake popover on mount

### DIFF
--- a/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
@@ -408,7 +408,7 @@ function BaseAprTooltip({
   )
 
   return (
-    <Popover placement={placement} trigger="hover">
+    <Popover isLazy placement={placement} trigger="hover">
       {({ isOpen }) => (
         <>
           <PopoverTrigger>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bac46036-8737-4536-940f-dfbef236add6)

With custom animations the popover was shown on mount instead of waiting for the hover trigger.