### PR TITLE
fix: portfolio claim incentives

### DIFF
--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPoolsLayoutWrapper.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPoolsLayoutWrapper.tsx
@@ -40,12 +40,17 @@ export default function ClaimNetworkPoolsLayoutWrapper() {
 
   const [modalPools, setModalPools] = useState<Pool[]>([])
 
-  const hasMultipleClaims = useMemo(() => {
-    if (!pools) return false
+  const poolsWithClaims = useMemo(() => {
+    if (!pools) return []
 
-    // filter out mabeets pool so it doesn't count
-    return pools.filter(pool => !isMaBeetsPool(pool.id)).length > 1
-  }, [pools])
+    return pools.filter(
+      pool =>
+        // filter out mabeets pool so it doesn't count and also filter out pools with no claims
+        !isMaBeetsPool(pool.id) && poolRewardsMap[pool.id]?.totalFiatClaimBalance?.isGreaterThan(0)
+    )
+  }, [pools, poolRewardsMap])
+
+  const hasMultipleClaims = useMemo(() => poolsWithClaims.length > 1, [poolsWithClaims])
 
   return (
     <ClaimNetworkPoolsLayout backLink="/portfolio" title="Portfolio">
@@ -63,55 +68,50 @@ export default function ClaimNetworkPoolsLayoutWrapper() {
       <Stack gap="md" py="4">
         {isLoadingRewards ? (
           <Skeleton height="126px" />
-        ) : pools && pools.length > 0 ? (
-          pools?.map(
-            pool =>
-              poolRewardsMap[pool.id]?.totalFiatClaimBalance?.isGreaterThan(0) && (
-                <Card key={pool.id} variant="subSection">
-                  <VStack align="start">
-                    <HStack w="full">
-                      <PoolName fontSize="lg" fontWeight="bold" pool={pool} />
-                      <Text fontWeight="bold" ml="auto" variant="special">
-                        {toCurrency(
-                          poolRewardsMap[pool.id]?.totalFiatClaimBalance?.toNumber() || 0
-                        )}
-                      </Text>
-                    </HStack>
-                    <HStack w="full">
-                      <TokenIconStack
-                        chain={pool.chain}
-                        size={36}
-                        tokens={getUserReferenceTokens(pool)}
-                      />
-                      {hasMultipleClaims && (
-                        <Button
-                          minW="60px"
-                          ml="auto"
-                          onClick={() => {
-                            setModalPools([pool])
-                          }}
-                          size="sm"
-                          variant="secondary"
-                        >
-                          Claim
-                        </Button>
-                      )}
-                    </HStack>
-                  </VStack>
-                </Card>
-              )
-          )
+        ) : poolsWithClaims.length > 0 ? (
+          poolsWithClaims.map(pool => (
+            <Card key={pool.id} variant="subSection">
+              <VStack align="start">
+                <HStack w="full">
+                  <PoolName fontSize="lg" fontWeight="bold" pool={pool} />
+                  <Text fontWeight="bold" ml="auto" variant="special">
+                    {toCurrency(poolRewardsMap[pool.id]?.totalFiatClaimBalance?.toNumber() || 0)}
+                  </Text>
+                </HStack>
+                <HStack w="full">
+                  <TokenIconStack
+                    chain={pool.chain}
+                    size={36}
+                    tokens={getUserReferenceTokens(pool)}
+                  />
+                  {hasMultipleClaims && (
+                    <Button
+                      minW="60px"
+                      ml="auto"
+                      onClick={() => {
+                        setModalPools([pool])
+                      }}
+                      size="sm"
+                      variant="secondary"
+                    >
+                      Claim
+                    </Button>
+                  )}
+                </HStack>
+              </VStack>
+            </Card>
+          ))
         ) : (
           <Text p="10" textAlign="center" variant="secondary">
             You have no liquidity incentives to claim
           </Text>
         )}
       </Stack>
-      {pools && pools.length > 0 && (
+      {poolsWithClaims.length > 0 && (
         <Button
           isDisabled={isClaimAllDisabled}
           onClick={() => {
-            setModalPools(pools)
+            setModalPools(poolsWithClaims)
           }}
           size="lg"
           variant="secondary"

--- a/packages/lib/modules/tokens/TokenRow/TokenRowGroup.tsx
+++ b/packages/lib/modules/tokens/TokenRow/TokenRowGroup.tsx
@@ -6,7 +6,7 @@ import { HumanTokenAmount } from '../token.types'
 import { useTotalUsdValue } from '../useTotalUsdValue'
 import TokenRow from './TokenRow'
 import { useMemo } from 'react'
-import { bn } from 'shared/utils/numbers'
+import { bn } from '@repo/lib/shared/utils/numbers'
 import { HumanAmount } from '@balancer/sdk'
 
 type HumanTokenAmountWithSymbol = HumanTokenAmount & { symbol?: string }

--- a/packages/lib/modules/tokens/TokenRow/TokenRowGroup.tsx
+++ b/packages/lib/modules/tokens/TokenRow/TokenRowGroup.tsx
@@ -5,6 +5,9 @@ import { ApiToken } from '../token.types'
 import { HumanTokenAmount } from '../token.types'
 import { useTotalUsdValue } from '../useTotalUsdValue'
 import TokenRow from './TokenRow'
+import { useMemo } from 'react'
+import { bn } from 'shared/utils/numbers'
+import { HumanAmount } from '@balancer/sdk'
 
 type HumanTokenAmountWithSymbol = HumanTokenAmount & { symbol?: string }
 
@@ -25,11 +28,35 @@ export function TokenRowGroup({
 }) {
   const { toCurrency } = useCurrency()
   const { usdValueFor } = useTotalUsdValue(tokens)
-  const _totalUSDValue = usdValueFor(amounts)
 
+  const _totalUSDValue = usdValueFor(amounts)
   const usdValue = totalUSDValue || _totalUSDValue
 
-  const hasMultipleAmounts = amounts.length > 1
+  // Aggregate amounts by tokenAddress
+  const aggregatedAmounts = useMemo(() => {
+    const amountMap: Record<string, HumanTokenAmountWithSymbol> = {}
+
+    amounts.forEach(amount => {
+      if (!amount.tokenAddress) return
+
+      const key = amount.tokenAddress
+
+      if (amountMap[key]) {
+        amountMap[key] = {
+          ...amountMap[key],
+          humanAmount: bn(amountMap[key].humanAmount)
+            .plus(bn(amount.humanAmount))
+            .toString() as HumanAmount,
+        }
+      } else {
+        amountMap[key] = { ...amount }
+      }
+    })
+
+    return Object.values(amountMap)
+  }, [amounts])
+
+  const hasMultipleAmounts = aggregatedAmounts.length > 1
 
   return (
     <VStack align="start" spacing="md">
@@ -41,7 +68,7 @@ export function TokenRowGroup({
           hasMultipleAmounts && <Text>{toCurrency(usdValue, { abbreviated: false })}</Text>
         )}
       </HStack>
-      {amounts.map(amount => {
+      {aggregatedAmounts.map(amount => {
         if (!amount.tokenAddress) return <div key={JSON.stringify(amount)}>Missing token</div>
 
         return (
@@ -50,7 +77,7 @@ export function TokenRowGroup({
             address={amount.tokenAddress}
             chain={chain}
             isLoading={isLoading}
-            key={`${amount.tokenAddress}-${amount.humanAmount}`}
+            key={amount.tokenAddress}
             symbol={amount?.symbol}
             value={amount.humanAmount}
           />


### PR DESCRIPTION
- filter pools with claims earlier so 'claim all' and 'claim' per pool are only set when needed
- aggregate amounts for the same token

before:

![image](https://github.com/user-attachments/assets/c4dbe1fd-a2f1-4864-8e96-b74998b03763)


after:

![image](https://github.com/user-attachments/assets/3cc2a72d-5e98-4bed-b501-c09187cd2235)
