### PR TITLE
refactor: move onSuccess tx handling to global provider

### DIFF
--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -6,7 +6,7 @@ import { sentryMetaForWagmiSimulation } from '@repo/lib/shared/utils/query-error
 import { useMemo } from 'react'
 import { Address, encodeFunctionData, erc20Abi } from 'viem'
 import { ManagedErc20TransactionButton } from '../../transactions/transaction-steps/TransactionButton'
-import { TransactionStep, TxCall } from '../../transactions/transaction-steps/lib'
+import { RetryOnSuccess, TransactionStep, TxCall } from '../../transactions/transaction-steps/lib'
 import { ManagedErc20TransactionInput } from '../../web3/contracts/useManagedErc20Transaction'
 import { useTokenAllowances } from '../../web3/useTokenAllowances'
 import { useUserAccount } from '../../web3/UserAccountProvider'
@@ -178,7 +178,7 @@ export function useTokenApprovalSteps({
       onSuccess: async () => {
         const newAllowances = await tokenAllowances.refetchAllowances()
         // Ignore check if allowances are refetching
-        if (newAllowances.isRefetching) return
+        if (newAllowances.isRefetching) return RetryOnSuccess
         const updatedTokenAllowance = newAllowances.allowanceFor(tokenAddress)
         const errors = checkEdgeCaseErrors(updatedTokenAllowance)
         if (errors.length > 0) throw new ErrorWithCauses('Edge case errors', errors)

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -177,7 +177,7 @@ export function useTokenApprovalSteps({
       batchableTxCall: isTxEnabled ? buildBatchableTxCall({ tokenAddress, args }) : undefined,
       onSuccess: async () => {
         const newAllowances = await tokenAllowances.refetchAllowances()
-        // Ignore check if allowances are refetching
+        // Ignore check and retry while allowances are refetching
         if (newAllowances.isRefetching) return RetryOnSuccess
         const updatedTokenAllowance = newAllowances.allowanceFor(tokenAddress)
         const errors = checkEdgeCaseErrors(updatedTokenAllowance)

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -6,7 +6,7 @@ import { sentryMetaForWagmiSimulation } from '@repo/lib/shared/utils/query-error
 import { useMemo } from 'react'
 import { Address, encodeFunctionData, erc20Abi } from 'viem'
 import { ManagedErc20TransactionButton } from '../../transactions/transaction-steps/TransactionButton'
-import { RetryOnSuccess, TransactionStep, TxCall } from '../../transactions/transaction-steps/lib'
+import { Retry, TransactionStep, TxCall } from '../../transactions/transaction-steps/lib'
 import { ManagedErc20TransactionInput } from '../../web3/contracts/useManagedErc20Transaction'
 import { useTokenAllowances } from '../../web3/useTokenAllowances'
 import { useUserAccount } from '../../web3/UserAccountProvider'
@@ -178,7 +178,7 @@ export function useTokenApprovalSteps({
       onSuccess: async () => {
         const newAllowances = await tokenAllowances.refetchAllowances()
         // Ignore check and retry while allowances are refetching
-        if (newAllowances.isRefetching) return RetryOnSuccess
+        if (newAllowances.isRefetching) return Retry
         const updatedTokenAllowance = newAllowances.allowanceFor(tokenAddress)
         const errors = checkEdgeCaseErrors(updatedTokenAllowance)
         if (errors.length > 0) throw new ErrorWithCauses('Edge case errors', errors)

--- a/packages/lib/modules/transactions/transaction-steps/lib.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/lib.tsx
@@ -134,7 +134,7 @@ type TransactionInput =
   | ManagedSendTransactionInput
 
 // In some cases, the onSuccess callback must be retried, for instance, when the refetchApprovals has not finished yet
-export const RetryOnSuccess = 'retry'
+export const Retry = 'retry'
 
 export type TransactionStep = {
   id: string
@@ -145,7 +145,7 @@ export type TransactionStep = {
   isComplete: () => boolean
   renderAction: () => ReactNode
   // All callbacks should be idempotent
-  onSuccess?: () => any | typeof RetryOnSuccess
+  onSuccess?: () => any | typeof Retry
   onActivated?: () => void
   onDeactivated?: () => void
   // only used for integration testing

--- a/packages/lib/modules/transactions/transaction-steps/lib.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/lib.tsx
@@ -133,6 +133,9 @@ type TransactionInput =
   | ManagedErc20TransactionInput
   | ManagedSendTransactionInput
 
+// In some cases, the onSuccess callback must be retried, for instance, when the refetchApprovals has not finished yet
+export const RetryOnSuccess = 'retry'
+
 export type TransactionStep = {
   id: string
   stepType: StepType
@@ -142,7 +145,7 @@ export type TransactionStep = {
   isComplete: () => boolean
   renderAction: () => ReactNode
   // All callbacks should be idempotent
-  onSuccess?: () => any
+  onSuccess?: () => any | typeof RetryOnSuccess
   onActivated?: () => void
   onDeactivated?: () => void
   // only used for integration testing

--- a/packages/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { getTransactionState, RetryOnSuccess, TransactionState, TransactionStep } from './lib'
+import { getTransactionState, Retry, TransactionState, TransactionStep } from './lib'
 import { useTxSound } from './useTxSound'
 import { ensureError, ErrorCause, ErrorWithCauses } from '@repo/lib/shared/utils/errors'
 import { useToast } from '@chakra-ui/react'
@@ -51,7 +51,7 @@ export function useTransactionSteps(steps: TransactionStep[] = [], isLoading = f
     async function handleTransactionCompletion() {
       try {
         const onSuccessResult = await currentStep?.onSuccess?.()
-        if (onSuccessResult !== RetryOnSuccess) {
+        if (onSuccessResult !== Retry) {
           updateOnSuccessCalled(currentStep, true)
         }
       } catch (e) {

--- a/packages/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
@@ -2,27 +2,19 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { getTransactionState, TransactionState, TransactionStep } from './lib'
+import { getTransactionState, RetryOnSuccess, TransactionState, TransactionStep } from './lib'
 import { useTxSound } from './useTxSound'
 import { ensureError, ErrorCause, ErrorWithCauses } from '@repo/lib/shared/utils/errors'
 import { useToast } from '@chakra-ui/react'
 import { resetTransaction } from './transaction.helper'
 import { showErrorAsToast } from '@repo/lib/shared/components/toasts/toast.helper'
+import { useTransactionState } from '@repo/lib/modules/transactions/transaction-steps/TransactionStateProvider'
 
 export type TransactionStepsResponse = ReturnType<typeof useTransactionSteps>
 
 export function useTransactionSteps(steps: TransactionStep[] = [], isLoading = false) {
   const [currentStepIndex, setCurrentStepIndex] = useState<number>(0)
-  const [onSuccessCalled, setOnSuccessCalled] = useState<{ [stepId: string]: boolean }>({})
-
-  const updateOnSuccessCalled = (stepId: string, value: boolean) => {
-    setOnSuccessCalled(prevState => ({
-      ...prevState,
-      [stepId]: value,
-    }))
-  }
-
-  const isOnSuccessCalled = (stepId: string) => !!onSuccessCalled[stepId]
+  const { isOnSuccessCalled, updateOnSuccessCalled, setOnSuccessCalled } = useTransactionState()
 
   const { playTxSound } = useTxSound()
 
@@ -58,8 +50,10 @@ export function useTransactionSteps(steps: TransactionStep[] = [], isLoading = f
     if (!currentStep) return
     async function handleTransactionCompletion() {
       try {
-        await currentStep?.onSuccess?.()
-        updateOnSuccessCalled(currentStep.id, true)
+        const onSuccessResult = await currentStep?.onSuccess?.()
+        if (onSuccessResult !== RetryOnSuccess) {
+          updateOnSuccessCalled(currentStep, true)
+        }
       } catch (e) {
         const error = ensureError(e)
         if (error instanceof ErrorWithCauses) {
@@ -73,7 +67,7 @@ export function useTransactionSteps(steps: TransactionStep[] = [], isLoading = f
         if (currentTransaction) resetTransaction(currentTransaction)
       }
     }
-    if (!isOnSuccessCalled(currentStep.id) && currentTransaction?.result.isSuccess) {
+    if (!isOnSuccessCalled(currentStep) && currentTransaction?.result.isSuccess) {
       handleTransactionCompletion()
     }
   }, [currentTransaction?.result.isSuccess, currentStep?.onSuccess])


### PR DESCRIPTION
After the previous trasaction handling refactors, TransactionStateProvider was not needed anymore but I reused it to globally handle the "onSuccess" state by step txhash. This will prevent unnecessary refetch calls (that we were sometimes avoiding with useMemos and useCallbacks that will become now unnecessary).