### PR TITLE
Add pre pectra fork block number in mainnet

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set up foundry (includes anvil)
         uses: foundry-rs/foundry-toolchain@v1
       - name: Start anvil fork in mainnet
-        run: anvil --fork-url "https://lb.drpc.org/ogrpc?network=ethereum&dkey=${{ env.NEXT_PRIVATE_DRPC_KEY }}" --port 8545 &
+        run: anvil --fork-url "https://lb.drpc.org/ogrpc?network=ethereum&dkey=${{ env.NEXT_PRIVATE_DRPC_KEY }}" --port 8545 --fork-block-number 22426500 &
       - name: Install Playwright Browsers
         run: pnpm playwright:install:chromium # CI only tests in chromium
       - name: Run Playwright dev tests

--- a/packages/test/anvil/anvil-setup.ts
+++ b/packages/test/anvil/anvil-setup.ts
@@ -89,9 +89,14 @@ export const ANVIL_NETWORKS: Record<ChainIdWithFork, NetworkSetup> = {
     chainId: mainnet.id,
     fallBackRpc: 'https://cloudflare-eth.com',
     port: ANVIL_PORTS[mainnet.id],
-    // From time to time this block gets outdated having this kind of error in integration tests:
-    // ContractFunctionExecutionError: The contract function "queryJoin" returned no data ("0x").
-    // forkBlockNumber: 21831471n,
+    /* From time to time this block gets outdated having this kind of error in integration tests:
+     ContractFunctionExecutionError: The contract function "queryJoin" returned no data ("0x").
+     forkBlockNumber: 21831471n,
+    */
+    // block number from 6 May 2025 (1 day before pectra launch)
+    // delete when foundry fixes issue affecting signing with permit2
+    // reproduction repo: https://github.com/agualis/boosted-add-demo
+    forkBlockNumber: 22426500n,
   },
   [polygon.id]: {
     chainId: polygon.id,


### PR DESCRIPTION
Our dev e2e tests for adding in the tri boosted pool started failing after the pectra upgrade.

The issues does not happen in production or tenderly virtual testnets but only in anvil forks. 

This PR points to a block number from May 6th 2025 until foundry fixes the issue. 

We registered the issue in their telegram, sent this [reproduction repo](https://github.com/agualis/boosted-add-demo)) and now they are investigating.