### PR TITLE
[LBP] patch:  form reset to initial values

### DIFF
--- a/packages/lib/modules/lbp/LbpFormProvider.tsx
+++ b/packages/lib/modules/lbp/LbpFormProvider.tsx
@@ -67,6 +67,11 @@ export function useLbpFormLogic() {
   const isFirstStep = activeStepIndex === 0
   const activeStep = steps[activeStepIndex]
 
+  const resetConfigSteps = () => {
+    setPersistedStepIndex(0)
+    setActiveStep(0)
+  }
+
   useEffect(() => {
     setPersistedStepIndex(activeStepIndex)
   }, [activeStepIndex, setPersistedStepIndex])
@@ -110,6 +115,7 @@ export function useLbpFormLogic() {
     fdvMarketCap,
     updatePriceStats,
     launchTokenSeed,
+    resetConfigSteps,
   }
 }
 

--- a/packages/lib/modules/lbp/LbpFormProvider.tsx
+++ b/packages/lib/modules/lbp/LbpFormProvider.tsx
@@ -11,6 +11,7 @@ import { useLocalStorage } from 'usehooks-ts'
 import { useEffect, useState } from 'react'
 import { useTokenMetadata } from '../tokens/useTokenMetadata'
 import { fNum } from '@repo/lib/shared/utils/numbers'
+import { Address } from 'viem'
 
 export type UseLbpFormResult = ReturnType<typeof useLbpFormLogic>
 export const LbpFormContext = createContext<UseLbpFormResult | null>(null)
@@ -67,14 +68,24 @@ export function useLbpFormLogic() {
   const isFirstStep = activeStepIndex === 0
   const activeStep = steps[activeStepIndex]
 
-  const resetConfigSteps = () => {
-    setPersistedStepIndex(0)
-    setActiveStep(0)
-  }
-
   useEffect(() => {
     setPersistedStepIndex(activeStepIndex)
   }, [activeStepIndex, setPersistedStepIndex])
+
+  const [, setPoolAddress] = useLocalStorage<Address | undefined>(
+    LS_KEYS.LbpConfig.PoolAddress,
+    undefined
+  )
+  const [, setIsMetadataSent] = useLocalStorage<boolean>(LS_KEYS.LbpConfig.IsMetadataSent, false)
+
+  const resetLbpCreation = () => {
+    saleStructureForm.resetToInitial()
+    projectInfoForm.resetToInitial()
+    setPersistedStepIndex(0)
+    setActiveStep(0)
+    setPoolAddress(undefined)
+    setIsMetadataSent(false)
+  }
 
   const { saleTokenAmount, launchTokenAddress, selectedChain } = saleStructureForm.watch()
 
@@ -115,7 +126,7 @@ export function useLbpFormLogic() {
     fdvMarketCap,
     updatePriceStats,
     launchTokenSeed,
-    resetConfigSteps,
+    resetLbpCreation,
   }
 }
 

