### PR TITLE
fix: comma in apr label breaks weekly yield calc

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolSnapshot/UserSnapshotValues.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolSnapshot/UserSnapshotValues.tsx
@@ -15,7 +15,6 @@ import { ClaimModal } from '../../../actions/claim/ClaimModal'
 import MainAprTooltip from '@repo/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip'
 import { calcTotalStakedBalanceUsd } from '../../../user-balance.helpers'
 import { useGetUserPoolRewards } from '../../../useGetUserPoolRewards'
-import { isQuantAmmPool } from '../../../pool.helpers'
 import FadeInOnView from '@repo/lib/shared/components/containers/FadeInOnView'
 
 export type PoolMyStatsValues = {
@@ -55,8 +54,7 @@ export function UserSnapshotValues() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [veBalBoostMap])
 
-  const canBeNegative = isQuantAmmPool(pool.type)
-  const myAprRaw = getTotalAprRaw(pool.dynamicData.aprItems, boost, canBeNegative)
+  const myAprRaw = getTotalAprRaw(pool.dynamicData.aprItems, boost)
 
   const poolMyStatsValues: PoolMyStatsValues | undefined = useMemo(() => {
     if (pool && pool.userBalance && !isLoadingPool && !isLoadingClaiming) {
@@ -68,9 +66,7 @@ export function UserSnapshotValues() {
 
       return {
         myLiquidity: totalBalanceUsd,
-        myPotentialWeeklyYield: bn(stakedBalanceUsd)
-          .times(bn(bn(myAprRaw).div(100)).div(52))
-          .toFixed(2),
+        myPotentialWeeklyYield: bn(stakedBalanceUsd).times(bn(myAprRaw).div(52)).toFixed(2),
         myClaimableRewards: myClaimableRewards,
       }
     }

--- a/packages/lib/modules/pool/pool.utils.ts
+++ b/packages/lib/modules/pool/pool.utils.ts
@@ -179,13 +179,9 @@ export function getTotalAprLabel(
   }
 }
 
-export function getTotalAprRaw(
-  aprItems: GqlPoolAprItem[],
-  vebalBoost?: string,
-  canBeNegative = false
-): string {
-  const apr = getTotalAprLabel(aprItems, vebalBoost, canBeNegative)
-  return apr.substring(0, apr.length - 1).replace(/,/g, '')
+export function getTotalAprRaw(aprItems: GqlPoolAprItem[], vebalBoost?: string): string {
+  const [minTotal] = getTotalApr(aprItems, vebalBoost)
+  return minTotal.toString()
 }
 
 // Maps GraphQL pool type enum to human readable label for UI.

--- a/packages/lib/modules/pool/pool.utils.ts
+++ b/packages/lib/modules/pool/pool.utils.ts
@@ -185,7 +185,7 @@ export function getTotalAprRaw(
   canBeNegative = false
 ): string {
   const apr = getTotalAprLabel(aprItems, vebalBoost, canBeNegative)
-  return apr.substring(0, apr.length - 1)
+  return apr.substring(0, apr.length - 1).replace(/,/g, '')
 }
 
 // Maps GraphQL pool type enum to human readable label for UI.


### PR DESCRIPTION
`getTotalAprRaw` was using `getTotalAprLabel` to get the 'raw' apr by removing the percentage sign
however aprs > 1000% were also adding a comma to the `raw` apr, this breaks the potential weekly yield calc

the fix is for `getTotalAprRaw` to use  `getTotalApr` which returns the apr without a comma or percentage sign

