### PR TITLE
refactor: make onTransactionChange required

### DIFF
--- a/apps/beets-frontend-v3/lib/modules/reliquary/hooks/useApproveRelayerRelicsStep.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/hooks/useApproveRelayerRelicsStep.tsx
@@ -2,10 +2,11 @@ import { SupportedChainId } from '@repo/lib/config/config.types'
 import { getNetworkConfig } from '@repo/lib/config/app.config'
 import { useHasApprovedRelayerForAllRelics } from './useHasApprovedRelayerForAllRelics'
 import { sentryMetaForWagmiSimulation } from '@repo/lib/shared/utils/query-errors'
-import { useMemo } from 'react'
+import { useState } from 'react'
 import {
   TransactionStep,
   TransactionLabels,
+  ManagedResult,
 } from '@repo/lib/modules/transactions/transaction-steps/lib'
 import { ManagedTransactionButton } from '@repo/lib/modules/transactions/transaction-steps/TransactionButton'
 import { ManagedTransactionInput } from '@repo/lib/modules/web3/contracts/useManagedTransaction'
@@ -18,6 +19,8 @@ export function useApproveRelayerRelicsStep(chainId: SupportedChainId): {
   step: TransactionStep
 } {
   const { userAddress, isConnected } = useUserAccount()
+  const [, setTransaction] = useState<ManagedResult | undefined>()
+
   const config = getNetworkConfig(chainId)
 
   const relayerAddress = config.contracts.balancer.relayerV6
@@ -54,20 +57,17 @@ export function useApproveRelayerRelicsStep(chainId: SupportedChainId): {
     args: [relayerAddress, true],
     enabled: !!userAddress && !isLoading,
     txSimulationMeta,
+    onTransactionChange: setTransaction,
   }
 
-  const step = useMemo(
-    (): TransactionStep => ({
-      id: approveRelayerRelicsStepId,
-      stepType: 'approveBatchRelayerForAllRelics',
-      labels,
-      isComplete: () => isConnected && hasApprovedRelayerForAllRelics,
-      renderAction: () => <ManagedTransactionButton id={approveRelayerRelicsStepId} {...props} />,
-      onSuccess: () => refetch(),
-    }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hasApprovedRelayerForAllRelics, isConnected, isLoading]
-  )
+  const step: TransactionStep = {
+    id: approveRelayerRelicsStepId,
+    stepType: 'approveBatchRelayerForAllRelics',
+    labels,
+    isComplete: () => isConnected && hasApprovedRelayerForAllRelics,
+    renderAction: () => <ManagedTransactionButton id={approveRelayerRelicsStepId} {...props} />,
+    onSuccess: () => refetch(),
+  }
 
   return {
     isLoading,

--- a/apps/frontend-v3/app/(app)/debug/remove-allowance/page.tsx
+++ b/apps/frontend-v3/app/(app)/debug/remove-allowance/page.tsx
@@ -31,6 +31,7 @@ export default function Page() {
     simulationMeta: sentryMetaForWagmiSimulation('Error in wagmi tx simulation: Approving token', {
       tokenAmountToApprove: 0n,
     }),
+    onTransactionChange: () => {},
   }
 
   const transaction = useManagedErc20Transaction(props)

--- a/apps/frontend-v3/app/(app)/debug/revoke-relayer-approval/page.tsx
+++ b/apps/frontend-v3/app/(app)/debug/revoke-relayer-approval/page.tsx
@@ -35,6 +35,7 @@ export default function Page() {
     args: [userAddress, relayerAddress, false],
     enabled: !!userAddress,
     txSimulationMeta: {},
+    onTransactionChange: () => {},
   }
 
   const transaction = useManagedTransaction(props)

--- a/packages/lib/modules/tokens/approvals/permit2/usePermit2ApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/permit2/usePermit2ApprovalSteps.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import { useMemo } from 'react'
 import { getChainId, getNativeAssetAddress, getNetworkConfig } from '@repo/lib/config/app.config'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
@@ -98,66 +97,64 @@ export function usePermit2ApprovalSteps({
     skipAllowanceCheck: isUnwrappingNative,
   })
 
-  const steps = useMemo(() => {
-    return tokenAmountsToApprove.map(tokenAmountToApprove => {
-      const {
-        tokenAddress,
-        requiredRawAmount,
-        requestedRawAmount,
-        symbol: approvalSymbol,
-      } = tokenAmountToApprove
+  const steps: TransactionStep[] = tokenAmountsToApprove.map(tokenAmountToApprove => {
+    const {
+      tokenAddress,
+      requiredRawAmount,
+      requestedRawAmount,
+      symbol: approvalSymbol,
+    } = tokenAmountToApprove
 
-      const id = tokenAddress + '-permit2Approval' // To avoid key collisions with default token approvals
-      const token = getToken(tokenAddress, chain)
-      const amountToApprove = getMaxAmountForPermit2(requestedRawAmount)
-      // Compute symbol using first defined value
-      const symbol =
-        approvalSymbol && approvalSymbol !== 'Unknown'
-          ? approvalSymbol
-          : bptSymbol || token?.symbol || 'Unknown'
+    const id = tokenAddress + '-permit2Approval' // To avoid key collisions with default token approvals
+    const token = getToken(tokenAddress, chain)
+    const amountToApprove = getMaxAmountForPermit2(requestedRawAmount)
+    // Compute symbol using first defined value
+    const symbol =
+      approvalSymbol && approvalSymbol !== 'Unknown'
+        ? approvalSymbol
+        : bptSymbol || token?.symbol || 'Unknown'
 
-      const labels = buildTokenApprovalLabels({
-        actionType,
-        symbol,
-        lpToken,
-      })
-
-      // Check if the token has been approved
-      const isComplete = () => {
-        const isNotExpired = !!expirations && expirations[tokenAddress] > getNowTimestampInSecs()
-        const isAllowed = allowanceFor(tokenAddress) >= amountToApprove
-        return requiredRawAmount > 0n && isAllowed && isNotExpired
-      }
-
-      const isTxEnabled = !isLoadingPermit2Allowances && !!permit2Address
-      const props: ManagedTransactionInput = {
-        contractAddress: permit2Address || '',
-        contractId: 'permit2',
-        functionName: 'approve',
-        labels,
-        chainId,
-        args: [tokenAddress, spenderAddress, amountToApprove, permitExpiry],
-        enabled: isTxEnabled,
-        txSimulationMeta: sentryMetaForWagmiSimulation(
-          'Error in wagmi tx simulation: Approving token',
-          tokenAmountToApprove
-        ),
-        onTransactionChange: () => setTransactionFn(id),
-      }
-
-      const args = props.args as Permit2ApproveArgs
-
-      return {
-        id,
-        stepType: 'tokenApproval',
-        labels,
-        isComplete,
-        renderAction: () => <ManagedTransactionButton id={id} key={id} {...props} />,
-        batchableTxCall: isTxEnabled ? buildBatchableTxCall({ permit2Address, args }) : undefined,
-        onSuccess: () => refetchPermit2Allowances(),
-      } as const satisfies TransactionStep
+    const labels = buildTokenApprovalLabels({
+      actionType,
+      symbol,
+      lpToken,
     })
-  }, [tokenAmountsToApprove, chain, isLoadingPermit2Allowances, userAddress, setTransactionFn])
+
+    // Check if the token has been approved
+    const isComplete = () => {
+      const isNotExpired = !!expirations && expirations[tokenAddress] > getNowTimestampInSecs()
+      const isAllowed = allowanceFor(tokenAddress) >= amountToApprove
+      return requiredRawAmount > 0n && isAllowed && isNotExpired
+    }
+
+    const isTxEnabled = !isLoadingPermit2Allowances && !!permit2Address
+    const props: ManagedTransactionInput = {
+      contractAddress: permit2Address || '',
+      contractId: 'permit2',
+      functionName: 'approve',
+      labels,
+      chainId,
+      args: [tokenAddress, spenderAddress, amountToApprove, permitExpiry],
+      enabled: isTxEnabled,
+      txSimulationMeta: sentryMetaForWagmiSimulation(
+        'Error in wagmi tx simulation: Approving token',
+        tokenAmountToApprove
+      ),
+      onTransactionChange: () => setTransactionFn(id),
+    }
+
+    const args = props.args as Permit2ApproveArgs
+
+    return {
+      id,
+      stepType: 'tokenApproval',
+      labels,
+      isComplete,
+      renderAction: () => <ManagedTransactionButton id={id} key={id} {...props} />,
+      batchableTxCall: isTxEnabled ? buildBatchableTxCall({ permit2Address, args }) : undefined,
+      onSuccess: () => refetchPermit2Allowances(),
+    } as const satisfies TransactionStep
+  })
 
   return {
     isLoading: isLoadingPermit2Allowances,

--- a/packages/lib/modules/tokens/approvals/permit2/usePermit2ApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/permit2/usePermit2ApprovalSteps.tsx
@@ -16,6 +16,7 @@ import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { getMaxAmountForPermit2 } from './permit2.helpers'
 import { Address, encodeFunctionData } from 'viem'
 import { permit2Abi } from '@balancer/sdk'
+import { useStepsTransactionState } from '@repo/lib/modules/transactions/transaction-steps/useStepsTransactionState'
 
 export type Params = {
   chain: GqlChain
@@ -53,6 +54,8 @@ export function usePermit2ApprovalSteps({
   shouldUseCompositeLiquidityRouterBoosted = false,
 }: Params): { isLoading: boolean; steps: TransactionStep[] } {
   const { userAddress } = useUserAccount()
+  const { setTransactionFn } = useStepsTransactionState()
+
   const { getToken } = useTokens()
 
   // Precompute common values
@@ -139,6 +142,7 @@ export function usePermit2ApprovalSteps({
           'Error in wagmi tx simulation: Approving token',
           tokenAmountToApprove
         ),
+        onTransactionChange: () => setTransactionFn(id),
       }
 
       const args = props.args as Permit2ApproveArgs
@@ -153,7 +157,7 @@ export function usePermit2ApprovalSteps({
         onSuccess: () => refetchPermit2Allowances(),
       } as const satisfies TransactionStep
     })
-  }, [tokenAmountsToApprove, chain, isLoadingPermit2Allowances, userAddress])
+  }, [tokenAmountsToApprove, chain, isLoadingPermit2Allowances, userAddress, setTransactionFn])
 
   return {
     isLoading: isLoadingPermit2Allowances,

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -20,6 +20,7 @@ import {
 } from './approval-rules'
 import { isVeBalBtpAddress, requiresDoubleApproval } from '../token.helpers'
 import { ErrorWithCauses } from '@repo/lib/shared/utils/errors'
+import { useStepsTransactionState } from '@repo/lib/modules/transactions/transaction-steps/useStepsTransactionState'
 
 export type Params = {
   spenderAddress: Address
@@ -48,6 +49,8 @@ export function useTokenApprovalSteps({
   wethIsEth,
 }: Params): { isLoading: boolean; steps: TransactionStep[] } {
   const { userAddress } = useUserAccount()
+  const { setTransactionFn } = useStepsTransactionState()
+
   const { getToken } = useTokens()
   const nativeAssetAddress = getNativeAssetAddress(chain)
 
@@ -161,6 +164,7 @@ export function useTokenApprovalSteps({
           'Error in wagmi tx simulation: Approving token',
           tokenAmountToApprove
         ),
+        onTransactionChange: () => setTransactionFn(id),
       }
 
       const args = props.args as [Address, bigint]
@@ -182,7 +186,7 @@ export function useTokenApprovalSteps({
         },
       } as const satisfies TransactionStep
     })
-  }, [tokenAllowances.allowances, userAddress, tokenAmountsToApprove])
+  }, [tokenAllowances.allowances, userAddress, tokenAmountsToApprove, setTransactionFn])
 
   return {
     isLoading: tokenAllowances.isAllowancesLoading,

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -84,109 +84,107 @@ export function useTokenApprovalSteps({
     skipAllowanceCheck: isUnwrappingNative,
   })
 
-  const steps = useMemo(() => {
-    return tokenAmountsToApprove.map((tokenAmountToApprove, index) => {
-      const {
-        tokenAddress,
+  const steps: TransactionStep[] = tokenAmountsToApprove.map((tokenAmountToApprove, index) => {
+    const {
+      tokenAddress,
+      requiredRawAmount,
+      requestedRawAmount,
+      symbol: approvalSymbol,
+    } = tokenAmountToApprove
+    // USDT edge-case: requires setting approval to 0n before adjusting the value up again
+    const isApprovingZeroForDoubleApproval =
+      requiresDoubleApproval(chain, tokenAddress) && requiredRawAmount === 0n
+    const id = isApprovingZeroForDoubleApproval ? `${tokenAddress}-0` : tokenAddress
+
+    const token = getToken(tokenAddress, chain)
+
+    const getSymbol = () => {
+      if (approvalSymbol && approvalSymbol !== 'Unknown') return approvalSymbol
+      if (bptSymbol) return bptSymbol
+      return token?.symbol || 'Unknown'
+    }
+
+    const labels = buildTokenApprovalLabels({
+      actionType,
+      symbol: getSymbol(),
+      isPermit2,
+      lpToken,
+    })
+
+    const isComplete = (tokenAllowanceAfterRefetch?: bigint) => {
+      const tokenAllowance =
+        tokenAllowanceAfterRefetch || tokenAllowances.allowanceFor(tokenAddress)
+      const nextToken = isApprovingZeroForDoubleApproval
+        ? tokenAmountsToApprove[index + 1]
+        : undefined
+
+      return isTheApprovedAmountEnough(
+        tokenAllowance,
         requiredRawAmount,
-        requestedRawAmount,
-        symbol: approvalSymbol,
-      } = tokenAmountToApprove
-      // USDT edge-case: requires setting approval to 0n before adjusting the value up again
-      const isApprovingZeroForDoubleApproval =
-        requiresDoubleApproval(chain, tokenAddress) && requiredRawAmount === 0n
-      const id = isApprovingZeroForDoubleApproval ? `${tokenAddress}-0` : tokenAddress
+        isApprovingZeroForDoubleApproval,
+        nextToken
+      )
+    }
 
-      const token = getToken(tokenAddress, chain)
+    const checkEdgeCaseErrors = (tokenAllowance: bigint) => {
+      const errors = []
 
-      const getSymbol = () => {
-        if (approvalSymbol && approvalSymbol !== 'Unknown') return approvalSymbol
-        if (bptSymbol) return bptSymbol
-        return token?.symbol || 'Unknown'
-      }
-
-      const labels = buildTokenApprovalLabels({
-        actionType,
-        symbol: getSymbol(),
-        isPermit2,
-        lpToken,
-      })
-
-      const isComplete = (tokenAllowanceAfterRefetch?: bigint) => {
-        const tokenAllowance =
-          tokenAllowanceAfterRefetch || tokenAllowances.allowanceFor(tokenAddress)
-        const nextToken = isApprovingZeroForDoubleApproval
-          ? tokenAmountsToApprove[index + 1]
-          : undefined
-
-        return isTheApprovedAmountEnough(
+      const nextToken = isApprovingZeroForDoubleApproval
+        ? tokenAmountsToApprove[index + 1]
+        : undefined
+      if (
+        !isTheApprovedAmountEnough(
           tokenAllowance,
           requiredRawAmount,
           isApprovingZeroForDoubleApproval,
           nextToken
         )
+      ) {
+        errors.push({
+          id: 'not-enough-allowance',
+          title: 'Error on approval step',
+          description: 'The approved amount is not enough for the current transaction.',
+        })
       }
 
-      const checkEdgeCaseErrors = (tokenAllowance: bigint) => {
-        const errors = []
+      return errors
+    }
 
-        const nextToken = isApprovingZeroForDoubleApproval
-          ? tokenAmountsToApprove[index + 1]
-          : undefined
-        if (
-          !isTheApprovedAmountEnough(
-            tokenAllowance,
-            requiredRawAmount,
-            isApprovingZeroForDoubleApproval,
-            nextToken
-          )
-        ) {
-          errors.push({
-            id: 'not-enough-allowance',
-            title: 'Error on approval step',
-            description: 'The approved amount is not enough for the current transaction.',
-          })
-        }
+    const isTxEnabled = !!spenderAddress && !tokenAllowances.isAllowancesLoading
+    const props: ManagedErc20TransactionInput = {
+      tokenAddress,
+      functionName: isVeBalBtpAddress(tokenAddress) ? 'increaseApproval' : 'approve',
+      labels,
+      isComplete,
+      chainId: getChainId(chain),
+      args: [spenderAddress, requestedRawAmount],
+      enabled: isTxEnabled,
+      simulationMeta: sentryMetaForWagmiSimulation(
+        'Error in wagmi tx simulation: Approving token',
+        tokenAmountToApprove
+      ),
+      onTransactionChange: () => setTransactionFn(id),
+    }
 
-        return errors
-      }
+    const args = props.args as [Address, bigint]
 
-      const isTxEnabled = !!spenderAddress && !tokenAllowances.isAllowancesLoading
-      const props: ManagedErc20TransactionInput = {
-        tokenAddress,
-        functionName: isVeBalBtpAddress(tokenAddress) ? 'increaseApproval' : 'approve',
-        labels,
-        isComplete,
-        chainId: getChainId(chain),
-        args: [spenderAddress, requestedRawAmount],
-        enabled: isTxEnabled,
-        simulationMeta: sentryMetaForWagmiSimulation(
-          'Error in wagmi tx simulation: Approving token',
-          tokenAmountToApprove
-        ),
-        onTransactionChange: () => setTransactionFn(id),
-      }
-
-      const args = props.args as [Address, bigint]
-
-      return {
-        id,
-        stepType: 'tokenApproval',
-        labels,
-        isComplete,
-        renderAction: () => <ManagedErc20TransactionButton id={id} key={id} {...props} />,
-        batchableTxCall: isTxEnabled ? buildBatchableTxCall({ tokenAddress, args }) : undefined,
-        onSuccess: async () => {
-          const newAllowances = await tokenAllowances.refetchAllowances()
-          // Ignore check if allowances are refetching
-          if (newAllowances.isRefetching) return
-          const updatedTokenAllowance = newAllowances.allowanceFor(tokenAddress)
-          const errors = checkEdgeCaseErrors(updatedTokenAllowance)
-          if (errors.length > 0) throw new ErrorWithCauses('Edge case errors', errors)
-        },
-      } as const satisfies TransactionStep
-    })
-  }, [tokenAllowances.allowances, userAddress, tokenAmountsToApprove, setTransactionFn])
+    return {
+      id,
+      stepType: 'tokenApproval',
+      labels,
+      isComplete,
+      renderAction: () => <ManagedErc20TransactionButton id={id} key={id} {...props} />,
+      batchableTxCall: isTxEnabled ? buildBatchableTxCall({ tokenAddress, args }) : undefined,
+      onSuccess: async () => {
+        const newAllowances = await tokenAllowances.refetchAllowances()
+        // Ignore check if allowances are refetching
+        if (newAllowances.isRefetching) return
+        const updatedTokenAllowance = newAllowances.allowanceFor(tokenAddress)
+        const errors = checkEdgeCaseErrors(updatedTokenAllowance)
+        if (errors.length > 0) throw new ErrorWithCauses('Edge case errors', errors)
+      },
+    } as const satisfies TransactionStep
+  })
 
   return {
     isLoading: tokenAllowances.isAllowancesLoading,

--- a/packages/lib/modules/transactions/transaction-steps/TransactionButton.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/TransactionButton.tsx
@@ -57,11 +57,6 @@ export function ManagedErc20TransactionButton({
   const { updateTransaction } = useTransactionState()
 
   useEffect(() => {
-    console.log({
-      onTransactionChange: params.onTransactionChange,
-      id,
-      functionName: params.functionName,
-    })
     params.onTransactionChange(transaction)
     // TODO(transaction-refactor): remove updateTransaction once TransactionStateProvider is removed
     updateTransaction(id, transaction)

--- a/packages/lib/modules/transactions/transaction-steps/TransactionButton.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/TransactionButton.tsx
@@ -25,8 +25,8 @@ export function ManagedTransactionButton({
   const { updateTransaction } = useTransactionState()
 
   useEffect(() => {
-    if (params.onTransactionChange) params.onTransactionChange(transaction)
-    // TODO(transaction-refactor): remove if and updateTransaction once all steps are migrated to use onTransactionChange
+    params.onTransactionChange(transaction)
+    // TODO(transaction-refactor): remove updateTransaction once TransactionStateProvider is removed
     updateTransaction(id, transaction)
   }, [id, transaction.execution.status, transaction.simulation.status, transaction.result.status])
 
@@ -41,8 +41,8 @@ export function ManagedSendTransactionButton({
   const { updateTransaction } = useTransactionState()
 
   useEffect(() => {
-    // TODO(transaction-refactor): remove if and updateTransaction once all steps are migrated to use onTransactionChange    if (params.onTransactionChange) params.onTransactionChange(transaction)
-    if (params.onTransactionChange) params.onTransactionChange(transaction)
+    params.onTransactionChange(transaction)
+    // TODO(transaction-refactor): remove updateTransaction once TransactionStateProvider is removed
     updateTransaction(id, transaction)
   }, [id, transaction.execution.status, transaction.simulation.status, transaction.result.status])
 
@@ -57,8 +57,13 @@ export function ManagedErc20TransactionButton({
   const { updateTransaction } = useTransactionState()
 
   useEffect(() => {
-    // TODO(transaction-refactor): remove if and updateTransaction once all steps are migrated to use onTransactionChange
-    if (params.onTransactionChange) params.onTransactionChange(transaction)
+    console.log({
+      onTransactionChange: params.onTransactionChange,
+      id,
+      functionName: params.functionName,
+    })
+    params.onTransactionChange(transaction)
+    // TODO(transaction-refactor): remove updateTransaction once TransactionStateProvider is removed
     updateTransaction(id, transaction)
   }, [id, transaction.execution.status, transaction.simulation.status, transaction.result.status])
 

--- a/packages/lib/modules/web3/contracts/useManagedErc20Transaction.integration.spec.ts
+++ b/packages/lib/modules/web3/contracts/useManagedErc20Transaction.integration.spec.ts
@@ -23,6 +23,7 @@ test('token approval transaction (wETH)', async () => {
       enabled: true,
       simulationMeta: {},
       labels: {} as TransactionLabels,
+      onTransactionChange: () => {},
     })
   )
 

--- a/packages/lib/modules/web3/contracts/useManagedErc20Transaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedErc20Transaction.ts
@@ -31,8 +31,7 @@ export interface ManagedErc20TransactionInput {
     | 'increaseApproval' // Edge-case for veBalBpt approval
   labels: TransactionLabels
   isComplete?: () => boolean
-  // TODO(transaction-refactor): make it non-optional once all steps are migrated to use onTransactionChange
-  onTransactionChange?: (transaction: ManagedResult) => void
+  onTransactionChange: (transaction: ManagedResult) => void
   chainId: SupportedChainId
   args?: ContractFunctionArgs<Erc20AbiWithIncreaseApproval, WriteAbiMutability> | null
   enabled: boolean

--- a/packages/lib/modules/web3/contracts/useManagedSendTransaction.integration.spec.ts
+++ b/packages/lib/modules/web3/contracts/useManagedSendTransaction.integration.spec.ts
@@ -56,6 +56,7 @@ describe('weighted add flow', () => {
       return useManagedSendTransaction({
         labels: { init: 'foo', tooltip: 'bar' },
         txConfig,
+        onTransactionChange: () => {},
       })
     })
 

--- a/packages/lib/modules/web3/contracts/useManagedSendTransaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedSendTransaction.ts
@@ -26,8 +26,7 @@ export type ManagedSendTransactionInput = {
   labels: TransactionLabels
   txConfig: TransactionConfig
   gasEstimationMeta?: Record<string, unknown>
-  // TODO(transaction-refactor): make it non-optional once all steps are migrated to use onTransactionChange
-  onTransactionChange?: (transaction: ManagedResult) => void
+  onTransactionChange: (transaction: ManagedResult) => void
 }
 
 export function useManagedSendTransaction({

--- a/packages/lib/modules/web3/contracts/useManagedTransaction.ts
+++ b/packages/lib/modules/web3/contracts/useManagedTransaction.ts
@@ -39,8 +39,7 @@ export interface ManagedTransactionInput {
   txSimulationMeta?: Record<string, unknown>
   enabled: boolean
   value?: bigint
-  // TODO(transaction-refactor): make it non-optional once all steps are migrated to use onTransactionChange
-  onTransactionChange?: (transaction: ManagedResult) => void
+  onTransactionChange: (transaction: ManagedResult) => void
 }
 
 export function useManagedTransaction({


### PR DESCRIPTION
Last transaction refactor before being able to remove `TransactionStateProvider`.

- Refactors the remaining step hooks to the new transaction system
- Makes `onTransactionChange` prop mandatory in the 3 core transaction hooks (managed, managedErc20 and managedSend)
- Removes useMemo in hooks iterating multiple steps to avoid useMemo dependency issues due to transaction state changes. 