### PR TITLE
fix: don't show a line when reward token is unknown

### DIFF
--- a/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
@@ -243,6 +243,7 @@ function BaseAprTooltip({
           apr={merklIncentivesAprDisplayed}
           displayValueFormatter={usedDisplayValueFormatter}
           title="Merkl.xyz incentives"
+          tooltipText={merklIncentivesTooltipText}
         >
           {merklTokensDisplayed
             .filter(item => item.title !== '') // filter out rewards where the token symbol empty
@@ -253,7 +254,6 @@ function BaseAprTooltip({
                 displayValueFormatter={usedDisplayValueFormatter}
                 key={`merkl-${item.title}-${item.apr}`}
                 title={item.title}
-                tooltipText={merklIncentivesTooltipText}
               />
             ))}
         </TooltipAprItem>

--- a/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
@@ -244,8 +244,9 @@ function BaseAprTooltip({
           displayValueFormatter={usedDisplayValueFormatter}
           title="Merkl.xyz incentives"
         >
-          {merklTokensDisplayed.map(item => {
-            return (
+          {merklTokensDisplayed
+            .filter(item => item.title !== '') // filter out rewards where the token symbol empty
+            .map(item => (
               <TooltipAprItem
                 {...subitemPopoverAprItemProps}
                 apr={item.apr}
@@ -254,8 +255,7 @@ function BaseAprTooltip({
                 title={item.title}
                 tooltipText={merklIncentivesTooltipText}
               />
-            )
-          })}
+            ))}
         </TooltipAprItem>
       ) : null}
       {isCowAmmPool(poolType) && (

--- a/packages/lib/shared/components/tooltips/apr-tooltip/TooltipAprItem.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/TooltipAprItem.tsx
@@ -63,11 +63,21 @@ export function TooltipAprItem({
           <Popover trigger="hover">
             <PopoverTrigger>
               <Text
-                className="tooltip-dashed-underline"
+                _after={{
+                  borderBottom: '1px dotted',
+                  borderColor: 'currentColor',
+                  bottom: '-2px',
+                  content: '""',
+                  left: 0,
+                  opacity: 0.5,
+                  position: 'absolute',
+                  width: '100%',
+                }}
                 color={valueFontColor ?? fontColor}
                 fontSize="sm"
                 fontWeight={fontWeight}
                 opacity={aprOpacity}
+                position="relative"
                 variant={textVariant}
               >
                 {displayValueFormatter(apr)}


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/f4e331c6-f01b-4206-ad47-bf6a9072e958)


after (moved the tooltip too):

![image](https://github.com/user-attachments/assets/cf447007-e609-4002-b779-c887d27d2845)

