### PR TITLE
Remove decimal points for APRs above 1,000%

### DIFF
--- a/packages/lib/shared/utils/numbers.spec.ts
+++ b/packages/lib/shared/utils/numbers.spec.ts
@@ -79,6 +79,9 @@ describe('aprFormat', () => {
     expect(fNum('apr', '0.00001')).toBe('<0.01%')
     expect(fNum('apr', '0.00009')).toBe('<0.01%')
     expect(fNum('apr', '0.000007595846919227514')).toBe('<0.01%')
+    expect(fNum('apr', '1.3456789')).toBe('134.57%')
+    // Big percentages > 1000%
+    expect(fNum('apr', '12.3456789')).toBe('1,235%')
   })
 })
 

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -27,6 +27,7 @@ export const TOKEN_FORMAT_A = '0,0.[0000]a'
 export const TOKEN_FORMAT_A_BIG = '0,0.[00]a'
 export const TOKEN_FORMAT = '0,0.[0000]'
 export const APR_FORMAT = '0,0.00%'
+export const APR_FORMAT_WITHOUT_DECIMALS = '0,0%'
 export const SLIPPAGE_FORMAT = '0.00%'
 export const FEE_FORMAT = '0.[0000]%'
 export const WEIGHT_FORMAT = '(%0,0)'
@@ -119,7 +120,7 @@ function aprFormat(apr: Numberish, { canBeNegative = false }: FormatOpts = {}): 
 
   // If absolute APR is > 1000% (i.e., apr value > 10), format without decimals.
   if (aprBn.abs().gt(10)) {
-    return numeral(apr.toString()).format('0,0%')
+    return numeral(apr.toString()).format(APR_FORMAT_WITHOUT_DECIMALS)
   }
 
   return numeral(apr.toString()).format(APR_FORMAT)

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -112,8 +112,15 @@ function tokenFormat(val: Numberish, { abbreviated = true }: FormatOpts = {}): s
 
 // Formats an APR value as a percentage.
 function aprFormat(apr: Numberish, { canBeNegative = false }: FormatOpts = {}): string {
-  if (bn(apr).gt(APR_UPPER_THRESHOLD)) return '-'
+  const aprBn = bn(apr)
+
+  if (aprBn.gt(APR_UPPER_THRESHOLD)) return '-'
   if (isSmallPercentage(apr) && !canBeNegative) return SMALL_PERCENTAGE_LABEL
+
+  // If absolute APR is > 1000% (i.e., apr value > 10), format without decimals.
+  if (aprBn.abs().gt(10)) {
+    return numeral(apr.toString()).format('0,0%')
+  }
 
   return numeral(apr.toString()).format(APR_FORMAT)
 }


### PR DESCRIPTION

To avoid unnecessary wrapping where possible, let's remove decimal points for large numbers.

![cs 2025-05-15 at 16 30 03@2x](https://github.com/user-attachments/assets/db5eb39c-4b90-4099-afaa-295d747db318)
