### PR TITLE
fix: filter out zero price to prevent infinity

### DIFF
--- a/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
+++ b/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
@@ -40,9 +40,9 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
   const data = useMemo(() => {
     if (!liquidityData) return null
 
-    const transformedData = liquidityData.map(([price, liquidity]) =>
-      isReversed ? [1 / price, liquidity] : [price, liquidity]
-    )
+    const transformedData = liquidityData
+      .filter(([price]) => price !== 0)
+      .map(([price, liquidity]) => (isReversed ? [1 / price, liquidity] : [price, liquidity]))
 
     return transformedData.sort((a, b) => a[0] - b[0]) as [[number, number]]
   }, [liquidityData, isReversed])

--- a/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
+++ b/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
@@ -41,7 +41,7 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
     if (!liquidityData) return null
 
     const transformedData = liquidityData
-      .filter(([price]) => price !== 0)
+      .filter(([price]) => price !== 0) // filter out zero price to prevent infinity on reverse
       .map(([price, liquidity]) => (isReversed ? [1 / price, liquidity] : [price, liquidity]))
 
     return transformedData.sort((a, b) => a[0] - b[0]) as [[number, number]]


### PR DESCRIPTION
fix edge case where the lower bound of an eclp is zero
reversing the chart then tried to go to infinity (and beyond)

before:

![image](https://github.com/user-attachments/assets/7bb1410c-ad0e-45fd-924f-8238afb6fc58)

after:

![image](https://github.com/user-attachments/assets/8c7a1eb3-1e06-420c-aa38-f15a7d0d4dab)

