### PR TITLE
fix: use increaseApproval instead of approval when approving veBal Bpt

### DIFF
--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -18,7 +18,7 @@ import {
   getRequiredTokenApprovals,
   isTheApprovedAmountEnough,
 } from './approval-rules'
-import { requiresDoubleApproval } from '../token.helpers'
+import { isVeBalBtpAddress, requiresDoubleApproval } from '../token.helpers'
 import { ErrorWithCauses } from '@repo/lib/shared/utils/errors'
 
 export type Params = {
@@ -151,7 +151,7 @@ export function useTokenApprovalSteps({
       const isTxEnabled = !!spenderAddress && !tokenAllowances.isAllowancesLoading
       const props: ManagedErc20TransactionInput = {
         tokenAddress,
-        functionName: 'approve',
+        functionName: isVeBalBtpAddress(tokenAddress) ? 'increaseApproval' : 'approve',
         labels,
         isComplete,
         chainId: getChainId(chain),

--- a/packages/lib/modules/tokens/token.helpers.ts
+++ b/packages/lib/modules/tokens/token.helpers.ts
@@ -13,6 +13,7 @@ import { Pool } from '../pool/pool.types'
 import { getVaultConfig, isCowAmmPool, isV3Pool } from '../pool/pool.helpers'
 import { PoolToken } from '../pool/pool.types'
 import { ApiToken } from './token.types'
+import mainnetNetworkConfig from '@repo/lib/config/networks/mainnet'
 
 export function isNativeAsset(token: TokenBase | string, chain: GqlChain | SupportedChainId) {
   return nativeAssetFilter(chain)(token)
@@ -152,4 +153,10 @@ export function getSpenderForAddLiquidity(pool: Pool): Address {
   }
   const { vaultAddress } = getVaultConfig(pool)
   return vaultAddress
+}
+
+export const veBalBptAddress = mainnetNetworkConfig.tokens.addresses.veBalBpt as Address
+
+export function isVeBalBtpAddress(tokenAddress: Address) {
+  return isSameAddress(tokenAddress, veBalBptAddress)
 }

--- a/packages/lib/modules/web3/contracts/abi/vebalAbi.ts
+++ b/packages/lib/modules/web3/contracts/abi/vebalAbi.ts
@@ -1,0 +1,20 @@
+import { AbiItem, erc20Abi } from 'viem'
+
+const increaseApprovalAbiItem: AbiItem = {
+  inputs: [
+    { internalType: 'address', name: 'spender', type: 'address' },
+    { internalType: 'uint256', name: 'amount', type: 'uint256' },
+  ],
+  name: 'increaseApproval',
+  outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+  stateMutability: 'nonpayable',
+  type: 'function',
+} as const
+
+/*
+  Edge case:
+  when locking veBalBPT for getting veBal, the veBalBPT contract must use its increaseApproval function
+  instead of the standard Erc20 approve function.
+  Here we extend the erc20Abi with the increaseApproval function to cover that edge case in the generic token approval flow.
+*/
+export const erc20AbiWithIncreaseApproval = [...erc20Abi, increaseApprovalAbiItem] as const

--- a/packages/lib/modules/web3/contracts/useManagedErc20Transaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedErc20Transaction.ts
@@ -10,7 +10,7 @@ import {
 import { isSameAddress } from '@repo/lib/shared/utils/addresses'
 import { captureWagmiExecutionError } from '@repo/lib/shared/utils/query-errors'
 import { useEffect, useState } from 'react'
-import { Address, ContractFunctionArgs, ContractFunctionName, erc20Abi } from 'viem'
+import { Address, ContractFunctionArgs, ContractFunctionName } from 'viem'
 import { useSimulateContract, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
 import { useTxHash } from '../safe.hooks'
 import { useChainSwitch } from '../useChainSwitch'
@@ -20,16 +20,19 @@ import { useOnTransactionConfirmation } from './useOnTransactionConfirmation'
 import { useOnTransactionSubmission } from './useOnTransactionSubmission'
 import { getWaitForReceiptTimeout } from './wagmi-helpers'
 import { onlyExplicitRefetch } from '@repo/lib/shared/utils/queries'
+import { erc20AbiWithIncreaseApproval } from '@repo/lib/modules/web3/contracts/abi/vebalAbi'
 
-type Erc20Abi = typeof erc20Abi
+type Erc20AbiWithIncreaseApproval = typeof erc20AbiWithIncreaseApproval
 
 export interface ManagedErc20TransactionInput {
   tokenAddress: Address
-  functionName: ContractFunctionName<Erc20Abi, WriteAbiMutability>
+  functionName:
+    | ContractFunctionName<Erc20AbiWithIncreaseApproval, WriteAbiMutability>
+    | 'increaseApproval' // Edge-case for veBalBpt approval
   labels: TransactionLabels
   isComplete?: () => boolean
   chainId: SupportedChainId
-  args?: ContractFunctionArgs<Erc20Abi, WriteAbiMutability> | null
+  args?: ContractFunctionArgs<Erc20AbiWithIncreaseApproval, WriteAbiMutability> | null
   enabled: boolean
   simulationMeta: Record<string, unknown>
 }
@@ -55,7 +58,7 @@ export function useManagedErc20Transaction({
       USDTs ABI does not exactly follow the erc20ABI so we need its explicit ABI to avoid errors (e.g. calling approve)
       More info: https://github.com/wevm/wagmi/issues/2749#issuecomment-1638200817
     */
-    abi: isUsdt ? usdtAbi : erc20Abi,
+    abi: isUsdt ? usdtAbi : erc20AbiWithIncreaseApproval,
     address: tokenAddress,
     functionName: functionName as ContractFunctionName<any, WriteAbiMutability>,
     // This any is 'safe'. The type provided to any is the same type for args that is inferred via the functionName
@@ -111,7 +114,9 @@ export function useManagedErc20Transaction({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(args)])
 
-  const managedWriteAsync = async (args?: ContractFunctionArgs<Erc20Abi, WriteAbiMutability>) => {
+  const managedWriteAsync = async (
+    args?: ContractFunctionArgs<Erc20AbiWithIncreaseApproval, WriteAbiMutability>
+  ) => {
     if (args) {
       setWriteArgs(args)
     }


### PR DESCRIPTION
Closes [#1027](https://github.com/balancer/frontend-monorepo/issues/1027)

This PR only uses the alternative `increaseApproval` instead of `approval` for `veBAL BPT` to workaround an issue that Ledger users are facing in combination with wallets like Metamask.

After removing the approval step in the increase veBAL lock [in this PR](https://github.com/balancer/frontend-monorepo/pull/1087) that won't be an issue anymore, so this PR can be closed. 

However, Ledger users can still face issues when [approving V2 BPTs for staking ](https://github.com/balancer/frontend-monorepo/blob/020b84d5545d66f1c49db60032f19157daad9237/packages/lib/modules/pool/actions/stake/useStakeSteps.tsx#L19). After [this PR](https://github.com/balancer/frontend-monorepo/pull/1074) they will see a custom error message with some recommendations.

Adding a proper fix in `useTokenApprovalSteps` is possible but tricky so maybe we want to wait until we understand the `increaseApproval` edge case better. 

cc @agorer @groninge01 
