### PR TITLE
refactor: rename 'internal' hooks

### DIFF
--- a/apps/beets-frontend-v3/lib/modules/lst/LstProvider.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/LstProvider.tsx
@@ -22,7 +22,7 @@ import { useGetRate } from './hooks/useGetRate'
 const CHAIN = GqlChain.Sonic
 const WITHDRAW_DELAY = 1209600 // 14 days in seconds
 
-export function _useLst() {
+export function useLstLogic() {
   const [activeTab, setActiveTab] = useState<ButtonGroupOption>()
   const [amountAssets, setAmountAssets] = useState('')
   const [amountShares, setAmountShares] = useState('')
@@ -139,11 +139,11 @@ export function _useLst() {
   }
 }
 
-export type Result = ReturnType<typeof _useLst>
+export type Result = ReturnType<typeof useLstLogic>
 export const LstContext = createContext<Result | null>(null)
 
 export function LstProvider({ children }: PropsWithChildren) {
-  const Lst = _useLst()
+  const Lst = useLstLogic()
 
   return <LstContext.Provider value={Lst}>{children}</LstContext.Provider>
 }

--- a/apps/beets-frontend-v3/lib/modules/reliquary/ReliquaryProvider.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/ReliquaryProvider.tsx
@@ -14,7 +14,7 @@ import { useClaimRewardsSteps } from './hooks/useClaimRewardsSteps'
 
 const CHAIN = GqlChain.Sonic
 
-export function _useReliquary() {
+export function useReliquaryLogic() {
   const { isConnected } = useUserAccount()
   const { hasValidationError, getValidationError } = useTokenInputsValidation()
   const [range, setRange] = useState<GqlPoolSnapshotDataRange>(GqlPoolSnapshotDataRange.ThirtyDays)
@@ -53,11 +53,11 @@ export function _useReliquary() {
   }
 }
 
-export type Result = ReturnType<typeof _useReliquary>
+export type Result = ReturnType<typeof useReliquaryLogic>
 export const ReliquaryContext = createContext<Result | null>(null)
 
 export function ReliquaryProvider({ children }: PropsWithChildren) {
-  const Reliquary = _useReliquary()
+  const Reliquary = useReliquaryLogic()
 
   return <ReliquaryContext.Provider value={Reliquary}>{children}</ReliquaryContext.Provider>
 }

--- a/apps/frontend-v3/lib/vebal/cross-chain/CrossChainSyncProvider.tsx
+++ b/apps/frontend-v3/lib/vebal/cross-chain/CrossChainSyncProvider.tsx
@@ -23,7 +23,7 @@ const veBalSyncSupportedNetworks: GqlChain[] = Object.keys(networkConfigs)
 
 const REFETCH_INTERVAL = secs(30).toMs()
 
-export type CrossChainSyncResult = ReturnType<typeof _useCrossChainSync>
+export type CrossChainSyncResult = ReturnType<typeof useCrossChainSyncLogic>
 export const CrossChainSyncContext = createContext<CrossChainSyncResult | null>(null)
 
 interface CheckIfNetworkSyncingArgs {
@@ -55,7 +55,7 @@ export type SyncTxHashes = Record<GqlChain, Hash>
 const initialTempSyncingNetworks: Record<Address, TempSyncingNetworks> = {}
 const initialSyncTxHashes: Record<Address, SyncTxHashes> = {}
 
-export const _useCrossChainSync = () => {
+export const useCrossChainSyncLogic = () => {
   const { userAddress } = useUserAccount()
 
   const {
@@ -256,7 +256,7 @@ export const _useCrossChainSync = () => {
 }
 
 export function CrossChainSyncProvider({ children }: PropsWithChildren) {
-  const hook = _useCrossChainSync()
+  const hook = useCrossChainSyncLogic()
   return <CrossChainSyncContext.Provider value={hook}>{children}</CrossChainSyncContext.Provider>
 }
 

--- a/apps/frontend-v3/lib/vebal/lock/VebalLockProvider.tsx
+++ b/apps/frontend-v3/lib/vebal/lock/VebalLockProvider.tsx
@@ -14,7 +14,7 @@ import { getPreviousThursday, oneYearInSecs } from '@repo/lib/shared/utils/time'
 import BigNumber from 'bignumber.js'
 import { useVebalLockData } from '@repo/lib/modules/vebal/VebalLockDataProvider'
 
-export type UseVebalLockResult = ReturnType<typeof _useVebalLock>
+export type UseVebalLockResult = ReturnType<typeof useVebalLockLogic>
 export const VebalLockContext = createContext<UseVebalLockResult | null>(null)
 
 export enum LockMode {
@@ -81,7 +81,7 @@ export function expectedVeBal({
   }
 }
 
-export function _useVebalLock() {
+export function useVebalLockLogic() {
   const { vebalBptToken } = useTokens()
   if (!vebalBptToken) throw new Error('vebalBptToken not found')
 
@@ -184,7 +184,7 @@ export function _useVebalLock() {
 }
 
 export function VebalLockProvider({ children }: PropsWithChildren) {
-  const vebalLock = _useVebalLock()
+  const vebalLock = useVebalLockLogic()
 
   return <VebalLockContext.Provider value={vebalLock}>{children}</VebalLockContext.Provider>
 }

--- a/apps/frontend-v3/lib/vebal/vote/VoteList/VoteListProvider.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/VoteList/VoteListProvider.tsx
@@ -79,7 +79,7 @@ function filterVoteList(
 export interface UseVoteListArgs {}
 
 // eslint-disable-next-line no-empty-pattern
-export function _useVoteList({}: UseVoteListArgs) {
+export function useVoteListLogic({}: UseVoteListArgs) {
   const {
     votingPools,
     incentives,
@@ -149,10 +149,10 @@ export function _useVoteList({}: UseVoteListArgs) {
   }
 }
 
-export const VoteListContext = createContext<ReturnType<typeof _useVoteList> | null>(null)
+export const VoteListContext = createContext<ReturnType<typeof useVoteListLogic> | null>(null)
 
 export function VoteListProvider({ children, ...props }: PropsWithChildren<UseVoteListArgs>) {
-  const hook = _useVoteList(props)
+  const hook = useVoteListLogic(props)
 
   return <VoteListContext.Provider value={hook}>{children}</VoteListContext.Provider>
 }

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesProvider.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesProvider.tsx
@@ -60,7 +60,7 @@ export interface SubmittingVote {
 export interface UseMyVotesArgs {}
 
 // eslint-disable-next-line no-empty-pattern
-export function _useMyVotes({}: UseMyVotesArgs) {
+export function useMyVotesLogic({}: UseMyVotesArgs) {
   const {
     loading: votesLoading,
     votingPools,
@@ -286,10 +286,10 @@ export function _useMyVotes({}: UseMyVotesArgs) {
   }
 }
 
-export const MyVotesContext = createContext<ReturnType<typeof _useMyVotes> | null>(null)
+export const MyVotesContext = createContext<ReturnType<typeof useMyVotesLogic> | null>(null)
 
 export function MyVotesProvider({ children, ...props }: PropsWithChildren<UseMyVotesArgs>) {
-  const hook = _useMyVotes(props)
+  const hook = useMyVotesLogic(props)
 
   return <MyVotesContext.Provider value={hook}>{children}</MyVotesContext.Provider>
 }

--- a/apps/frontend-v3/lib/vebal/vote/Votes/VotesProvider.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/VotesProvider.tsx
@@ -26,7 +26,7 @@ export interface UseVotesArgs {
   error?: any
 }
 
-export function _useVotes({ data, votingListLoading = false, error }: UseVotesArgs) {
+export function useVotesLogic({ data, votingListLoading = false, error }: UseVotesArgs) {
   const { userAddress, isConnected } = useUserAccount()
 
   const votingList = useMemo(() => {
@@ -217,10 +217,10 @@ export function _useVotes({ data, votingListLoading = false, error }: UseVotesAr
   }
 }
 
-export const VotesContext = createContext<ReturnType<typeof _useVotes> | null>(null)
+export const VotesContext = createContext<ReturnType<typeof useVotesLogic> | null>(null)
 
 export function VotesProvider({ children, ...props }: PropsWithChildren<UseVotesArgs>) {
-  const hook = _useVotes(props)
+  const hook = useVotesLogic(props)
 
   return <VotesContext.Provider value={hook}>{children}</VotesContext.Provider>
 }

--- a/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
+++ b/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
@@ -5,11 +5,11 @@ import { useTheme as useChakraTheme } from '@chakra-ui/react'
 import { createContext, PropsWithChildren, useMemo } from 'react'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 
-type EclpChartContextType = ReturnType<typeof _useEclpChart>
+type EclpChartContextType = ReturnType<typeof useEclpChartLogic>
 
 const EclpChartContext = createContext<EclpChartContextType | null>(null)
 
-function _useEclpChart() {
+export function useEclpChartLogic() {
   const { pool } = usePool()
 
   const {
@@ -434,7 +434,7 @@ function _useEclpChart() {
 }
 
 export function EclpChartProvider({ children }: PropsWithChildren) {
-  const hook = _useEclpChart()
+  const hook = useEclpChartLogic()
   return <EclpChartContext.Provider value={hook}>{children}</EclpChartContext.Provider>
 }
 

--- a/packages/lib/modules/fee-managers/FeeManagersProvider.tsx
+++ b/packages/lib/modules/fee-managers/FeeManagersProvider.tsx
@@ -4,10 +4,10 @@ import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { createContext, PropsWithChildren } from 'react'
 import { FeeManagersMetadata } from './getFeeManagersMetadata'
 
-export type UseFeeManagersResult = ReturnType<typeof _useFeeManagers>
+export type UseFeeManagersResult = ReturnType<typeof useFeeManagersLogic>
 export const FeeManagersContext = createContext<UseFeeManagersResult | null>(null)
 
-export function _useFeeManagers(metadata: FeeManagersMetadata[] | undefined) {
+export function useFeeManagersLogic(metadata: FeeManagersMetadata[] | undefined) {
   return { metadata }
 }
 
@@ -15,7 +15,7 @@ export function FeeManagersProvider({
   children,
   data,
 }: PropsWithChildren & { data: FeeManagersMetadata[] | undefined }) {
-  const hook = _useFeeManagers(data)
+  const hook = useFeeManagersLogic(data)
   return <FeeManagersContext.Provider value={hook}>{children}</FeeManagersContext.Provider>
 }
 

--- a/packages/lib/modules/hooks/HooksProvider.tsx
+++ b/packages/lib/modules/hooks/HooksProvider.tsx
@@ -4,10 +4,10 @@ import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { createContext, PropsWithChildren } from 'react'
 import { HooksMetadata } from './getHooksMetadata'
 
-export type UseHooksResult = ReturnType<typeof _useHooks>
+export type UseHooksResult = ReturnType<typeof useHooksLogic>
 export const HooksContext = createContext<UseHooksResult | null>(null)
 
-export function _useHooks(metadata: HooksMetadata[] | undefined) {
+export function useHooksLogic(metadata: HooksMetadata[] | undefined) {
   return { metadata }
 }
 
@@ -15,7 +15,7 @@ export function HooksProvider({
   children,
   data,
 }: PropsWithChildren & { data: HooksMetadata[] | undefined }) {
-  const hook = _useHooks(data)
+  const hook = useHooksLogic(data)
   return <HooksContext.Provider value={hook}>{children}</HooksContext.Provider>
 }
 

--- a/packages/lib/modules/lbp/LbpFormProvider.tsx
+++ b/packages/lib/modules/lbp/LbpFormProvider.tsx
@@ -7,7 +7,7 @@ import { useForm } from 'react-hook-form'
 import { ProjectInfoForm, SaleStructureForm } from './lbp.types'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
-export type UseLbpFormResult = ReturnType<typeof _useLbpForm>
+export type UseLbpFormResult = ReturnType<typeof useLbpFormLogic>
 export const LbpFormContext = createContext<UseLbpFormResult | null>(null)
 
 const steps = [
@@ -16,7 +16,7 @@ const steps = [
   { id: 'step3', title: 'Review' },
 ]
 
-export function _useLbpForm() {
+export function useLbpFormLogic() {
   const saleStructureForm = useForm<SaleStructureForm>({
     defaultValues: {
       selectedChain: PROJECT_CONFIG.defaultNetwork,
@@ -65,7 +65,7 @@ export function _useLbpForm() {
 }
 
 export function LbpFormProvider({ children }: PropsWithChildren) {
-  const hook = _useLbpForm()
+  const hook = useLbpFormLogic()
   return <LbpFormContext.Provider value={hook}>{children}</LbpFormContext.Provider>
 }
 

--- a/packages/lib/modules/pool/PoolDetail/PoolActivity/usePoolActivity.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivity/usePoolActivity.tsx
@@ -25,12 +25,12 @@ import { usePoolActivityViewType } from '../PoolActivityViewType/usePoolActivity
 import { sortAlphabetically } from '@repo/lib/shared/utils/sorting'
 import { Sorting } from '@repo/lib/shared/components/tables/SortableHeader'
 
-export type PoolActivityResponse = ReturnType<typeof _usePoolActivity>
+export type PoolActivityResponse = ReturnType<typeof usePoolActivityLogic>
 export const PoolActivityContext = createContext<PoolActivityResponse | null>(null)
 
 const MAX_EVENTS = 500
 
-function _usePoolActivity() {
+function usePoolActivityLogic() {
   const { id: poolId, variant, chain } = useParams()
   const { pool } = usePool()
   const { getToken } = useTokens()
@@ -263,7 +263,7 @@ function _usePoolActivity() {
 }
 
 export function PoolActivityProvider({ children }: PropsWithChildren) {
-  const hook = _usePoolActivity()
+  const hook = usePoolActivityLogic()
   return <PoolActivityContext.Provider value={hook}>{children}</PoolActivityContext.Provider>
 }
 

--- a/packages/lib/modules/pool/PoolDetail/PoolActivityViewType/usePoolActivityViewType.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivityViewType/usePoolActivityViewType.tsx
@@ -6,7 +6,7 @@ export enum PoolActivityView {
   List = 'list',
 }
 
-export function _usePoolActivityViewType() {
+export function usePoolActivityViewTypeLogic() {
   const [poolActivityView, setPoolActivityView] = useState<PoolActivityView>(PoolActivityView.Chart)
 
   const isListView = useMemo(() => poolActivityView === PoolActivityView.List, [poolActivityView])
@@ -19,11 +19,11 @@ export function _usePoolActivityViewType() {
   }
 }
 
-export type UsePoolActivityViewTypeResult = ReturnType<typeof _usePoolActivityViewType>
+export type UsePoolActivityViewTypeResult = ReturnType<typeof usePoolActivityViewTypeLogic>
 export const PoolActivityViewTypeContext = createContext<UsePoolActivityViewTypeResult | null>(null)
 
 export function PoolActivityViewTypeProvider({ children }: PropsWithChildren) {
-  const poolActivityViewType = _usePoolActivityViewType()
+  const poolActivityViewType = usePoolActivityViewTypeLogic()
 
   return (
     <PoolActivityViewTypeContext.Provider value={poolActivityViewType}>

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartTabsProvider.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartTabsProvider.tsx
@@ -56,11 +56,11 @@ export function getPoolTabsList({
   return POOL_SPECIFIC_TABS[poolType] || POOL_SPECIFIC_TABS.default
 }
 
-export type PoolChartTabsResponse = ReturnType<typeof _usePoolChartTabs>
+export type PoolChartTabsResponse = ReturnType<typeof usePoolChartTabsLogic>
 
 export const PoolChartTabsContext = createContext<PoolChartTabsResponse | null>(null)
 
-export function _usePoolChartTabs() {
+export function usePoolChartTabsLogic() {
   const { pool } = usePool()
   const { variant } = useParams()
 
@@ -96,7 +96,7 @@ export function _usePoolChartTabs() {
 }
 
 export function PoolChartTabsProvider({ children }: PropsWithChildren) {
-  const hook = _usePoolChartTabs()
+  const hook = usePoolChartTabsLogic()
   return <PoolChartTabsContext.Provider value={hook}>{children}</PoolChartTabsContext.Provider>
 }
 

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsProvider.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsProvider.tsx
@@ -193,11 +193,11 @@ export function usePoolSnapshots(
   })
 }
 
-type PoolChartsContextType = ReturnType<typeof _usePoolCharts>
+type PoolChartsContextType = ReturnType<typeof usePoolChartsLogic>
 
 const PoolChartsContext = createContext<PoolChartsContextType | null>(null)
 
-export function _usePoolCharts() {
+export function usePoolChartsLogic() {
   const { pool, tvl } = usePool()
   const { id: poolId } = useParams()
   const { toCurrency } = useCurrency()
@@ -524,7 +524,7 @@ export function _usePoolCharts() {
 }
 
 export function PoolChartsProvider({ children }: PropsWithChildren) {
-  const hook = _usePoolCharts()
+  const hook = usePoolChartsLogic()
   return <PoolChartsContext.Provider value={hook}>{children}</PoolChartsContext.Provider>
 }
 

--- a/packages/lib/modules/pool/PoolList/PoolListProvider.spec.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListProvider.spec.tsx
@@ -2,10 +2,10 @@ import { PoolList as PoolListType } from '@repo/lib/modules/pool/pool.types'
 import { defaultPoolListMock, mockPoolList } from '@repo/lib/test/msw/handlers/PoolList.handlers'
 import { aGqlPoolMinimalMock } from '@repo/lib/test/msw/builders/gqlPoolMinimal.builders'
 import { testHook } from '@repo/lib/test/utils/custom-renderers'
-import { _usePoolList } from './PoolListProvider'
+import { usePoolListLogic } from './PoolListProvider'
 
 async function renderUsePoolsList() {
-  const { result, waitForLoadedUseQuery } = testHook(() => _usePoolList())
+  const { result, waitForLoadedUseQuery } = testHook(() => usePoolListLogic())
   await waitForLoadedUseQuery(result)
   return result
 }

--- a/packages/lib/modules/pool/PoolList/PoolListProvider.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListProvider.tsx
@@ -15,7 +15,7 @@ import { isAddress } from 'viem'
 import { PoolDisplayType } from '../pool.types'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
-export function _usePoolList({
+export function usePoolListLogic({
   fixedPoolTypes,
   fixedChains,
 }: {
@@ -72,7 +72,7 @@ export function _usePoolList({
   }
 }
 
-export const PoolListContext = createContext<ReturnType<typeof _usePoolList> | null>(null)
+export const PoolListContext = createContext<ReturnType<typeof usePoolListLogic> | null>(null)
 
 export function PoolListProvider({
   fixedPoolTypes,
@@ -82,7 +82,7 @@ export function PoolListProvider({
   fixedPoolTypes?: GqlPoolType[]
   fixedChains?: GqlChain[]
 }>) {
-  const hook = _usePoolList({
+  const hook = usePoolListLogic({
     fixedPoolTypes,
     fixedChains,
   })

--- a/packages/lib/modules/pool/PoolProvider.spec.tsx
+++ b/packages/lib/modules/pool/PoolProvider.spec.tsx
@@ -3,7 +3,7 @@ import { defaultPoolMock, defaultPoolResponseMock } from '@repo/lib/test/msw/han
 import { testHook } from '@repo/lib/test/utils/custom-renderers'
 import { waitFor } from '@testing-library/react'
 import { BaseVariant } from './pool.types'
-import { _usePool } from './PoolProvider'
+import { usePoolLogic } from './PoolProvider'
 import { defaultTestGaugeAddress } from '@repo/lib/test/msw/builders/gqlStaking.builders'
 
 async function testUsePool({
@@ -12,7 +12,7 @@ async function testUsePool({
   initialData?: GetPoolQuery
 } = {}) {
   const { result } = testHook(() => {
-    return _usePool({
+    return usePoolLogic({
       id: poolId,
       chain: GqlChain.Mainnet,
       variant: BaseVariant.v2,

--- a/packages/lib/modules/pool/PoolProvider.tsx
+++ b/packages/lib/modules/pool/PoolProvider.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable react-hooks/exhaustive-deps */
 'use client'
 
 import {
@@ -9,7 +9,7 @@ import {
 } from '@repo/lib/shared/services/api/generated/graphql'
 import { createContext, PropsWithChildren, useRef } from 'react'
 import { useQuery } from '@apollo/client'
-import { FetchPoolProps, Pool } from './pool.types'
+import { FetchPoolProps } from './pool.types'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { getPoolHelpers } from './pool.helpers'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
@@ -20,13 +20,13 @@ import { useTokens } from '../tokens/TokensProvider'
 import { getCompositionTokens } from './pool-tokens.utils'
 
 export type FeaturedPool = GetFeaturedPoolsQuery['featuredPools'][0]['pool']
-export type UsePoolResponse = ReturnType<typeof _usePool> & {
+export type UsePoolResponse = ReturnType<typeof usePoolLogic> & {
   chain: GqlChain
 }
 
 export const PoolContext = createContext<UsePoolResponse | null>(null)
 
-export function _usePool({
+export function usePoolLogic({
   id,
   chain,
   initialData,
@@ -84,7 +84,7 @@ export function PoolProvider({
   children,
   data,
 }: PropsWithChildren<FetchPoolProps> & { data: GetPoolQuery }) {
-  const hook = _usePool({ id, chain, variant, initialData: data })
+  const hook = usePoolLogic({ id, chain, variant, initialData: data })
   return <PoolContext.Provider value={{ ...hook, chain }}>{children}</PoolContext.Provider>
 }
 

--- a/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.spec.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.spec.tsx
@@ -12,7 +12,7 @@ import {
   testHook,
 } from '@repo/lib/test/utils/custom-renderers'
 import { PropsWithChildren } from 'react'
-import { _useAddLiquidity } from './AddLiquidityProvider'
+import { useAddLiquidityLogic } from './AddLiquidityProvider'
 import { nestedPoolMock } from '../../__mocks__/nestedPoolMock'
 import { aBalWethPoolElementMock } from '@repo/lib/test/msw/builders/gqlPoolElement.builders'
 
@@ -26,7 +26,7 @@ async function testUseAddLiquidity(pool: GqlPoolElement = aBalWethPoolElementMoc
       </PoolProvider>
     )
   }
-  const { result } = testHook(() => _useAddLiquidity(), {
+  const { result } = testHook(() => useAddLiquidityLogic(), {
     wrapper: Providers,
   })
   return result

--- a/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
@@ -38,10 +38,10 @@ import { useIsMinimumDepositMet } from './useIsMinimumDepositMet'
 import { useWrapUnderlying } from '../useWrapUnderlying'
 import { useProportionalSlippage } from './form/useProportionalSlippage'
 
-export type UseAddLiquidityResponse = ReturnType<typeof _useAddLiquidity>
+export type UseAddLiquidityResponse = ReturnType<typeof useAddLiquidityLogic>
 export const AddLiquidityContext = createContext<UseAddLiquidityResponse | null>(null)
 
-export function _useAddLiquidity(urlTxHash?: Hash) {
+export function useAddLiquidityLogic(urlTxHash?: Hash) {
   const [humanAmountsIn, setHumanAmountsIn] = useState<HumanTokenAmountWithAddress[]>([])
   // only used by Proportional handlers that require a referenceAmount
   const [referenceAmountAddress, setReferenceAmountAddress] = useState<Address | undefined>()
@@ -270,7 +270,7 @@ type Props = PropsWithChildren<{
 }>
 
 export function AddLiquidityProvider({ urlTxHash, children }: Props) {
-  const hook = _useAddLiquidity(urlTxHash)
+  const hook = useAddLiquidityLogic(urlTxHash)
   return <AddLiquidityContext.Provider value={hook}>{children}</AddLiquidityContext.Provider>
 }
 

--- a/packages/lib/modules/pool/actions/claim/ClaimProvider.tsx
+++ b/packages/lib/modules/pool/actions/claim/ClaimProvider.tsx
@@ -14,7 +14,7 @@ import { Pool } from '../../pool.types'
 
 export type ClaimablePool = Pool | PoolListItem
 
-export function _useClaim(pools: ClaimablePool[]) {
+export function useClaimLogic(pools: ClaimablePool[]) {
   const { isConnected } = useUserAccount()
   const previewModalDisclosure = useDisclosure()
   const { isDisabled, disabledReason } = isDisabledWithReason([
@@ -51,7 +51,7 @@ export function _useClaim(pools: ClaimablePool[]) {
   }
 }
 
-export type UseClaimProviderResponse = ReturnType<typeof _useClaim>
+export type UseClaimProviderResponse = ReturnType<typeof useClaimLogic>
 export const ClaimProviderContext = createContext<UseClaimProviderResponse | null>(null)
 
 type Props = PropsWithChildren<{
@@ -59,7 +59,7 @@ type Props = PropsWithChildren<{
 }>
 
 export function ClaimProvider({ pools, children }: Props) {
-  const hook = _useClaim(pools)
+  const hook = useClaimLogic(pools)
   return <ClaimProviderContext.Provider value={hook}>{children}</ClaimProviderContext.Provider>
 }
 

--- a/packages/lib/modules/pool/actions/migrateStake/MigrateStakeProvider.tsx
+++ b/packages/lib/modules/pool/actions/migrateStake/MigrateStakeProvider.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 'use client'
 
 import { useTransactionSteps } from '@repo/lib/modules/transactions/transaction-steps/useTransactionSteps'
@@ -12,10 +11,10 @@ import { usePool } from '../../PoolProvider'
 import { useUnstake } from '../unstake/UnstakeProvider'
 import { useMigrateStakeSteps } from './useMigrateStakeSteps'
 
-export type UseMigrateStakeResponse = ReturnType<typeof _useMigrateStake>
+export type UseMigrateStakeResponse = ReturnType<typeof useMigrateStakeLogic>
 export const MigrateStakeContext = createContext<UseMigrateStakeResponse | null>(null)
 
-export function _useMigrateStake() {
+export function useMigrateStakeLogic() {
   const { quoteAmountOut: migratedAmount } = useUnstake()
 
   const { pool, refetch: refetchPoolBalances, isLoading: isLoadingPool } = usePool()
@@ -47,7 +46,7 @@ export function _useMigrateStake() {
 }
 
 export function MigrateStakeProvider({ children }: PropsWithChildren) {
-  const hook = _useMigrateStake()
+  const hook = useMigrateStakeLogic()
   return <MigrateStakeContext.Provider value={hook}>{children}</MigrateStakeContext.Provider>
 }
 

--- a/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.spec.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.spec.tsx
@@ -10,7 +10,7 @@ import { act } from 'react-dom/test-utils'
 import { mock } from 'vitest-mock-extended'
 import { aTokenAmountMock } from '../__mocks__/liquidity.builders'
 import { RemoveLiquiditySimulationQueryResult } from './queries/useRemoveLiquiditySimulationQuery'
-import { _useRemoveLiquidity } from './RemoveLiquidityProvider'
+import { useRemoveLiquidityLogic } from './RemoveLiquidityProvider'
 import { aSuccessfulQueryResultMock } from '@repo/lib/test/utils/react-query'
 
 const balTokenOutUnits = '1'
@@ -44,7 +44,7 @@ poolMock.dynamicData.totalShares = '100'
 // bptPrice = 1000/100 = 10
 
 async function testUseRemoveLiquidity(pool: GqlPoolElement = poolMock) {
-  const { result } = testHook(() => _useRemoveLiquidity(), {
+  const { result } = testHook(() => useRemoveLiquidityLogic(), {
     wrapper: buildDefaultPoolTestProvider(pool),
   })
   return result

--- a/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -27,10 +27,10 @@ import { useModalWithPoolRedirect } from '../../useModalWithPoolRedirect'
 import { ApiToken } from '@repo/lib/modules/tokens/token.types'
 import { useWrapUnderlying } from '../useWrapUnderlying'
 
-export type UseRemoveLiquidityResponse = ReturnType<typeof _useRemoveLiquidity>
+export type UseRemoveLiquidityResponse = ReturnType<typeof useRemoveLiquidityLogic>
 export const RemoveLiquidityContext = createContext<UseRemoveLiquidityResponse | null>(null)
 
-export function _useRemoveLiquidity(urlTxHash?: Hash) {
+export function useRemoveLiquidityLogic(urlTxHash?: Hash) {
   const [singleTokenAddress, setSingleTokenAddress] = useState<Address | undefined>(undefined)
   const [humanBptInPercent, setHumanBptInPercent] = useState<number>(100)
   const [wethIsEth, setWethIsEth] = useState(false)
@@ -316,7 +316,7 @@ export function _useRemoveLiquidity(urlTxHash?: Hash) {
 type Props = PropsWithChildren<{ urlTxHash?: Hash }>
 
 export function RemoveLiquidityProvider({ urlTxHash, children }: Props) {
-  const hook = _useRemoveLiquidity(urlTxHash)
+  const hook = useRemoveLiquidityLogic(urlTxHash)
   return <RemoveLiquidityContext.Provider value={hook}>{children}</RemoveLiquidityContext.Provider>
 }
 

--- a/packages/lib/modules/pool/actions/stake/StakeProvider.tsx
+++ b/packages/lib/modules/pool/actions/stake/StakeProvider.tsx
@@ -15,10 +15,10 @@ import { bn } from '@repo/lib/shared/utils/numbers'
 import { HumanAmount } from '@balancer/sdk'
 import { getUserWalletBalance, getUserWalletBalanceUsd } from '../../user-balance.helpers'
 
-export type UseStakeResponse = ReturnType<typeof _useStake>
+export type UseStakeResponse = ReturnType<typeof useStakeLogic>
 export const StakeContext = createContext<UseStakeResponse | null>(null)
 
-export function _useStake() {
+export function useStakeLogic() {
   const { userAddress, isConnected } = useUserAccount()
   const { pool, chainId, isLoadingOnchainUserBalances } = usePool()
   const { isDisabled, disabledReason } = isDisabledWithReason([
@@ -72,7 +72,7 @@ export function _useStake() {
 }
 
 export function StakeProvider({ children }: PropsWithChildren) {
-  const hook = _useStake()
+  const hook = useStakeLogic()
   return <StakeContext.Provider value={hook}>{children}</StakeContext.Provider>
 }
 

--- a/packages/lib/modules/pool/actions/unstake/UnstakeProvider.tsx
+++ b/packages/lib/modules/pool/actions/unstake/UnstakeProvider.tsx
@@ -16,10 +16,10 @@ import { useClaimsData } from '../claim/useClaimsData'
 import { useClaimAndUnstakeSteps } from './useClaimAndUnstakeSteps'
 import { getUnstakeQuote } from '../stake.helpers'
 
-export type UseUnstakeResponse = ReturnType<typeof _useUnstake>
+export type UseUnstakeResponse = ReturnType<typeof useUnstakeLogic>
 export const UnstakeContext = createContext<UseUnstakeResponse | null>(null)
 
-export function _useUnstake() {
+export function useUnstakeLogic() {
   // State so that we can maintain the amounts in the modal after confirmation.
   const [quoteAmountOut, setQuoteAmountOut] = useState<HumanAmount>('0')
   const [quoteRewardAmounts, setQuoteRewardAmounts] = useState<HumanTokenAmount[]>([])
@@ -97,7 +97,7 @@ export function _useUnstake() {
 }
 
 export function UnstakeProvider({ children }: PropsWithChildren) {
-  const hook = _useUnstake()
+  const hook = useUnstakeLogic()
   return <UnstakeContext.Provider value={hook}>{children}</UnstakeContext.Provider>
 }
 

--- a/packages/lib/modules/pool/metadata/PoolsMetadataProvider.tsx
+++ b/packages/lib/modules/pool/metadata/PoolsMetadataProvider.tsx
@@ -8,10 +8,10 @@ import { PoolListItem } from '../pool.types'
 import { getChainId } from '@repo/lib/config/app.config'
 import { PoolMetadata, PoolsMetadata } from './getPoolsMetadata'
 
-export type UsePoolsMetadataResult = ReturnType<typeof _usePoolsMetadata>
+export type UsePoolsMetadataResult = ReturnType<typeof usePoolsMetadataLogic>
 export const PoolsMetadataContext = createContext<UsePoolsMetadataResult | null>(null)
 
-export function _usePoolsMetadata(
+export function usePoolsMetadataLogic(
   erc4626Metadata: Erc4626Metadata[] | undefined,
   poolsMetadata: PoolsMetadata | undefined
 ) {
@@ -44,7 +44,7 @@ export function PoolsMetadataProvider({
   erc4626Metadata: Erc4626Metadata[] | undefined
   poolsMetadata: PoolsMetadata | undefined
 }) {
-  const hook = _usePoolsMetadata(erc4626Metadata, poolsMetadata)
+  const hook = usePoolsMetadataLogic(erc4626Metadata, poolsMetadata)
   return <PoolsMetadataContext.Provider value={hook}>{children}</PoolsMetadataContext.Provider>
 }
 

--- a/packages/lib/modules/pool/tags/PoolTagsProvider.tsx
+++ b/packages/lib/modules/pool/tags/PoolTagsProvider.tsx
@@ -5,10 +5,10 @@ import { createContext, PropsWithChildren } from 'react'
 import { Pool } from '../pool.types'
 import { PoolTag } from './getPoolTags'
 
-export type UsePoolTagsResult = ReturnType<typeof _usePoolTags>
+export type UsePoolTagsResult = ReturnType<typeof usePoolTagsLogic>
 export const PoolTagsContext = createContext<UsePoolTagsResult | null>(null)
 
-export function _usePoolTags(tags: PoolTag[] | undefined) {
+export function usePoolTagsLogic(tags: PoolTag[] | undefined) {
   const hasTags = !!tags
 
   function getPoolTags(pool: Pool): PoolTag[] {
@@ -32,7 +32,7 @@ export function PoolTagsProvider({
   children,
   data,
 }: PropsWithChildren & { data: PoolTag[] | undefined }) {
-  const hook = _usePoolTags(data)
+  const hook = usePoolTagsLogic(data)
   return <PoolTagsContext.Provider value={hook}>{children}</PoolTagsContext.Provider>
 }
 

--- a/packages/lib/modules/portfolio/PortfolioProvider.tsx
+++ b/packages/lib/modules/portfolio/PortfolioProvider.tsx
@@ -35,9 +35,9 @@ export type PoolRewardsData = Pool & {
 }
 
 export type PoolRewardsDataMap = Record<string, PoolRewardsData>
-export type UsePortfolio = ReturnType<typeof _usePortfolio>
+export type UsePortfolio = ReturnType<typeof usePortfolioLogic>
 
-function _usePortfolio() {
+export function usePortfolioLogic() {
   const { userAddress, isConnected } = useUserAccount()
   const { transactions } = useRecentTransactions()
 
@@ -252,7 +252,7 @@ function _usePortfolio() {
 export const PortfolioContext = createContext<UsePortfolio | null>(null)
 
 export function PortfolioProvider({ children }: PropsWithChildren) {
-  const hook = _usePortfolio()
+  const hook = usePortfolioLogic()
   return <PortfolioContext.Provider value={hook}>{children}</PortfolioContext.Provider>
 }
 

--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioFiltersProvider.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioFiltersProvider.tsx
@@ -17,9 +17,9 @@ import { usePortfolio } from '../PortfolioProvider'
 import { poolTypeLabel } from '../../pool/pool.helpers'
 import { hasTinyBalance } from '../../pool/user-balance.helpers'
 
-export type UsePortfolioFiltersResult = ReturnType<typeof _usePortfolioFilters>
+export type UsePortfolioFiltersResult = ReturnType<typeof usePortfolioFiltersLogic>
 
-function _usePortfolioFilters() {
+export function usePortfolioFiltersLogic() {
   const [selectedNetworks, setSelectedNetworks] = useState<GqlChain[]>([])
   const [selectedPoolTypes, setSelectedPoolTypes] = useState<PoolFilterType[]>([])
   const [selectedStakingTypes, setSelectedStakingTypes] = useState<StakingFilterKeyType[]>([])
@@ -200,7 +200,7 @@ function _usePortfolioFilters() {
 export const PortfolioFiltersContext = createContext<UsePortfolioFiltersResult | null>(null)
 
 export function PortfolioFiltersProvider({ children }: { children: React.ReactNode }) {
-  const filters = _usePortfolioFilters()
+  const filters = usePortfolioFiltersLogic()
 
   return (
     <PortfolioFiltersContext.Provider value={filters}>{children}</PortfolioFiltersContext.Provider>

--- a/packages/lib/modules/price-impact/PriceImpactProvider.tsx
+++ b/packages/lib/modules/price-impact/PriceImpactProvider.tsx
@@ -6,7 +6,7 @@ import { getPriceImpactColor, getPriceImpactLevel } from './price-impact.utils'
 
 export type PriceImpactLevel = 'low' | 'medium' | 'high' | 'max' | 'unknown'
 
-export function _usePriceImpact() {
+export function usePriceImpactLogic() {
   const [priceImpactLevel, setPriceImpactLevel] = useState<PriceImpactLevel>('low')
   const [priceImpactColor, setPriceImpactColor] = useState('green.400')
   const [acceptPriceImpactRisk, setAcceptPriceImpactRisk] = useState(false)
@@ -80,11 +80,11 @@ export function _usePriceImpact() {
   }
 }
 
-export type Result = ReturnType<typeof _usePriceImpact>
+export type Result = ReturnType<typeof usePriceImpactLogic>
 export const PriceImpactContext = createContext<Result | null>(null)
 
 export function PriceImpactProvider({ children }: PropsWithChildren) {
-  const priceImpact = _usePriceImpact()
+  const priceImpact = usePriceImpactLogic()
 
   return <PriceImpactContext.Provider value={priceImpact}>{children}</PriceImpactContext.Provider>
 }

--- a/packages/lib/modules/protocol/ProtocolStatsProvider.tsx
+++ b/packages/lib/modules/protocol/ProtocolStatsProvider.tsx
@@ -4,10 +4,10 @@ import { GetProtocolStatsQuery } from '@repo/lib/shared/services/api/generated/g
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { createContext, PropsWithChildren } from 'react'
 
-export type UseProtocolStatsResult = ReturnType<typeof _useProtocolStats>
+export type UseProtocolStatsResult = ReturnType<typeof useProtocolStatsLogic>
 export const ProtocolStatsContext = createContext<UseProtocolStatsResult | null>(null)
 
-export function _useProtocolStats(data: GetProtocolStatsQuery | undefined) {
+export function useProtocolStatsLogic(data: GetProtocolStatsQuery | undefined) {
   return { protocolData: data }
 }
 
@@ -15,7 +15,7 @@ export function ProtocolStatsProvider({
   children,
   data,
 }: PropsWithChildren & { data: GetProtocolStatsQuery | undefined }) {
-  const hook = _useProtocolStats(data)
+  const hook = useProtocolStatsLogic(data)
   return <ProtocolStatsContext.Provider value={hook}>{children}</ProtocolStatsContext.Provider>
 }
 

--- a/packages/lib/modules/relayer/RelayerSignatureProvider.tsx
+++ b/packages/lib/modules/relayer/RelayerSignatureProvider.tsx
@@ -6,10 +6,10 @@ import { PropsWithChildren, createContext, useState } from 'react'
 import { Address } from 'viem'
 import { SignatureState } from '../web3/signatures/signature.helpers'
 
-export type UseRelayerSignatureResponse = ReturnType<typeof _useRelayerSignature>
+export type UseRelayerSignatureResponse = ReturnType<typeof useRelayerSignatureLogic>
 export const RelayerSignatureContext = createContext<UseRelayerSignatureResponse | null>(null)
 
-export function _useRelayerSignature() {
+export function useRelayerSignatureLogic() {
   const [relayerApprovalSignature, setRelayerApprovalSignature] = useState<Address | undefined>()
 
   const [signRelayerState, setSignRelayerState] = useState<SignatureState>(SignatureState.Preparing)
@@ -23,7 +23,7 @@ export function _useRelayerSignature() {
 }
 
 export function RelayerSignatureProvider({ children }: PropsWithChildren) {
-  const hook = _useRelayerSignature()
+  const hook = useRelayerSignatureLogic()
   return (
     <RelayerSignatureContext.Provider value={hook}>{children}</RelayerSignatureContext.Provider>
   )

--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -57,7 +57,7 @@ import { ProtocolVersion } from '../pool/pool.types'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { ApiToken } from '../tokens/token.types'
 
-export type UseSwapResponse = ReturnType<typeof _useSwap>
+export type UseSwapResponse = ReturnType<typeof useSwapLogic>
 export const SwapContext = createContext<UseSwapResponse | null>(null)
 
 export type PathParams = {
@@ -96,7 +96,7 @@ export type SwapProviderProps = {
   pool?: Pool
   poolActionableTokens?: ApiToken[]
 }
-export function _useSwap({ poolActionableTokens, pool, pathParams }: SwapProviderProps) {
+export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapProviderProps) {
   const urlTxHash = pathParams.urlTxHash
   const isPoolSwapUrl = useIsPoolSwapUrl()
 
@@ -666,7 +666,7 @@ type Props = PropsWithChildren<{
 }>
 
 export function SwapProvider({ params, children }: Props) {
-  const hook = _useSwap(params)
+  const hook = useSwapLogic(params)
   return <SwapContext.Provider value={hook}>{children}</SwapContext.Provider>
 }
 

--- a/packages/lib/modules/tokens/TokenBalancesProvider.integration.spec.ts
+++ b/packages/lib/modules/tokens/TokenBalancesProvider.integration.spec.ts
@@ -2,13 +2,13 @@ import { allFakeGqlTokens, fakeTokenBySymbol } from '@repo/lib/test/data/all-gql
 import { testHook } from '@repo/lib/test/utils/custom-renderers'
 import { act, waitFor } from '@testing-library/react'
 import { connectWithDefaultUser } from '@repo/test/utils/wagmi/wagmi-connections'
-import { _useTokenBalances } from './TokenBalancesProvider'
+import { useTokenBalancesLogic } from './TokenBalancesProvider'
 
 await connectWithDefaultUser()
 
 test('fetches balance for native asset token', async () => {
   const nativeAssetBasicToken = fakeTokenBySymbol('ETH')
-  const { result } = testHook(() => _useTokenBalances([nativeAssetBasicToken]))
+  const { result } = testHook(() => useTokenBalancesLogic([nativeAssetBasicToken]))
 
   await waitFor(() => expect(result.current.balances.length).toBe(1))
 
@@ -26,7 +26,7 @@ test('fetches balance for native asset token', async () => {
 test('fetches token balance', async () => {
   const balBasicToken = fakeTokenBySymbol('BAL')
 
-  const { result } = testHook(() => _useTokenBalances([balBasicToken]))
+  const { result } = testHook(() => useTokenBalancesLogic([balBasicToken]))
 
   expect(result.current.balances).toEqual([])
 
@@ -50,7 +50,7 @@ test('fetches token balance', async () => {
 test('refetches balances', async () => {
   const balBasicToken = fakeTokenBySymbol('BAL')
 
-  const { result } = testHook(() => _useTokenBalances([balBasicToken]))
+  const { result } = testHook(() => useTokenBalancesLogic([balBasicToken]))
 
   await waitFor(() => expect(result.current.isBalancesLoading).toBeFalsy())
   await waitFor(() => expect(result.current.balances.length).toBe(1))
@@ -79,7 +79,7 @@ test('Should not return balances when user is not connected (account is empty) '
   const balBasicToken = fakeTokenBySymbol('BAL')
   const nativeAssetToken = fakeTokenBySymbol('ETH')
 
-  const { result } = testHook(() => _useTokenBalances([balBasicToken, nativeAssetToken]))
+  const { result } = testHook(() => useTokenBalancesLogic([balBasicToken, nativeAssetToken]))
 
   await waitFor(() => expect(result.current.balances.length).toBe(2))
   expect(result.current.isBalancesLoading).toBeFalsy()
@@ -100,7 +100,9 @@ test('Should not return balances when user is not connected (account is empty) '
 
 test.skip('Debug: should return balances of 50 tokens', async () => {
   const numberOfTokens = 50
-  const { result } = testHook(() => _useTokenBalances(allFakeGqlTokens.slice(0, numberOfTokens)))
+  const { result } = testHook(() =>
+    useTokenBalancesLogic(allFakeGqlTokens.slice(0, numberOfTokens))
+  )
 
   await waitFor(() => expect(result.current.isBalancesLoading).toBeFalsy())
   expect(result.current.balances).toHaveLength(numberOfTokens)

--- a/packages/lib/modules/tokens/TokenBalancesProvider.tsx
+++ b/packages/lib/modules/tokens/TokenBalancesProvider.tsx
@@ -21,7 +21,7 @@ import { isZero } from '@repo/lib/shared/utils/numbers'
 
 const BALANCE_CACHE_TIME_MS = 30_000
 
-export type UseTokenBalancesResponse = ReturnType<typeof _useTokenBalances>
+export type UseTokenBalancesResponse = ReturnType<typeof useTokenBalancesLogic>
 export const TokenBalancesContext = createContext<UseTokenBalancesResponse | null>(null)
 
 /**
@@ -32,7 +32,7 @@ export const TokenBalancesContext = createContext<UseTokenBalancesResponse | nul
  * an amount of the user's tokens to ensure the add is successful. In this
  * case the buffer is set to the slippage percentage set by the user.
  */
-export function _useTokenBalances(
+export function useTokenBalancesLogic(
   initTokens?: ApiToken[],
   extTokens?: ApiToken[],
   bufferPercentage: HumanAmount | string = '0'
@@ -164,7 +164,7 @@ export function TokenBalancesProvider({
   bufferPercentage,
   children,
 }: ProviderProps) {
-  const hook = _useTokenBalances(initTokens, extTokens, bufferPercentage)
+  const hook = useTokenBalancesLogic(initTokens, extTokens, bufferPercentage)
   return <TokenBalancesContext.Provider value={hook}>{children}</TokenBalancesContext.Provider>
 }
 

--- a/packages/lib/modules/tokens/TokenInputsValidationProvider.tsx
+++ b/packages/lib/modules/tokens/TokenInputsValidationProvider.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren, createContext, useState } from 'react'
 import { Address } from 'viem'
 import { ApiToken } from './token.types'
 
-export function _useTokenInputsValidation() {
+export function useTokenInputsValidationLogic() {
   type ValidationErrorsByToken = Record<Address, string>
   const [validationErrors, setValidationErrors] = useState<ValidationErrorsByToken>({})
 
@@ -40,11 +40,11 @@ export function _useTokenInputsValidation() {
   }
 }
 
-export type Result = ReturnType<typeof _useTokenInputsValidation>
+export type Result = ReturnType<typeof useTokenInputsValidationLogic>
 export const TokenValidationContext = createContext<Result | null>(null)
 
 export function TokenInputsValidationProvider({ children }: PropsWithChildren) {
-  const validation = _useTokenInputsValidation()
+  const validation = useTokenInputsValidationLogic()
 
   return (
     <TokenValidationContext.Provider value={validation}>{children}</TokenValidationContext.Provider>

--- a/packages/lib/modules/tokens/TokensProvider.spec.tsx
+++ b/packages/lib/modules/tokens/TokensProvider.spec.tsx
@@ -8,14 +8,14 @@ import {
   defaultGetTokensQueryVariablesMock,
   defaultTokenListMock,
 } from './__mocks__/token.builders'
-import { _useTokens } from './TokensProvider'
+import { useTokensLogic } from './TokensProvider'
 
 const initTokensData = defaultGetTokensQueryMock
 const initTokenPricesData = defaultGetTokenPricesQueryMock
 
 function testUseTokens() {
   const variables = defaultGetTokensQueryVariablesMock
-  const { result } = testHook(() => _useTokens(initTokensData, initTokenPricesData, variables))
+  const { result } = testHook(() => useTokensLogic(initTokensData, initTokenPricesData, variables))
   return result
 }
 

--- a/packages/lib/modules/tokens/TokensProvider.tsx
+++ b/packages/lib/modules/tokens/TokensProvider.tsx
@@ -24,12 +24,12 @@ import mainnetNetworkConfig from '@repo/lib/config/networks/mainnet'
 import { PoolToken } from '../pool/pool.types'
 import { ApiToken } from './token.types'
 
-export type UseTokensResult = ReturnType<typeof _useTokens>
+export type UseTokensResult = ReturnType<typeof useTokensLogic>
 export const TokensContext = createContext<UseTokensResult | null>(null)
 
 export type GetTokenFn = (address: string, chain: GqlChain) => ApiToken | undefined
 
-export function _useTokens(
+export function useTokensLogic(
   initTokenData: GetTokensQuery,
   initTokenPricesData: GetTokenPricesQuery,
   variables: GetTokensQueryVariables
@@ -198,7 +198,7 @@ export function TokensProvider({
   tokenPricesData: GetTokenPricesQuery
   variables: GetTokensQueryVariables
 }) {
-  const tokens = _useTokens(tokensData, tokenPricesData, variables)
+  const tokens = useTokensLogic(tokensData, tokenPricesData, variables)
 
   return <TokensContext.Provider value={tokens}>{children}</TokensContext.Provider>
 }

--- a/packages/lib/modules/tokens/approvals/permit2/Permit2SignatureProvider.tsx
+++ b/packages/lib/modules/tokens/approvals/permit2/Permit2SignatureProvider.tsx
@@ -5,10 +5,10 @@ import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { Permit2 } from '@balancer/sdk'
 import { PropsWithChildren, createContext, useState } from 'react'
 
-export type UsePermit2SignatureResponse = ReturnType<typeof _usePermit2Signature>
+export type UsePermit2SignatureResponse = ReturnType<typeof usePermit2SignatureLogic>
 export const Permit2SignatureContext = createContext<UsePermit2SignatureResponse | null>(null)
 
-export function _usePermit2Signature() {
+export function usePermit2SignatureLogic() {
   const [permit2Signature, setPermit2Signature] = useState<Permit2 | undefined>()
 
   const [signPermit2State, setSignPermit2State] = useState<SignatureState>(SignatureState.Preparing)
@@ -22,7 +22,7 @@ export function _usePermit2Signature() {
 }
 
 export function Permit2SignatureProvider({ children }: PropsWithChildren) {
-  const hook = _usePermit2Signature()
+  const hook = usePermit2SignatureLogic()
   return (
     <Permit2SignatureContext.Provider value={hook}>{children}</Permit2SignatureContext.Provider>
   )

--- a/packages/lib/modules/tokens/approvals/permit2/PermitSignatureProvider.tsx
+++ b/packages/lib/modules/tokens/approvals/permit2/PermitSignatureProvider.tsx
@@ -5,10 +5,10 @@ import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { Permit } from '@balancer/sdk'
 import { PropsWithChildren, createContext, useState } from 'react'
 
-export type UsePermitSignatureResponse = ReturnType<typeof _usePermitSignature>
+export type UsePermitSignatureResponse = ReturnType<typeof usePermitSignatureLogic>
 export const PermitSignatureContext = createContext<UsePermitSignatureResponse | null>(null)
 
-export function _usePermitSignature() {
+export function usePermitSignatureLogic() {
   const [permitSignature, setPermitSignature] = useState<Permit | undefined>()
 
   const [signPermitState, setSignPermitState] = useState<SignatureState>(SignatureState.Preparing)
@@ -22,7 +22,7 @@ export function _usePermitSignature() {
 }
 
 export function PermitSignatureProvider({ children }: PropsWithChildren) {
-  const hook = _usePermitSignature()
+  const hook = usePermitSignatureLogic()
   return <PermitSignatureContext.Provider value={hook}>{children}</PermitSignatureContext.Provider>
 }
 

--- a/packages/lib/modules/transactions/RecentTransactionsProvider.tsx
+++ b/packages/lib/modules/transactions/RecentTransactionsProvider.tsx
@@ -18,7 +18,7 @@ import { TransactionStatus as SafeTxStatus } from '@safe-global/safe-apps-sdk'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { getBlockExplorerTxUrl } from '@repo/lib/shared/utils/blockExplorer'
 
-export type RecentTransactionsResponse = ReturnType<typeof _useRecentTransactions>
+export type RecentTransactionsResponse = ReturnType<typeof useRecentTransactionsLogic>
 export const TransactionsContext = createContext<RecentTransactionsResponse | null>(null)
 const NUM_RECENT_TRANSACTIONS = 20
 const RECENT_TRANSACTIONS_KEY = `${PROJECT_CONFIG.projectId}.recentTransactions`
@@ -66,7 +66,7 @@ const TransactionStatusToastStatusMapping: Record<TransactionStatus, AlertStatus
   unknown: 'warning',
 }
 
-export function _useRecentTransactions() {
+export function useRecentTransactionsLogic() {
   const [transactions, setTransactions] = useState<Record<string, TrackedTransaction>>({})
   const toast = useToast()
   const publicClient = usePublicClient()
@@ -259,7 +259,7 @@ export function _useRecentTransactions() {
 }
 
 export function RecentTransactionsProvider({ children }: { children: ReactNode }) {
-  const transactions = _useRecentTransactions()
+  const transactions = useRecentTransactionsLogic()
   return (
     <TransactionsContext.Provider value={transactions}>{children}</TransactionsContext.Provider>
   )

--- a/packages/lib/modules/transactions/transaction-steps/TransactionStateProvider.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/TransactionStateProvider.tsx
@@ -5,7 +5,7 @@ import { ManagedResult } from './lib'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { resetTransaction } from './transaction.helper'
 
-export function _useTransactionState() {
+export function useTransactionStateLogic() {
   const [transactionMap, setTransactionMap] = useState<Map<string, ManagedResult>>(new Map())
 
   function updateTransaction(k: string, v: ManagedResult) {
@@ -47,11 +47,11 @@ export function _useTransactionState() {
   }
 }
 
-export type TransactionStateResponse = ReturnType<typeof _useTransactionState>
+export type TransactionStateResponse = ReturnType<typeof useTransactionStateLogic>
 export const TransactionStateContext = createContext<TransactionStateResponse | null>(null)
 
 export function TransactionStateProvider({ children }: PropsWithChildren) {
-  const hook = _useTransactionState()
+  const hook = useTransactionStateLogic()
 
   return (
     <TransactionStateContext.Provider value={hook}>{children}</TransactionStateContext.Provider>

--- a/packages/lib/modules/user/settings/UserSettingsProvider.tsx
+++ b/packages/lib/modules/user/settings/UserSettingsProvider.tsx
@@ -17,10 +17,10 @@ const DEFAULT_ACCEPTED_POLICIES: string[] = []
 const DEFAULT_ALLOW_SOUNDS: YesNo = 'yes'
 const DEFAULT_ENABLE_TX_BUNDLING: YesNo = 'yes'
 
-export type UseUserSettingsResult = ReturnType<typeof _useUserSettings>
+export type UseUserSettingsResult = ReturnType<typeof useUserSettingsLogic>
 export const UserSettingsContext = createContext<UseUserSettingsResult | null>(null)
 
-export function _useUserSettings({
+export function useUserSettingsLogic({
   initCurrency,
   initSlippage,
   initEnableSignatures,
@@ -124,7 +124,7 @@ export function UserSettingsProvider({
   const _initAllowSounds = (initAllowSounds as YesNo) || DEFAULT_ALLOW_SOUNDS
   const _initEnableTxBundling = (initEnableTxBundling as YesNo) || DEFAULT_ENABLE_TX_BUNDLING
 
-  const hook = _useUserSettings({
+  const hook = useUserSettingsLogic({
     initCurrency: _initCurrency,
     initSlippage: _initSlippage,
     initEnableSignatures: _initEnableSignatures,

--- a/packages/lib/modules/vebal/VebalLockDataProvider.tsx
+++ b/packages/lib/modules/vebal/VebalLockDataProvider.tsx
@@ -14,7 +14,7 @@ import { toJsTimestamp } from '@repo/lib/shared/utils/time'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { LockActionType } from './vote/vote.types'
 
-export type UseVebalLockDataResult = ReturnType<typeof _useVebalLockData>
+export type UseVebalLockDataResult = ReturnType<typeof useVebalLockDataLogic>
 export const VebalLockDataContext = createContext<UseVebalLockDataResult | null>(null)
 
 function getAvailableLockActions(
@@ -61,7 +61,7 @@ interface MulticallLockDataResponse {
   }
 }
 
-export function _useVebalLockData() {
+export function useVebalLockDataLogic() {
   const { userAddress, isConnected } = useUserAccount()
 
   const lockDataRequestsData = [
@@ -147,7 +147,7 @@ export function _useVebalLockData() {
 }
 
 export function VebalLockDataProvider({ children }: PropsWithChildren) {
-  const vebalLockData = _useVebalLockData()
+  const vebalLockData = useVebalLockDataLogic()
 
   return (
     <VebalLockDataContext.Provider value={vebalLockData}>{children}</VebalLockDataContext.Provider>

--- a/packages/lib/modules/web3/UserAccountProvider.tsx
+++ b/packages/lib/modules/web3/UserAccountProvider.tsx
@@ -28,10 +28,10 @@ async function isAuthorizedAddress(address: Address): Promise<boolean> {
   }
 }
 
-export type UseUserAccountResponse = ReturnType<typeof _useUserAccount>
+export type UseUserAccountResponse = ReturnType<typeof useUserAccountLogic>
 export const UserAccountContext = createContext<UseUserAccountResponse | null>(null)
 
-export function _useUserAccount() {
+export function useUserAccountLogic() {
   const isMounted = useIsMounted()
   const query = useAccount()
   const { disconnect } = useDisconnect()
@@ -129,7 +129,7 @@ export function _useUserAccount() {
 }
 
 export function UserAccountProvider({ children }: PropsWithChildren) {
-  const hook = _useUserAccount()
+  const hook = useUserAccountLogic()
   return <UserAccountContext.Provider value={hook}>{children}</UserAccountContext.Provider>
 }
 

--- a/packages/lib/modules/web3/WagmiConfigProvider.tsx
+++ b/packages/lib/modules/web3/WagmiConfigProvider.tsx
@@ -4,10 +4,10 @@ import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { createContext, PropsWithChildren, useState } from 'react'
 import { wagmiConfig as _wagmiConfig } from './WagmiConfig'
 
-export type UseWagmiConfigResult = ReturnType<typeof _useWagmiConfig>
+export type UseWagmiConfigResult = ReturnType<typeof useWagmiConfigLogic>
 export const WagmiConfigContext = createContext<UseWagmiConfigResult | null>(null)
 
-export function _useWagmiConfig() {
+export function useWagmiConfigLogic() {
   const [wagmiConfig, setWagmiConfig] = useState(_wagmiConfig)
 
   return { wagmiConfig, setWagmiConfig }
@@ -18,7 +18,7 @@ export function _useWagmiConfig() {
   Useful for manual and E2E testing
 */
 export function WagmiConfigProvider({ children }: PropsWithChildren) {
-  const config = _useWagmiConfig()
+  const config = useWagmiConfigLogic()
 
   return <WagmiConfigContext.Provider value={config}>{children}</WagmiConfigContext.Provider>
 }

--- a/packages/lib/shared/hooks/FxRatesProvider.tsx
+++ b/packages/lib/shared/hooks/FxRatesProvider.tsx
@@ -4,10 +4,10 @@ import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { createContext, PropsWithChildren } from 'react'
 import { FxRates, SupportedCurrency } from '../utils/currencies'
 
-export type UseFxRatesResult = ReturnType<typeof _useFxRates>
+export type UseFxRatesResult = ReturnType<typeof useFxRatesLogic>
 export const FxRatesContext = createContext<UseFxRatesResult | null>(null)
 
-export function _useFxRates(rates: FxRates | undefined) {
+export function useFxRatesLogic(rates: FxRates | undefined) {
   const hasFxRates = !!rates
 
   function getFxRate(currency: SupportedCurrency): number {
@@ -22,7 +22,7 @@ export function FiatFxRatesProvider({
   children,
   data,
 }: PropsWithChildren & { data: FxRates | undefined }) {
-  const hook = _useFxRates(data)
+  const hook = useFxRatesLogic(data)
   return <FxRatesContext.Provider value={hook}>{children}</FxRatesContext.Provider>
 }
 

--- a/packages/lib/test/utils/custom-renderers.tsx
+++ b/packages/lib/test/utils/custom-renderers.tsx
@@ -101,7 +101,7 @@ function GlobalProviders({ children }: PropsWithChildren) {
  * @param hookResult is the result of calling renderHookWithDefaultProviders
  *
  *  Example:
- *    const { result, waitForLoadedUseQuery } = testHook(() => _useMyHookUnderTest())
+ *    const { result, waitForLoadedUseQuery } = testHook(() => useMyHookUnderTestLogic())
  *    await waitForLoadedUseQuery(result)
  *
  */


### PR DESCRIPTION
Preparation commit for incoming next 15.x migration.

next 15 eslint does not allow underscores in hook names so we use Logic sufix as a naming pattern for internal logic context hooks that are only exported to be testable by unit tests. 