--- a/packages/lib/modules/lbp/modal/LbpCreationModal.tsx
+++ b/packages/lib/modules/lbp/modal/LbpCreationModal.tsx
@@ -32,28 +32,18 @@ export function LbpCreationModal({
 }: Props & Omit<ModalProps, 'children'>) {
   const initialFocusRef = useRef(null)
   const { isDesktop } = useBreakpoints()
-  const {
-    saleStructureForm,
-    projectInfoForm,
-    isLastStep: isLastConfigStep,
-    resetConfigSteps,
-  } = useLbpForm()
+  const { saleStructureForm, isLastStep: isLastConfigStep, resetLbpCreation } = useLbpForm()
   const { selectedChain } = saleStructureForm.getValues()
   const { transactionSteps, initLbpTxHash, urlTxHash, previewModalDisclosure } = useLbpCreation()
 
-  const [poolAddress, setPoolAddress] = useLocalStorage<Address | undefined>(
+  const [poolAddress] = useLocalStorage<Address | undefined>(
     LS_KEYS.LbpConfig.PoolAddress,
     undefined
   )
-  const [, setIsMetadataSent] = useLocalStorage<boolean>(LS_KEYS.LbpConfig.IsMetadataSent, false)
 
-  const handleReset = async () => {
-    saleStructureForm.resetToInitial()
-    projectInfoForm.resetToInitial()
-    resetConfigSteps()
+  const handleReset = () => {
+    resetLbpCreation()
     transactionSteps.resetTransactionSteps()
-    setPoolAddress(undefined)
-    setIsMetadataSent(false)
     onClose()
   }
 

--- a/packages/lib/modules/lbp/modal/LbpCreationModal.tsx
+++ b/packages/lib/modules/lbp/modal/LbpCreationModal.tsx
@@ -35,25 +35,25 @@ export function LbpCreationModal({
   const {
     saleStructureForm,
     projectInfoForm,
-    setActiveStep,
     isLastStep: isLastConfigStep,
+    resetConfigSteps,
   } = useLbpForm()
   const { selectedChain } = saleStructureForm.getValues()
   const { transactionSteps, initLbpTxHash, urlTxHash, previewModalDisclosure } = useLbpCreation()
 
-  const [, setStepIndex] = useLocalStorage(LS_KEYS.LbpConfig.StepIndex, 0)
-  const [poolAddress] = useLocalStorage<Address | undefined>(
+  const [poolAddress, setPoolAddress] = useLocalStorage<Address | undefined>(
     LS_KEYS.LbpConfig.PoolAddress,
     undefined
   )
+  const [, setIsMetadataSent] = useLocalStorage<boolean>(LS_KEYS.LbpConfig.IsMetadataSent, false)
+
   const handleReset = async () => {
     saleStructureForm.resetToInitial()
     projectInfoForm.resetToInitial()
-    setStepIndex(0)
-    setActiveStep(0)
-
+    resetConfigSteps()
     transactionSteps.resetTransactionSteps()
-
+    setPoolAddress(undefined)
+    setIsMetadataSent(false)
     onClose()
   }
 

--- a/packages/lib/modules/lbp/modal/LbpCreationModal.tsx
+++ b/packages/lib/modules/lbp/modal/LbpCreationModal.tsx
@@ -16,7 +16,6 @@ import { LS_KEYS } from '@repo/lib/modules/local-storage/local-storage.constants
 import { PoolCreationModalFooter } from '@repo/lib/shared/components/modals/PoolCreationModalFooter'
 import { ActionModalFooter } from '@repo/lib/shared/components/modals/ActionModalFooter'
 import { Address } from 'viem'
-import { useRouter } from 'next/navigation'
 
 type Props = {
   isOpen: boolean
@@ -31,7 +30,6 @@ export function LbpCreationModal({
   finalFocusRef,
   ...rest
 }: Props & Omit<ModalProps, 'children'>) {
-  const router = useRouter()
   const initialFocusRef = useRef(null)
   const { isDesktop } = useBreakpoints()
   const {
@@ -49,25 +47,14 @@ export function LbpCreationModal({
     undefined
   )
   const handleReset = async () => {
-    // clear local storage
-    localStorage.removeItem(LS_KEYS.LbpConfig.SaleStructure)
-    localStorage.removeItem(LS_KEYS.LbpConfig.ProjectInfo)
-    localStorage.removeItem(LS_KEYS.LbpConfig.PoolAddress)
-    localStorage.removeItem(LS_KEYS.LbpConfig.IsMetadataSent)
+    saleStructureForm.resetToInitial()
+    projectInfoForm.resetToInitial()
     setStepIndex(0)
-
-    // clear temp state
-    saleStructureForm.reset()
-    projectInfoForm.reset()
     setActiveStep(0)
 
-    // clear tx steps
     transactionSteps.resetTransactionSteps()
 
-    // clear path
-    if (initLbpTxHash) router.replace('/')
-
-    onClose() // close modal
+    onClose()
   }
 
   const path = getPoolPath({

--- a/packages/lib/modules/lbp/steps/SaleStructureStep.tsx
+++ b/packages/lib/modules/lbp/steps/SaleStructureStep.tsx
@@ -54,11 +54,11 @@ export function SaleStructureStep() {
       watch,
       setValue,
       trigger,
-      resetToInitial,
     },
     projectInfoForm,
     setActiveStep,
     activeStepIndex,
+    resetLbpCreation,
   } = useLbpForm()
   const saleStructureData = watch()
 
@@ -99,7 +99,7 @@ export function SaleStructureStep() {
             <NetworkSelectInput chains={supportedChains} control={control} />
             <LaunchTokenAddressInput
               triggerValidation={trigger}
-              resetForm={resetToInitial}
+              resetForm={resetLbpCreation}
               control={control}
               errors={errors}
               setFormValue={setValue}

--- a/packages/lib/modules/lbp/steps/SaleStructureStep.tsx
+++ b/packages/lib/modules/lbp/steps/SaleStructureStep.tsx
@@ -54,7 +54,7 @@ export function SaleStructureStep() {
       watch,
       setValue,
       trigger,
-      reset,
+      resetToInitial,
     },
     projectInfoForm,
     setActiveStep,
@@ -99,7 +99,7 @@ export function SaleStructureStep() {
             <NetworkSelectInput chains={supportedChains} control={control} />
             <LaunchTokenAddressInput
               triggerValidation={trigger}
-              resetForm={reset}
+              resetForm={resetToInitial}
               control={control}
               errors={errors}
               setFormValue={setValue}

--- a/packages/lib/modules/lbp/steps/useCreateLbpStep.tsx
+++ b/packages/lib/modules/lbp/steps/useCreateLbpStep.tsx
@@ -87,10 +87,10 @@ export function useCreateLbpStep(): TransactionStep {
     userAddress &&
     launchTokenAddress &&
     collateralTokenAddress &&
-    projectTokenStartWeight != null &&
-    reserveTokenStartWeight != null &&
-    projectTokenEndWeight != null &&
-    reserveTokenEndWeight != null &&
+    projectTokenStartWeight &&
+    reserveTokenStartWeight &&
+    projectTokenEndWeight &&
+    reserveTokenEndWeight &&
     startTime &&
     endTime
 

--- a/packages/lib/modules/lbp/steps/useCreateLbpStep.tsx
+++ b/packages/lib/modules/lbp/steps/useCreateLbpStep.tsx
@@ -12,7 +12,7 @@ import { sentryMetaForWagmiSimulation } from '@repo/lib/shared/utils/query-error
 import { useLbpForm } from '../LbpFormProvider'
 import { DisabledTransactionButton } from '@repo/lib/modules/transactions/transaction-steps/TransactionStepButton'
 import { useCreatePoolBuildCall } from '@repo/lib/modules/pool/actions/create/useCreatePoolBuildCall'
-import { parseUnits } from 'viem'
+import { parseUnits, Address } from 'viem'
 import { PoolType, type CreatePoolLiquidityBootstrappingInput } from '@balancer/sdk'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { usePoolCreationReceipt } from '@repo/lib/modules/transactions/transaction-steps/receipts/receipt.hooks'
@@ -79,28 +79,43 @@ export function useCreateLbpStep(): TransactionStep {
   const { symbol: launchTokenSymbol } = useTokenMetadata(launchTokenAddress, selectedChain)
   const { symbol: collateralTokenSymbol } = useTokenMetadata(collateralTokenAddress, selectedChain)
 
-  const createPoolInput = {
-    protocolVersion: 3 as const,
-    poolType: PoolType.LiquidityBootstrapping,
-    symbol: `${launchTokenSymbol}-${collateralTokenSymbol}-LBP`,
-    name: `${name} Liquidity Bootstrapping Pool`,
-    swapFeePercentage: parseUnits('0.01', 18),
-    chainId,
-    lbpParams: {
-      owner: userAddress,
-      blockProjectTokenSwapsIn,
-      projectToken: launchTokenAddress as `0x${string}`,
-      reserveToken: collateralTokenAddress as `0x${string}`,
-      projectTokenStartWeight: parseUnits(((projectTokenStartWeight || 0) / 100).toString(), 18),
-      reserveTokenStartWeight: parseUnits(((reserveTokenStartWeight || 0) / 100).toString(), 18),
-      projectTokenEndWeight: parseUnits(((projectTokenEndWeight || 0) / 100).toString(), 18),
-      reserveTokenEndWeight: parseUnits(((reserveTokenEndWeight || 0) / 100).toString(), 18),
-      startTime: BigInt(Math.floor(new Date(startTime || Date.now()).getTime() / 1000)),
-      endTime: BigInt(
-        Math.floor(new Date(endTime || Date.now() + 1000 * 60 * 60 * 24).getTime() / 1000)
-      ), // added day because sentry capture query error if default start / end at same time
-    },
-  }
+  const hasRequiredValues =
+    launchTokenSymbol &&
+    collateralTokenSymbol &&
+    name &&
+    chainId &&
+    userAddress &&
+    launchTokenAddress &&
+    collateralTokenAddress &&
+    projectTokenStartWeight != null &&
+    reserveTokenStartWeight != null &&
+    projectTokenEndWeight != null &&
+    reserveTokenEndWeight != null &&
+    startTime &&
+    endTime
+
+  const createPoolInput = hasRequiredValues
+    ? {
+        protocolVersion: 3 as const,
+        poolType: PoolType.LiquidityBootstrapping,
+        symbol: `${launchTokenSymbol}-${collateralTokenSymbol}-LBP`,
+        name: `${name} Liquidity Bootstrapping Pool`,
+        swapFeePercentage: parseUnits('0.01', 18), // TODO: confirm default value
+        chainId,
+        lbpParams: {
+          owner: userAddress,
+          blockProjectTokenSwapsIn,
+          projectToken: launchTokenAddress as Address,
+          reserveToken: collateralTokenAddress as Address,
+          projectTokenStartWeight: parseUnits(`${projectTokenStartWeight / 100}`, 18),
+          reserveTokenStartWeight: parseUnits(`${reserveTokenStartWeight / 100}`, 18),
+          projectTokenEndWeight: parseUnits(`${projectTokenEndWeight / 100}`, 18),
+          reserveTokenEndWeight: parseUnits(`${reserveTokenEndWeight / 100}`, 18),
+          startTime: BigInt(Math.floor(new Date(startTime).getTime() / 1000)),
+          endTime: BigInt(Math.floor(new Date(endTime).getTime() / 1000)),
+        },
+      }
+    : undefined
 
   const buildCallDataQuery = useCreatePoolBuildCall({
     createPoolInput: createPoolInput as CreatePoolLiquidityBootstrappingInput,

--- a/packages/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/useTransactionSteps.tsx
@@ -40,6 +40,9 @@ export function useTransactionSteps(steps: TransactionStep[] = [], isLoading = f
   function resetTransactionSteps() {
     setCurrentStepIndex(0)
     setOnSuccessCalled({})
+    steps.forEach(step => {
+      if (step.transaction) resetTransaction(step.transaction)
+    })
   }
 
   // Trigger side effects on transaction completion. The step itself decides

--- a/packages/lib/shared/hooks/usePersistentForm.ts
+++ b/packages/lib/shared/hooks/usePersistentForm.ts
@@ -1,6 +1,6 @@
 import { useLocalStorage } from 'usehooks-ts'
 import { useForm, UseFormProps, UseFormReturn, FieldValues, DefaultValues } from 'react-hook-form'
-import { useEffect } from 'react'
+import { useEffect, useCallback } from 'react'
 
 /**
  * Combines react-hook-form with useLocalStorage to persist form data.
@@ -15,7 +15,7 @@ export function usePersistentForm<TFieldValues extends FieldValues = FieldValues
   storageKey: string,
   initialDefaultValues: DefaultValues<TFieldValues>,
   formOptions?: Omit<UseFormProps<TFieldValues>, 'defaultValues'>
-): UseFormReturn<TFieldValues> {
+): UseFormReturn<TFieldValues> & { resetToInitial: () => void } {
   const [persistedValues, setPersistedValues] = useLocalStorage<DefaultValues<TFieldValues>>(
     storageKey,
     initialDefaultValues
@@ -33,5 +33,12 @@ export function usePersistentForm<TFieldValues extends FieldValues = FieldValues
     return () => subscription.unsubscribe()
   }, [watch, setPersistedValues])
 
-  return form
+  const resetToInitial = useCallback(() => {
+    // First reset local storage to initial values
+    setPersistedValues(initialDefaultValues)
+    // Then reset the form to use those initial values
+    form.reset(initialDefaultValues)
+  }, [form, initialDefaultValues, setPersistedValues])
+
+  return { ...form, resetToInitial }
 }


### PR DESCRIPTION
Closes #1178 

### Summary
- added reset logic to `usePersistedForm` to manage interaction btwn local storage and react hook form
- validate existence of form values before defining pool creation input to fix premature build call query
- make reset progress button also reset state for transaction steps
