### PR TITLE
feat: use actionable tokens in eclp chart

### DIFF
--- a/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
+++ b/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
@@ -28,7 +28,6 @@ function _useEclpChart() {
 
   const tokens = useMemo(() => {
     const poolTokens = getPoolActionableTokens(pool).map(token => token.symbol)
-    console.log({ poolTokens })
 
     return isReversed ? poolTokens.join('/') : poolTokens.reverse().join('/')
   }, [pool, isReversed])

--- a/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
+++ b/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
@@ -29,7 +29,7 @@ function _useEclpChart() {
   const tokens = useMemo(() => {
     const poolTokens = getPoolActionableTokens(pool).map(token => token.symbol)
 
-    return isReversed ? poolTokens.join('/') : poolTokens.reverse().join('/')
+    return isReversed ? poolTokens.reverse().join('/') : poolTokens.join('/')
   }, [pool, isReversed])
 
   const secondaryFontColor = theme.semanticTokens.colors.font.secondary.default

--- a/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
+++ b/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
@@ -28,8 +28,9 @@ function _useEclpChart() {
 
   const tokens = useMemo(() => {
     const poolTokens = getPoolActionableTokens(pool).map(token => token.symbol)
+    console.log({ poolTokens })
 
-    return isReversed ? poolTokens.reverse().join('/') : poolTokens.join('/')
+    return isReversed ? poolTokens.join('/') : poolTokens.reverse().join('/')
   }, [pool, isReversed])
 
   const secondaryFontColor = theme.semanticTokens.colors.font.secondary.default

--- a/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
+++ b/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
@@ -4,6 +4,7 @@ import { usePool } from '../../pool/PoolProvider'
 import { useTheme as useChakraTheme } from '@chakra-ui/react'
 import { createContext, PropsWithChildren, useMemo } from 'react'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
+import { allPoolTokens } from 'modules/pool/pool-tokens.utils'
 
 type EclpChartContextType = ReturnType<typeof _useEclpChart>
 
@@ -26,9 +27,13 @@ function _useEclpChart() {
   const theme = useChakraTheme()
 
   const tokens = useMemo(() => {
-    const poolTokens = pool.poolTokens.map(token => token.symbol)
+    const poolTokensLength = pool.poolTokens.length
+    const poolTokens = allPoolTokens(pool)
+      // top level tokens are first in the array
+      .slice(0, poolTokensLength)
+      .map(token => token.symbol)
 
-    return isReversed ? poolTokens.reverse().join('/') : poolTokens.join('/')
+    return isReversed ? poolTokens.join('/') : poolTokens.reverse().join('/')
   }, [pool, isReversed])
 
   const secondaryFontColor = theme.semanticTokens.colors.font.secondary.default

--- a/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
+++ b/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
@@ -4,7 +4,7 @@ import { usePool } from '../../pool/PoolProvider'
 import { useTheme as useChakraTheme } from '@chakra-ui/react'
 import { createContext, PropsWithChildren, useMemo } from 'react'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
-import { allPoolTokens } from '../../pool/pool-tokens.utils'
+import { getPoolActionableTokens } from '../../pool/pool-tokens.utils'
 
 type EclpChartContextType = ReturnType<typeof _useEclpChart>
 
@@ -27,11 +27,7 @@ function _useEclpChart() {
   const theme = useChakraTheme()
 
   const tokens = useMemo(() => {
-    const poolTokensLength = pool.poolTokens.length
-    const poolTokens = allPoolTokens(pool)
-      // top level tokens are first in the array
-      .slice(0, poolTokensLength)
-      .map(token => token.symbol)
+    const poolTokens = getPoolActionableTokens(pool).map(token => token.symbol)
 
     return isReversed ? poolTokens.join('/') : poolTokens.reverse().join('/')
   }, [pool, isReversed])

--- a/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
+++ b/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
@@ -4,7 +4,7 @@ import { usePool } from '../../pool/PoolProvider'
 import { useTheme as useChakraTheme } from '@chakra-ui/react'
 import { createContext, PropsWithChildren, useMemo } from 'react'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
-import { allPoolTokens } from 'modules/pool/pool-tokens.utils'
+import { allPoolTokens } from '../../pool/pool-tokens.utils'
 
 type EclpChartContextType = ReturnType<typeof _useEclpChart>
 

--- a/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
+++ b/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
@@ -6,6 +6,7 @@ import { Pool } from '../../pool/pool.types'
 import { calculateSpotPrice, destructureRequiredPoolParams } from '../helpers/calculateSpotPrice'
 import { GqlPoolType } from '@repo/lib/shared/services/api/generated/graphql'
 import { formatUnits } from 'viem'
+import { getPriceRateRatio } from '../../pool/pool-tokens.utils'
 
 export function useGetECLPLiquidityProfile(pool: Pool) {
   const { data: tokenRates, isLoading } = useGetTokenRates(pool)
@@ -26,13 +27,13 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
     [pool, tokenRateScalingFactorString]
   )
 
-  const priceRate = bn(pool.poolTokens[0].priceRate).div(bn(pool.poolTokens[1].priceRate))
+  const priceRateRatio = getPriceRateRatio(pool)
 
   const params = pool && pool.poolTokens ? destructureRequiredPoolParams(pool, tokenRates) : null
 
   const originalPoolSpotPrice = params
     ? bn(formatUnits(calculateSpotPrice(pool.type as GqlPoolType.Gyroe, params), 18))
-        .div(priceRate)
+        .div(priceRateRatio)
         .toNumber()
     : null
 
@@ -47,12 +48,12 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
     const transformedData = liquidityData
       .filter(([price]) => price !== 0) // filter out zero price to prevent infinity on reverse
       .map(([price, liquidity]) => {
-        const displayedPrice = bn(price).div(priceRate).toNumber()
+        const displayedPrice = bn(price).div(priceRateRatio).toNumber()
         return isReversed ? [1 / displayedPrice, liquidity] : [displayedPrice, liquidity]
       })
 
     return transformedData.sort((a, b) => a[0] - b[0]) as [[number, number]]
-  }, [liquidityData, isReversed, priceRate])
+  }, [liquidityData, isReversed, priceRateRatio])
 
   const xMin = useMemo(() => (data ? Math.min(...data.map(([x]) => x)) : 0), [data])
   const xMax = useMemo(() => (data ? Math.max(...data.map(([x]) => x)) : 0), [data])


### PR DESCRIPTION
fixes #995 

show rate adjusted underlying tokens instead of boosted (where applicable)

- for price
- and for display in legend

[example pool](https://beets.fi/pools/sonic/v3/0x7d836813d1d0b710979f2747c071eac8e8693198)

before:

![image](https://github.com/user-attachments/assets/fee1e09f-16d0-4c7f-a6c4-3a9832a63789)


after:

![image](https://github.com/user-attachments/assets/264f9f6c-2210-4959-a383-1031e6a29e20)
