### PR TITLE
refactor: addStep hook to use new transaction system

### DIFF
--- a/packages/lib/modules/transactions/transaction-steps/TransactionButton.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/TransactionButton.tsx
@@ -25,6 +25,7 @@ export function ManagedTransactionButton({
   const { updateTransaction } = useTransactionState()
 
   useEffect(() => {
+    // TODO(transaction-refactor): remove if and updateTransaction once all steps are migrated to use onTransactionChange
     updateTransaction(id, transaction)
   }, [id, transaction.execution.status, transaction.simulation.status, transaction.result.status])
 
@@ -39,6 +40,8 @@ export function ManagedSendTransactionButton({
   const { updateTransaction } = useTransactionState()
 
   useEffect(() => {
+    // TODO(transaction-refactor): remove if and updateTransaction once all steps are migrated to use onTransactionChange    if (params.onTransactionChange) params.onTransactionChange(transaction)
+    if (params.onTransactionChange) params.onTransactionChange(transaction)
     updateTransaction(id, transaction)
   }, [id, transaction.execution.status, transaction.simulation.status, transaction.result.status])
 
@@ -53,6 +56,8 @@ export function ManagedErc20TransactionButton({
   const { updateTransaction } = useTransactionState()
 
   useEffect(() => {
+    // TODO(transaction-refactor): remove if and updateTransaction once all steps are migrated to use onTransactionChange
+    if (params.onTransactionChange) params.onTransactionChange(transaction)
     updateTransaction(id, transaction)
   }, [id, transaction.execution.status, transaction.simulation.status, transaction.result.status])
 

--- a/packages/lib/modules/transactions/transaction-steps/lib.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/lib.tsx
@@ -140,6 +140,8 @@ export type TransactionStep = {
   labels: TransactionLabels
   isComplete: () => boolean
   renderAction: () => ReactNode
+  // TODO(transaction-refactor): make it non-optional once all steps are migrated to use onTransactionChange
+  transaction?: ManagedResult
   // All callbacks should be idempotent
   onSuccess?: () => any
   onActivated?: () => void

--- a/packages/lib/modules/transactions/transaction-steps/transaction.helper.ts
+++ b/packages/lib/modules/transactions/transaction-steps/transaction.helper.ts
@@ -8,3 +8,7 @@ export function resetTransaction(v: ManagedResult) {
   v.execution.reset()
   return v
 }
+
+export function isTransactionSuccess(transaction?: ManagedResult) {
+  return transaction?.result.isSuccess || false
+}

--- a/packages/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { getTransactionState, TransactionState, TransactionStep } from './lib'
+import { getTransactionState, ManagedResult, TransactionState, TransactionStep } from './lib'
 import { useTransactionState } from './TransactionStateProvider'
 import { useTxSound } from './useTxSound'
 import { ensureError, ErrorCause, ErrorWithCauses } from '@repo/lib/shared/utils/errors'
@@ -29,7 +29,13 @@ export function useTransactionSteps(steps: TransactionStep[] = [], isLoading = f
   const { playTxSound } = useTxSound()
 
   const currentStep = steps[currentStepIndex]
-  const currentTransaction = currentStep ? getTransaction(currentStep.id) : undefined
+
+  let currentTransaction: ManagedResult | undefined
+  if (currentStep) {
+    // TODO(transaction-refactor): remove getTransaction once all steps have been migrated
+    currentTransaction = currentStep?.transaction ?? getTransaction(currentStep.id)
+  }
+
   const isCurrentStepComplete = currentStep?.isComplete() || false
   const lastStepIndex = steps?.length ? steps.length - 1 : 0
   const lastStep = steps?.[lastStepIndex]

--- a/packages/lib/modules/web3/contracts/useManagedErc20Transaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedErc20Transaction.ts
@@ -28,6 +28,8 @@ export interface ManagedErc20TransactionInput {
   functionName: ContractFunctionName<Erc20Abi, WriteAbiMutability>
   labels: TransactionLabels
   isComplete?: () => boolean
+  // TODO(transaction-refactor): make it non-optional once all steps are migrated to use onTransactionChange
+  onTransactionChange?: (transaction: ManagedResult) => void
   chainId: SupportedChainId
   args?: ContractFunctionArgs<Erc20Abi, WriteAbiMutability> | null
   enabled: boolean

--- a/packages/lib/modules/web3/contracts/useManagedSendTransaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedSendTransaction.ts
@@ -26,6 +26,8 @@ export type ManagedSendTransactionInput = {
   labels: TransactionLabels
   txConfig: TransactionConfig
   gasEstimationMeta?: Record<string, unknown>
+  // TODO(transaction-refactor): make it non-optional once all steps are migrated to use onTransactionChange
+  onTransactionChange?: (transaction: ManagedResult) => void
 }
 
 export function useManagedSendTransaction({

--- a/packages/lib/modules/web3/contracts/useManagedTransaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedTransaction.ts
@@ -39,6 +39,8 @@ export interface ManagedTransactionInput {
   txSimulationMeta?: Record<string, unknown>
   enabled: boolean
   value?: bigint
+  // TODO(transaction-refactor): make it non-optional once all steps are migrated to use onTransactionChange
+  onTransactionChange?: (transaction: ManagedResult) => void
 }
 
 export function useManagedTransaction({


### PR DESCRIPTION
This is the first step of a big refactor to simplify the way we handle transaction (AKA `ManagedResult`) states. 