### PR TITLE
Use token caps when calculating voting incentives

### DIFF
--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesProvider.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesProvider.tsx
@@ -30,6 +30,7 @@ import { useBlacklistedVotes } from './incentivesBlacklist'
 import { useLastUserSlope } from '../../useVeBALBalance'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { Address } from 'viem'
+import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 
 function sortMyVotesList(voteList: VotingPoolWithData[], sortBy: SortingBy, order: Sorting) {
   return orderBy(
@@ -126,6 +127,7 @@ export function useMyVotesLogic({}: UseMyVotesArgs) {
   const { blacklistedVotes, isLoading: blacklistedLoading } = useBlacklistedVotes(votingPools)
   const { userAddress, isLoading: userAccountLoading } = useUserAccount()
   const { slope, isLoading: slopeLoading } = useLastUserSlope(userAddress)
+  const { priceFor } = useTokens()
 
   const totalInfo: MyVotesTotalInfo = useMemo(() => {
     const infos = availableMyVotes.map(myVote => {
@@ -139,7 +141,8 @@ export function useMyVotesLogic({}: UseMyVotesArgs) {
         slope,
         lockEnd,
         totalVotes,
-        blacklistedVotes[myVote.gauge.address as Address]
+        blacklistedVotes[myVote.gauge.address as Address],
+        priceFor
       )
 
       return {
@@ -162,7 +165,8 @@ export function useMyVotesLogic({}: UseMyVotesArgs) {
         slope,
         lockEnd,
         totalVotes,
-        blacklistedVotes[vote.gauge.address as Address]
+        blacklistedVotes[vote.gauge.address as Address],
+        priceFor
       )
     )
 
@@ -173,7 +177,8 @@ export function useMyVotesLogic({}: UseMyVotesArgs) {
         slope,
         lockEnd,
         totalVotes,
-        blacklistedVotes[vote.gauge.address as Address]
+        blacklistedVotes[vote.gauge.address as Address],
+        priceFor
       )
     )
 
@@ -204,6 +209,7 @@ export function useMyVotesLogic({}: UseMyVotesArgs) {
     slope,
     blacklistedVotes,
     lockEnd,
+    priceFor,
   ])
 
   const hasVotedBefore = votedPools.length > 0

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/incentives-optimization/MyVotesStatsMyIncentivesOptimized.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/incentives-optimization/MyVotesStatsMyIncentivesOptimized.tsx
@@ -36,7 +36,7 @@ export function MyVotesStatsMyIncentivesOptimized() {
   const aprItems = pool?.dynamicData.aprItems as GqlPoolAprItem[]
   const lockingApr = aprItems?.find(item => item.type === GqlPoolAprItemType.Locking)?.apr || 0
   const balance = pool ? getStakedBalance(pool as Pool, GqlPoolStakingType.Vebal) : undefined
-  const protocolRevenueShare = balance ? balance.balanceUsd * lockingApr : 0
+  const protocolRevenueShare = balance ? (balance.balanceUsd * lockingApr) / 52 : 0
 
   const { incentives, incentivesAreLoading } = useVeBALIncentives(userAddress)
 

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/incentives-optimization/useIncentivesOptimized.ts
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/incentives-optimization/useIncentivesOptimized.ts
@@ -31,7 +31,9 @@ type PoolInfo = {
   userPrct: BigNumber
 }
 
-const PERCENT_STEP = bn(0.0001)
+// The smallest step that could be voted for is 0.01%, but in the past this has caused
+// problems with the transactions. For now, we will set the step to 1%
+const PERCENT_STEP = bn(0.01)
 
 export function useIncentivesOptimized(
   votingPools: VotingPoolWithData[],

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesTable/MyVotesTableRow.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesTable/MyVotesTableRow.tsx
@@ -41,6 +41,7 @@ import { useVebalLockInfo } from '@bal/lib/vebal/useVebalLockInfo'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { useLastUserSlope } from '../../../useVeBALBalance'
 import { Address } from 'viem'
+import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 
 interface Props extends GridProps {
   vote: VotingPoolWithData
@@ -86,13 +87,15 @@ export function MyVotesTableRow({ vote, totalVotes, keyValue, cellProps, ...rest
   const { mainnetLockedInfo } = useVebalLockInfo()
   const lockEnd = mainnetLockedInfo.lockedEndDate
   const { blacklistedVotes } = useBlacklistedVotes(votingPools)
+  const { priceFor } = useTokens()
   const rewards = calculateMyVoteRewardsValue(
     editVotesWeights[vote.id] ?? 0,
     vote,
     slope,
     lockEnd,
     totalVotes,
-    blacklistedVotes[vote.gauge.address as Address]
+    blacklistedVotes[vote.gauge.address as Address],
+    priceFor
   )
   const averageRewards = calculateMyValuePerVote(
     editVotesWeights[vote.id] ?? 0,
@@ -100,7 +103,8 @@ export function MyVotesTableRow({ vote, totalVotes, keyValue, cellProps, ...rest
     slope,
     lockEnd,
     totalVotes,
-    blacklistedVotes[vote.gauge.address as Address]
+    blacklistedVotes[vote.gauge.address as Address],
+    priceFor
   )
 
   return (

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/myVotes.helpers.ts
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/myVotes.helpers.ts
@@ -1,5 +1,5 @@
 import { oneDayInMs, startOfDayUtc, toJsTimestamp } from '@repo/lib/shared/utils/time'
-import { bn, Numberish } from '@repo/lib/shared/utils/numbers'
+import { bn, MAX_BIGNUMBER, Numberish } from '@repo/lib/shared/utils/numbers'
 import { formatDistanceToNow, millisecondsToSeconds, nextThursday } from 'date-fns'
 import { SortingBy } from './myVotes.types'
 import BigNumber from 'bignumber.js'
@@ -81,16 +81,12 @@ export function calculateMyVoteRewardsValue(
   const newPoolVoteCount = bn(poolVoteCount).minus(currentUserVotes).plus(newUserVotes)
   const maxValuePerVote = incentiveTokenPrice.times(incentivesInfo.maxTokensPerVote)
   const expectedValuePerVote = bn(totalIncentives).div(newPoolVoteCount)
-  const valuePerVote = BigNumber.min(maxValuePerVote, expectedValuePerVote)
+  const valuePerVote = BigNumber.min(
+    maxValuePerVote.isZero() ? MAX_BIGNUMBER : maxValuePerVote,
+    expectedValuePerVote
+  )
 
   const rewardInUSD = valuePerVote.times(newUserVotes)
-
-  if (votingPool.gauge.address === '0x0312aa8d0ba4a1969fddb382235870bf55f7f242') {
-    console.log({
-      maxValuePerVote: maxValuePerVote.toString(),
-      expectedValuePerVote: expectedValuePerVote.toString(),
-    })
-  }
 
   return rewardInUSD
 }

--- a/packages/lib/modules/web3/useTokenAllowances.integration.spec.ts
+++ b/packages/lib/modules/web3/useTokenAllowances.integration.spec.ts
@@ -36,9 +36,7 @@ test('allows refetching allowances', async () => {
 
   await waitFor(() => expect(result.current.isAllowancesLoading).toBeFalsy())
 
-  act(() => {
-    result.current.refetchAllowances()
-  })
+  await act(() => result.current.refetchAllowances())
 
   expect(result.current.isAllowancesRefetching).toBeTruthy()
   await waitFor(() => expect(result.current.isAllowancesRefetching).toBeFalsy())

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -16,6 +16,7 @@ BigInt.prototype.toJSON = function () {
 }
 
 export const MAX_BIGINT = BigInt(MAX_UINT256)
+export const MAX_BIGNUMBER = bn(MAX_UINT256)
 
 export const INTEGER_FORMAT = '0,0'
 export const FIAT_FORMAT_A = '0,0.00a'

--- a/packages/lib/test/utils/custom-renderers.tsx
+++ b/packages/lib/test/utils/custom-renderers.tsx
@@ -66,8 +66,8 @@ function GlobalProviders({ children }: PropsWithChildren) {
   const defaultRouterOptions = {}
 
   return (
-    <WagmiProvider config={testWagmiConfig} reconnectOnMount={false}>
-      <QueryClientProvider client={testQueryClient}>
+    <QueryClientProvider client={testQueryClient()}>
+      <WagmiProvider config={testWagmiConfig} reconnectOnMount={false}>
         <AppRouterContextProviderMock router={defaultRouterOptions}>
           <ApolloProvider client={apolloTestClient}>
             <UserAccountProvider>
@@ -89,8 +89,8 @@ function GlobalProviders({ children }: PropsWithChildren) {
             </UserAccountProvider>
           </ApolloProvider>
         </AppRouterContextProviderMock>
-      </QueryClientProvider>
-    </WagmiProvider>
+      </WagmiProvider>
+    </QueryClientProvider>
   )
 }
 

--- a/packages/lib/test/utils/react-query.ts
+++ b/packages/lib/test/utils/react-query.ts
@@ -1,26 +1,27 @@
 import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query'
 
-export const testQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      // Prevent vitest from garbage collecting cache
-      gcTime: Infinity,
+export const testQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        // Prevent vitest from garbage collecting cache
+        gcTime: Infinity,
 
-      // Turn off retries to prevent timeouts
-      retry: false,
+        // Turn off retries to prevent timeouts
+        retry: false,
+      },
     },
-  },
-  queryCache: new QueryCache({
-    onError: e => {
-      console.error('Error in query:', e)
-    },
-  }),
-  mutationCache: new MutationCache({
-    onError: e => {
-      console.error('Error in mutation:', e)
-    },
-  }),
-})
+    queryCache: new QueryCache({
+      onError: e => {
+        console.error('Error in query:', e)
+      },
+    }),
+    mutationCache: new MutationCache({
+      onError: e => {
+        console.error('Error in mutation:', e)
+      },
+    }),
+  })
 
 export function aSuccessfulQueryResultMock() {
   return {


### PR DESCRIPTION
- Some HH incentives have a token cap per vote that makes the incentive per vote not as high as `total_incentives / votes`.
- Changed the optimization step to 1% as Xeonus mentioned that smaller amounts (we were using 0.01%) can cause transaction problems.