### PR TITLE
Pools page hero stats

### DIFF
--- a/apps/beets-frontend-v3/app/(app)/pools/page.tsx
+++ b/apps/beets-frontend-v3/app/(app)/pools/page.tsx
@@ -1,44 +1,18 @@
 import { PoolsPage } from '@repo/lib/shared/pages/PoolsPage/PoolsPage'
 import { BeetsPromoBanner } from '@/lib/components/promos/BeetsPromoBanner'
-import {
-  GetProtocolStatsDocument,
-  GetStakedSonicDataDocument,
-  GqlChain,
-} from '@repo/lib/shared/services/api/generated/graphql'
+import { GetStakedSonicDataDocument } from '@repo/lib/shared/services/api/generated/graphql'
 import { getApolloServerClient } from '@repo/lib/shared/services/api/apollo-server.client'
-import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
-import { mins } from '@repo/lib/shared/utils/time'
 
 export default async function PoolsPageWrapper() {
   const client = getApolloServerClient()
-
-  const variables = {
-    chains: [...PROJECT_CONFIG.supportedNetworks, GqlChain.Fantom], // manually adding Fantom to the list to get the data for the landing page
-  }
 
   const { data: stakedSonicData } = await client.query({
     query: GetStakedSonicDataDocument,
     variables: {},
   })
 
-  const { data: protocolData } = await client.query({
-    query: GetProtocolStatsDocument,
-    variables,
-    context: {
-      fetchOptions: {
-        next: { revalidate: mins(10).toSecs() },
-      },
-    },
-  })
-
-  // we're on the server here so can't use 'bn'
-  const additionalFees = (
-    parseFloat(stakedSonicData.stsGetGqlStakedSonicData.rewardsClaimed24h) +
-    parseFloat(protocolData.protocolMetricsAggregated.yieldCapture24h)
-  ).toString()
-
   return (
-    <PoolsPage additionalFees={additionalFees}>
+    <PoolsPage rewardsClaimed24h={stakedSonicData.stsGetGqlStakedSonicData.rewardsClaimed24h}>
       <BeetsPromoBanner />
     </PoolsPage>
   )

--- a/packages/lib/shared/components/other/AnimatedNumber.tsx
+++ b/packages/lib/shared/components/other/AnimatedNumber.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react'
+import {
+  motion,
+  animate,
+  useMotionValue,
+  useTransform,
+  AnimationPlaybackControls,
+} from 'framer-motion'
+import { fNumCustom } from '../../utils/numbers'
+
+type AnimatedNumberProps = {
+  value: number
+  formatOptions: string
+}
+
+export function AnimatedNumber({ value, formatOptions }: AnimatedNumberProps) {
+  const motionValue = useMotionValue(value)
+  const isInitialRenderRef = useRef(true)
+  const controlsRef = useRef<AnimationPlaybackControls | null>(null)
+
+  const formattedValue = useTransform(motionValue, latest => {
+    const num = Number.isFinite(latest) ? latest : 0
+    return fNumCustom(num, formatOptions)
+  })
+
+  useEffect(() => {
+    if (isInitialRenderRef.current) {
+      motionValue.set(value * 0.75)
+      isInitialRenderRef.current = false
+    }
+
+    controlsRef.current = animate(motionValue, value, {
+      duration: 1.5,
+      ease: 'easeOut',
+    })
+
+    return () => controlsRef.current?.stop()
+  }, [value, motionValue])
+
+  return <motion.span>{formattedValue}</motion.span>
+}

--- a/packages/lib/shared/components/other/Stat.tsx
+++ b/packages/lib/shared/components/other/Stat.tsx
@@ -58,7 +58,7 @@ function Stat({
         <Text fontSize="xs" mb="1.5" variant="secondary">
           {label}
         </Text>
-        <Text className="home-stats" fontSize="md" fontWeight="bold" letterSpacing="-0.5px">
+        <Text className="home-stats" fontSize="md" fontWeight="bold" letterSpacing="-0.6px">
           {value}
         </Text>
       </Box>

--- a/packages/lib/shared/components/other/Stat.tsx
+++ b/packages/lib/shared/components/other/Stat.tsx
@@ -1,9 +1,10 @@
 import { Box, Text } from '@chakra-ui/react'
 import { Picture } from './Picture'
+import { ReactNode } from 'react'
 
 interface StatProps {
   label: string
-  value: string
+  value: ReactNode
   imageBackgroundSize?: string
   imageBackgroundPosition?: string
   imageTransform?: string
@@ -57,7 +58,7 @@ function Stat({
         <Text fontSize="xs" mb="1.5" variant="secondary">
           {label}
         </Text>
-        <Text fontSize="md" fontWeight="bold">
+        <Text className="home-stats" fontSize="md" fontWeight="bold" letterSpacing="-0.5px">
           {value}
         </Text>
       </Box>

--- a/packages/lib/shared/components/other/Stat.tsx
+++ b/packages/lib/shared/components/other/Stat.tsx
@@ -8,6 +8,7 @@ interface StatProps {
   imageBackgroundSize?: string
   imageBackgroundPosition?: string
   imageTransform?: string
+  popover?: boolean
 }
 
 function Stat({
@@ -16,6 +17,7 @@ function Stat({
   imageBackgroundSize = 'cover',
   imageBackgroundPosition = 'left',
   imageTransform = 'scale(1)',
+  popover = false,
 }: StatProps) {
   return (
     <Box
@@ -55,7 +57,30 @@ function Stat({
         </Box>
       </Box>
       <Box p="2">
-        <Text fontSize="xs" mb="1.5" variant="secondary">
+        <Text
+          fontSize="xs"
+          mb="1.5"
+          position="relative"
+          variant="secondary"
+          w="fit-content"
+          {...(popover
+            ? {
+                _after: {
+                  content: '""',
+                  display: 'block',
+                  position: 'absolute',
+                  left: 0,
+                  right: 0,
+                  bottom: '-1.5px',
+                  height: '0px',
+                  borderBottom: '1px dotted',
+                  opacity: 0.5,
+                  width: '100%',
+                  pointerEvents: 'none',
+                },
+              }
+            : {})}
+        >
           {label}
         </Text>
         <Text className="home-stats" fontSize="md" fontWeight="bold" letterSpacing="-0.6px">

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -2,8 +2,9 @@
 
 import { Box, Flex } from '@chakra-ui/react'
 import Stat from '../../components/other/Stat'
-import { bn, fNumCustom } from '../../utils/numbers'
+import { bn } from '../../utils/numbers'
 import { useProtocolStats } from '@repo/lib/modules/protocol/ProtocolStatsProvider'
+import { AnimatedNumber } from '../../components/other/AnimatedNumber'
 
 export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
   const { protocolData } = useProtocolStats()
@@ -12,26 +13,43 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
     .plus(bn(additionalFees || 0))
     .toString()
 
+  const formatOptions = '$0,0.00a'
+
+  const safeToNumber = (val: string | number | undefined | null): number => {
+    const num = Number(val)
+    return Number.isNaN(num) ? 0 : num
+  }
+
   return (
     <Flex direction="row" flexWrap="wrap" gap={{ base: 'sm', lg: 'ms' }} mt="3">
       <Box flex="1">
         <Stat
           label="TVL"
-          value={fNumCustom(protocolData?.protocolMetricsAggregated.totalLiquidity ?? 0, '$0,0.0a')}
+          value={
+            <AnimatedNumber
+              formatOptions={formatOptions}
+              value={safeToNumber(protocolData?.protocolMetricsAggregated.totalLiquidity)}
+            />
+          }
         />
       </Box>
       <Box flex="1">
         <Stat
           imageTransform="rotate(180deg)"
           label="Volume (24h)"
-          value={fNumCustom(protocolData?.protocolMetricsAggregated.swapVolume24h ?? 0, '$0,0.0a')}
+          value={
+            <AnimatedNumber
+              formatOptions={formatOptions}
+              value={safeToNumber(protocolData?.protocolMetricsAggregated.swapVolume24h)}
+            />
+          }
         />
       </Box>
       <Box flex="1">
         <Stat
           imageTransform="scale(1.5)"
           label={`${additionalFees ? 'Fees' : 'Swap fees'} (24h)`}
-          value={fNumCustom(totalFees, '$0,0.0a')}
+          value={<AnimatedNumber formatOptions={formatOptions} value={bn(totalFees).toNumber()} />}
         />
       </Box>
       {/* <Box flex={{ base: '1 1 40%', sm: '1' }}>
@@ -39,10 +57,12 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
           imageBackgroundSize="400%"
           imageTransform="rotate(180deg) scale(2)"
           label="Protocol revenue (24h)"
-          value={fNumCustom(
-            protocolData?.protocolMetricsAggregated.yieldCapture24h ?? 0,
-            '$0,0.0a'
-          )}
+          value={
+            <AnimatedNumber
+              formatOptions={'$0,0.0a'}
+              value={safeToNumber(protocolData?.protocolMetricsAggregated.yieldCapture24h)}
+            />
+          }
         />
       </Box> */}
     </Flex>

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -57,7 +57,7 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
 
       <Box flex={{ base: '1 1 40%', sm: '1' }}>
         <Popover
-          modifiers={[{ name: 'offset', options: { offset: [0, -5] } }]}
+          modifiers={[{ name: 'offset', options: { offset: [0, -3] } }]}
           placement="top"
           trigger="hover"
         >
@@ -88,7 +88,7 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
                   <Text color="font.secondary" fontSize="xs">
                     Swap fees
                   </Text>
-                  <Text color="font.secondary" fontSize="xs">
+                  <Text className="home-stats" color="font.secondary" fontSize="xs">
                     <AnimatedNumber
                       formatOptions={formatOptions}
                       value={safeToNumber(protocolData?.protocolMetricsAggregated.swapFee24h)}
@@ -99,7 +99,7 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
                   <Text color="font.secondary" fontSize="xs">
                     Yield-bearing tokens
                   </Text>
-                  <Text color="font.secondary" fontSize="xs">
+                  <Text className="home-stats" color="font.secondary" fontSize="xs">
                     <AnimatedNumber
                       formatOptions={formatOptions}
                       value={safeToNumber(protocolData?.protocolMetricsAggregated.yieldCapture24h)}

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -55,8 +55,6 @@ export function PoolPageStats({ rewardsClaimed24h }: PoolPageStatsProps) {
     })
   }
 
-  console.log({ fees })
-
   const totalFees = fees
     .reduce((sum, fee) => {
       return sum.plus(bn(fee.value || 0))

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -107,6 +107,7 @@ export function PoolPageStats({ rewardsClaimed24h }: PoolPageStatsProps) {
                 imageBackgroundSize="400%"
                 imageTransform="rotate(180deg) scale(2)"
                 label={feeLabel}
+                popover
                 value={
                   <AnimatedNumber formatOptions={formatOptions} value={safeToNumber(totalFees)} />
                 }

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -10,7 +10,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 import Stat from '../../components/other/Stat'
-import { bn } from '../../utils/numbers'
+import { bn, safeToNumber } from '../../utils/numbers'
 import { useProtocolStats } from '@repo/lib/modules/protocol/ProtocolStatsProvider'
 import { AnimatedNumber } from '../../components/other/AnimatedNumber'
 import { isBalancer } from '@repo/lib/config/getProjectConfig'
@@ -62,11 +62,6 @@ export function PoolPageStats({ rewardsClaimed24h }: PoolPageStatsProps) {
     .toString()
 
   const formatOptions = '$0,0.00a'
-
-  const safeToNumber = (val: string | number | undefined | null): number => {
-    const num = Number(val)
-    return Number.isNaN(num) ? 0 : num
-  }
 
   return (
     <Flex direction="row" flexWrap="wrap" gap={{ base: 'sm', lg: 'ms' }} mt="3">

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -57,71 +57,87 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
       </Box>
 
       <Box flex={{ base: '1 1 40%', sm: '1' }}>
-        <Popover
-          modifiers={[{ name: 'offset', options: { offset: [0, -24] } }]}
-          placement="top"
-          trigger="hover"
-        >
-          <PopoverTrigger>
-            <Box>
-              <Stat
-                imageBackgroundSize="400%"
-                imageTransform="rotate(180deg) scale(2)"
-                label="Yield (24h)"
-                value={
-                  <AnimatedNumber formatOptions={formatOptions} value={bn(totalYield).toNumber()} />
-                }
-              />
-            </Box>
-          </PopoverTrigger>
-          <PopoverContent
-            bg="background.level0"
-            borderRadius="md"
-            minW="200px"
-            p={2}
-            shadow="2xl"
-            w="auto"
-            zIndex={9999}
+        {!additionalFees ? (
+          <Popover
+            modifiers={[{ name: 'offset', options: { offset: [0, -24] } }]}
+            placement="top"
+            trigger="hover"
           >
-            <PopoverBody p="0">
-              <Flex direction="column" gap={1}>
-                <Flex align="center" justify="space-between">
-                  <Text color="font.secondary" fontSize="xs">
-                    Swap fees
-                  </Text>
-                  <Text className="home-stats" color="font.secondary" fontSize="xs">
+            <PopoverTrigger>
+              <Box>
+                <Stat
+                  imageBackgroundSize="400%"
+                  imageTransform="rotate(180deg) scale(2)"
+                  label="Yield (24h)"
+                  value={
                     <AnimatedNumber
                       formatOptions={formatOptions}
-                      value={safeToNumber(protocolData?.protocolMetricsAggregated.swapFee24h)}
+                      value={safeToNumber(totalYield)}
                     />
-                  </Text>
+                  }
+                />
+              </Box>
+            </PopoverTrigger>
+            <PopoverContent
+              bg="background.level0"
+              borderRadius="md"
+              minW="200px"
+              p={2}
+              shadow="2xl"
+              w="auto"
+              zIndex={9999}
+            >
+              <PopoverBody p="0">
+                <Flex direction="column" gap={1}>
+                  <Flex align="center" justify="space-between">
+                    <Text color="font.secondary" fontSize="xs">
+                      Swap fees
+                    </Text>
+                    <Text className="home-stats" color="font.secondary" fontSize="xs">
+                      <AnimatedNumber
+                        formatOptions={formatOptions}
+                        value={safeToNumber(protocolData?.protocolMetricsAggregated.swapFee24h)}
+                      />
+                    </Text>
+                  </Flex>
+                  <Flex align="center" justify="space-between">
+                    <Text color="font.secondary" fontSize="xs">
+                      Yield-bearing tokens
+                    </Text>
+                    <Text className="home-stats" color="font.secondary" fontSize="xs">
+                      <AnimatedNumber
+                        formatOptions={formatOptions}
+                        value={safeToNumber(
+                          protocolData?.protocolMetricsAggregated.yieldCapture24h
+                        )}
+                      />
+                    </Text>
+                  </Flex>
+                  <Flex align="center" justify="space-between">
+                    <Text color="font.secondary" fontSize="xs">
+                      CoW AMM LVR surplus
+                    </Text>
+                    <Text className="home-stats" color="font.secondary" fontSize="xs">
+                      <AnimatedNumber
+                        formatOptions={formatOptions}
+                        value={safeToNumber(protocolData?.protocolMetricsAggregated.surplus24h)}
+                      />
+                    </Text>
+                  </Flex>
                 </Flex>
-                <Flex align="center" justify="space-between">
-                  <Text color="font.secondary" fontSize="xs">
-                    Yield-bearing tokens
-                  </Text>
-                  <Text className="home-stats" color="font.secondary" fontSize="xs">
-                    <AnimatedNumber
-                      formatOptions={formatOptions}
-                      value={safeToNumber(protocolData?.protocolMetricsAggregated.yieldCapture24h)}
-                    />
-                  </Text>
-                </Flex>
-                <Flex align="center" justify="space-between">
-                  <Text color="font.secondary" fontSize="xs">
-                    CoW AMM LVR surplus
-                  </Text>
-                  <Text className="home-stats" color="font.secondary" fontSize="xs">
-                    <AnimatedNumber
-                      formatOptions={formatOptions}
-                      value={safeToNumber(protocolData?.protocolMetricsAggregated.surplus24h)}
-                    />
-                  </Text>
-                </Flex>
-              </Flex>
-            </PopoverBody>
-          </PopoverContent>
-        </Popover>
+              </PopoverBody>
+            </PopoverContent>
+          </Popover>
+        ) : (
+          <Stat
+            imageBackgroundSize="400%"
+            imageTransform="rotate(180deg) scale(2)"
+            label="Fees (24h)"
+            value={
+              <AnimatedNumber formatOptions={formatOptions} value={safeToNumber(totalYield)} />
+            }
+          />
+        )}
       </Box>
     </Flex>
   )

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -1,6 +1,14 @@
 'use client'
 
-import { Box, Flex } from '@chakra-ui/react'
+import {
+  Box,
+  Flex,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverBody,
+  Text,
+} from '@chakra-ui/react'
 import Stat from '../../components/other/Stat'
 import { bn } from '../../utils/numbers'
 import { useProtocolStats } from '@repo/lib/modules/protocol/ProtocolStatsProvider'
@@ -9,7 +17,8 @@ import { AnimatedNumber } from '../../components/other/AnimatedNumber'
 export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
   const { protocolData } = useProtocolStats()
 
-  const totalFees = bn(protocolData?.protocolMetricsAggregated.swapFee24h || 0)
+  const totalYield = bn(protocolData?.protocolMetricsAggregated.swapFee24h || 0)
+    .plus(bn(protocolData?.protocolMetricsAggregated.yieldCapture24h || 0))
     .plus(bn(additionalFees || 0))
     .toString()
 
@@ -45,26 +54,63 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
           }
         />
       </Box>
-      <Box flex="1">
-        <Stat
-          imageTransform="scale(1.5)"
-          label={`${additionalFees ? 'Fees' : 'Swap fees'} (24h)`}
-          value={<AnimatedNumber formatOptions={formatOptions} value={bn(totalFees).toNumber()} />}
-        />
+
+      <Box flex={{ base: '1 1 40%', sm: '1' }}>
+        <Popover
+          modifiers={[{ name: 'offset', options: { offset: [0, -5] } }]}
+          placement="top"
+          trigger="hover"
+        >
+          <PopoverTrigger>
+            <Box>
+              <Stat
+                imageBackgroundSize="400%"
+                imageTransform="rotate(180deg) scale(2)"
+                label="Yield (24h)"
+                value={
+                  <AnimatedNumber formatOptions={formatOptions} value={bn(totalYield).toNumber()} />
+                }
+              />
+            </Box>
+          </PopoverTrigger>
+          <PopoverContent
+            bg="background.level0"
+            borderRadius="md"
+            minW="190px"
+            p={2}
+            shadow="2xl"
+            w="auto"
+            zIndex={9999}
+          >
+            <PopoverBody p="0">
+              <Flex direction="column" gap={1}>
+                <Flex align="center" justify="space-between">
+                  <Text color="font.secondary" fontSize="xs">
+                    Swap fees
+                  </Text>
+                  <Text color="font.secondary" fontSize="xs">
+                    <AnimatedNumber
+                      formatOptions={formatOptions}
+                      value={safeToNumber(protocolData?.protocolMetricsAggregated.swapFee24h)}
+                    />
+                  </Text>
+                </Flex>
+                <Flex align="center" justify="space-between">
+                  <Text color="font.secondary" fontSize="xs">
+                    Yield-bearing tokens
+                  </Text>
+                  <Text color="font.secondary" fontSize="xs">
+                    <AnimatedNumber
+                      formatOptions={formatOptions}
+                      value={safeToNumber(protocolData?.protocolMetricsAggregated.yieldCapture24h)}
+                    />
+                  </Text>
+                </Flex>
+              </Flex>
+            </PopoverBody>
+          </PopoverContent>
+        </Popover>
       </Box>
-      {/* <Box flex={{ base: '1 1 40%', sm: '1' }}>
-        <Stat
-          imageBackgroundSize="400%"
-          imageTransform="rotate(180deg) scale(2)"
-          label="Protocol revenue (24h)"
-          value={
-            <AnimatedNumber
-              formatOptions={'$0,0.0a'}
-              value={safeToNumber(protocolData?.protocolMetricsAggregated.yieldCapture24h)}
-            />
-          }
-        />
-      </Box> */}
     </Flex>
   )
 }

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -41,7 +41,7 @@ export function PoolPageStats({ rewardsClaimed24h }: PoolPageStatsProps) {
     },
   ]
 
-  if (rewardsClaimed24h) {
+  if (rewardsClaimed24h && rewardsClaimed24h !== '0') {
     fees.push({
       label: 'stS rewards',
       value: rewardsClaimed24h,

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -57,7 +57,7 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
 
       <Box flex={{ base: '1 1 40%', sm: '1' }}>
         <Popover
-          modifiers={[{ name: 'offset', options: { offset: [0, -3] } }]}
+          modifiers={[{ name: 'offset', options: { offset: [0, -24] } }]}
           placement="top"
           trigger="hover"
         >
@@ -76,7 +76,7 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
           <PopoverContent
             bg="background.level0"
             borderRadius="md"
-            minW="190px"
+            minW="200px"
             p={2}
             shadow="2xl"
             w="auto"
@@ -103,6 +103,17 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
                     <AnimatedNumber
                       formatOptions={formatOptions}
                       value={safeToNumber(protocolData?.protocolMetricsAggregated.yieldCapture24h)}
+                    />
+                  </Text>
+                </Flex>
+                <Flex align="center" justify="space-between">
+                  <Text color="font.secondary" fontSize="xs">
+                    CoW AMM LVR surplus
+                  </Text>
+                  <Text className="home-stats" color="font.secondary" fontSize="xs">
+                    <AnimatedNumber
+                      formatOptions={formatOptions}
+                      value={safeToNumber(protocolData?.protocolMetricsAggregated.surplus24h)}
                     />
                   </Text>
                 </Flex>

--- a/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolPageStats.tsx
@@ -19,6 +19,7 @@ export function PoolPageStats({ additionalFees }: { additionalFees?: string }) {
 
   const totalYield = bn(protocolData?.protocolMetricsAggregated.swapFee24h || 0)
     .plus(bn(protocolData?.protocolMetricsAggregated.yieldCapture24h || 0))
+    .plus(bn(protocolData?.protocolMetricsAggregated.surplus24h || 0))
     .plus(bn(additionalFees || 0))
     .toString()
 

--- a/packages/lib/shared/pages/PoolsPage/PoolsPage.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolsPage.tsx
@@ -13,10 +13,11 @@ import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { fNumCustom } from '../../utils/numbers'
 import { useProtocolStats } from '@repo/lib/modules/protocol/ProtocolStatsProvider'
 
-export function PoolsPage({
-  children,
-  additionalFees,
-}: PropsWithChildren & { additionalFees?: string }) {
+type PoolsPageProps = PropsWithChildren & {
+  rewardsClaimed24h?: string
+}
+
+export function PoolsPage({ children, rewardsClaimed24h }: PoolsPageProps) {
   const { protocolData } = useProtocolStats()
 
   return (
@@ -93,7 +94,7 @@ export function PoolsPage({
                     {`Join ${fNumCustom(protocolData?.protocolMetricsAggregated.numLiquidityProviders || '0', '0a')}+ Liquidity Providers in yield-bearing pools`}
                   </Text>
                 </Box>
-                <PoolPageStats additionalFees={additionalFees} />
+                <PoolPageStats rewardsClaimed24h={rewardsClaimed24h} />
               </Flex>
             </FadeInOnView>
             <FadeInOnView animateOnce={false}>

--- a/packages/lib/shared/services/api/protocol-stats.graphql
+++ b/packages/lib/shared/services/api/protocol-stats.graphql
@@ -7,6 +7,7 @@ query GetProtocolStats($chains: [GqlChain!]) {
     yieldCapture24h
     poolCount
     yieldCapture24h
+    surplus24h
   }
 }
 
@@ -19,5 +20,6 @@ query GetProtocolStatsPerChain($chain: GqlChain) {
     swapVolume24h
     totalLiquidity
     yieldCapture24h
+    surplus24h
   }
 }

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -280,7 +280,7 @@ export function isTooSmallToRemoveUsd(value: Numberish): boolean {
   return !isZero(value) && bn(value).lt(USD_LOWER_THRESHOLD)
 }
 
-export const isValidNumber = (value: string): boolean =>
+export const isValidNumber = (value: string | number | undefined | null): boolean =>
   isNumber(toNumber(value)) && !isNaN(toNumber(value))
 
 // Parses a fixed-point decimal string into a bigint
@@ -302,4 +302,8 @@ export function sum<T>(items: T[], extractFn: (item: T) => BigNumber): BigNumber
   return items.reduce((acc, item) => {
     return acc.plus(extractFn(item))
   }, bn(0))
+}
+
+export const safeToNumber = (val: string | number | undefined | null): number => {
+  return isValidNumber(val) ? toNumber(val) : 0
 }


### PR DESCRIPTION
- Replaced the "Swap fees" stat with 'Yield (24h)'
- Added `surplus24h` from the API to `protocol-stats.graphql`
- Added a hover state to show the breakdown of the Yield stat which shows
  - Swap fees
  - Yield-bearing tokens
- Added a number animation on page load

![cs 2025-04-24 at 11 11 41@2x](https://github.com/user-attachments/assets/67f469fe-119d-477a-a3ad-5dfb253cae9a)




