### PR TITLE
fix: update app nav links for beets

### DIFF
--- a/packages/lib/config/projects/beets.ts
+++ b/packages/lib/config/projects/beets.ts
@@ -48,11 +48,6 @@ export const ProjectConfigBeets: ProjectConfig = {
         label: 'maBEETS',
         isExternal: true,
       },
-      {
-        href: 'https://www.spoints.fyi/gems',
-        label: 'Sonic Gems',
-        isExternal: true,
-      },
     ],
     ecosystemLinks: [
       { label: 'Docs', href: 'https://docs.beets.fi/' },


### PR DESCRIPTION
- remove 'sonic gems' app nav link