### PR TITLE
Remove pool symbol from sor paths query

### DIFF
--- a/packages/lib/shared/services/api/swap.graphql
+++ b/packages/lib/shared/services/api/swap.graphql
@@ -36,9 +36,6 @@ query SorGetSwapPaths(
     returnAmount
     routes {
       hops {
-        pool {
-          symbol
-        }
         poolId
         tokenIn
         tokenInAmount


### PR DESCRIPTION
On certain cases an error was returned by the API and right now we are not really using this data.