### PR TITLE
fix: change default impersonation anvil account to one without 7702

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set up foundry (includes anvil)
         uses: foundry-rs/foundry-toolchain@v1
       - name: Start anvil fork in mainnet
-        run: anvil --fork-url "https://lb.drpc.org/ogrpc?network=ethereum&dkey=${{ env.NEXT_PRIVATE_DRPC_KEY }}" --port 8545 --fork-block-number 22426500 &
+        run: anvil --fork-url "https://lb.drpc.org/ogrpc?network=ethereum&dkey=${{ env.NEXT_PRIVATE_DRPC_KEY }}" --port 8545 &
       - name: Install Playwright Browsers
         run: pnpm playwright:install:chromium # CI only tests in chromium
       - name: Run Playwright dev tests

--- a/packages/lib/test/utils/wagmi/fork.helpers.ts
+++ b/packages/lib/test/utils/wagmi/fork.helpers.ts
@@ -12,7 +12,12 @@ import { GetVeBalVotingListQuery } from '@repo/lib/shared/services/api/generated
   This is a helper file to provide related constants and helpers
 */
 
-export const defaultAnvilAccount = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+/*
+  This is the 4th anvil account and we chose this one explicitly as it does not have authlist7702
+  https://etherscan.io/address/0x90F79bf6EB2c4f870365E785982E1f101E93b906#authlist7702 -> does not open 7702 tab
+  Which is important for permit2 signatures working with anvil forks after pectra upgrade
+*/
+export const defaultAnvilAccount = '0x90F79bf6EB2c4f870365E785982E1f101E93b906'
 export const defaultAnvilForkRpcUrl = 'http://127.0.0.1:8545'
 
 export const mainnetTest = {

--- a/packages/test/anvil/anvil-setup.ts
+++ b/packages/test/anvil/anvil-setup.ts
@@ -91,12 +91,8 @@ export const ANVIL_NETWORKS: Record<ChainIdWithFork, NetworkSetup> = {
     port: ANVIL_PORTS[mainnet.id],
     /* From time to time this block gets outdated having this kind of error in integration tests:
      ContractFunctionExecutionError: The contract function "queryJoin" returned no data ("0x").
-     forkBlockNumber: 21831471n,
+     forkBlockNumber: 22426500n, // block number from 6 May 2025 (1 day before pectra launch)
     */
-    // block number from 6 May 2025 (1 day before pectra launch)
-    // delete when foundry fixes issue affecting signing with permit2
-    // reproduction repo: https://github.com/agualis/boosted-add-demo
-    forkBlockNumber: 22426500n,
   },
   [polygon.id]: {
     chainId: polygon.id,


### PR DESCRIPTION
From foundry team: 
> so for 7702 accounts, it would make sense if permit2 starts failing.
Because if the EOA is authorized, instead of using ECDSA.recover, the permit2 SignatureChecker lib would use 1271 signature verification first.
So indeed the first anvil account has 7702 auth lists https://etherscan.io/address/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266#authlist7702

So the workaround is using an anvil account that does not have 7702 auth lists. For instance:
`0x90F79bf6EB2c4f870365E785982E1f101E93b906`
https://etherscan.io/address/0x90F79bf6EB2c4f870365E785982E1f101E93b906#authlist7702 --> no 7702 tab