### PR TITLE
chore: change tsconfig.json relative paths

### DIFF
--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -5,7 +5,8 @@
     "types": ["vitest/globals"],
     "baseUrl": ".",
     "paths": {
-      "@repo/lib/*": ["../../packages/lib/*"]
+      "@repo/lib/*": ["../../packages/lib/*"],
+      "@repo/test/*": ["../../packages/test/*"]
     },
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
   },

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -5,7 +5,7 @@
     "types": ["vitest/globals"],
     "baseUrl": ".",
     "paths": {
-      "@repo/*": ["../*"]
+      "@repo/lib/*": ["../../packages/lib/*"]
     },
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
   },


### PR DESCRIPTION
The old setup using: 

`"@repo/*": ["../*"]`

was causing issues when using auto imports in some IDEs as they added as valid imports:

`import {foo} from '/modules/bar'`
