### PR TITLE
Add approval step when creating lock

### DIFF
--- a/apps/frontend-v3/lib/vebal/lock/steps/useLockSteps.tsx
+++ b/apps/frontend-v3/lib/vebal/lock/steps/useLockSteps.tsx
@@ -56,7 +56,10 @@ export function useLockSteps({
       .map(lockActionType => lockSteps.find(lockStep => lockStep.stepType === lockActionType))
       .filter(Boolean) as TransactionStep[]
 
-    if (!lockActionTypes.includes(LockActionType.IncreaseLock)) {
+    if (
+      !lockActionTypes.includes(LockActionType.CreateLock) &&
+      !lockActionTypes.includes(LockActionType.IncreaseLock)
+    ) {
       // Avoid token approvals when extending lock date without increasing amount
       return [...selectedLockSteps]
     }


### PR DESCRIPTION
When removing the approvals for extending locks without increasing the amount on https://github.com/balancer/frontend-monorepo/pull/1087, a bug was introduced that does not allow to create new locks.