### PR TITLE
fix: avoid undefined blacklistedVotes

### DIFF
--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/incentivesBlacklist.ts
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/incentivesBlacklist.ts
@@ -48,7 +48,7 @@ export function useBlacklistedVotes(votingPools: VoteListItem[]) {
 
   return {
     isLoading: votesAreLoading || endLockTimestampsLoading,
-    blacklistedVotes: blacklistedVotesGroupedByGauge,
+    blacklistedVotes: blacklistedVotesGroupedByGauge as Record<string, BigNumber | undefined>,
   }
 }
 

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/myVotes.helpers.ts
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/myVotes.helpers.ts
@@ -56,7 +56,7 @@ export function calculateMyVoteRewardsValue(
   slope: bigint,
   lockEnd: number | undefined,
   totalVotes: bigint,
-  blacklistedVotes: BigNumber
+  blacklistedVotes: BigNumber = bn(0)
 ) {
   const votingPower = calculateVotingPower(slope, lockEnd)
   const oldWeight = votingPool.gaugeVotes?.userVotes || '0'
@@ -83,7 +83,7 @@ export function calculateMyValuePerVote(
   slope: bigint,
   lockEnd: number | undefined,
   totalVotes: bigint,
-  blacklistedVotes: BigNumber
+  blacklistedVotes: BigNumber = bn(0)
 ) {
   const votingPower = calculateVotingPower(slope, lockEnd)
   const newUserVotes = votingPower.times(bpsToPercentage(newWeight))


### PR DESCRIPTION
We don't have `noUncheckedIndexedAccess` rule activated so accessing 

`blacklistedVotes[vote.gauge.address]` [here](https://github.com/balancer/frontend-monorepo/blob/9b05fb0284abed1eeb8f60fd52a30443289afa61/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesProvider.tsx#L164) always returns BigNumber type even if the record is empty.

Casting the result of the hook from `Record<string, BigNumber>` to `Record<string, BigNumber | undefined>` fixes the issue but the proper way would be activating `noUncheckedIndexedAccess` (which could be done in increments).