### PR TITLE
fix: use rate providers in eclps

### DIFF
--- a/packages/lib/modules/pool/pool-tokens.utils.ts
+++ b/packages/lib/modules/pool/pool-tokens.utils.ts
@@ -348,7 +348,7 @@ export function getPriceRateRatio(pool: Pool) {
     (
       token: ApiToken & { priceRate?: string; priceRateProviderData?: GqlPriceRateProviderData }
     ) => {
-      return !token.useUnderlyingForAddRemove ? '1' : token.priceRate
+      return token.useUnderlyingForAddRemove ? token.priceRate : '1'
     }
   )
   return bn(priceRates[0] || '1').div(priceRates[1] || '1')

--- a/packages/lib/modules/pool/pool-tokens.utils.ts
+++ b/packages/lib/modules/pool/pool-tokens.utils.ts
@@ -342,15 +342,13 @@ export function getPriceRateForToken(token: ApiToken, pool: Pool) {
     ?.priceRate
 }
 
+// for use with ECLPs
 export function getPriceRateRatio(pool: Pool) {
   const priceRates = getPoolActionableTokens(pool).map(
     (
       token: ApiToken & { priceRate?: string; priceRateProviderData?: GqlPriceRateProviderData }
     ) => {
-      return token.priceRateProviderData &&
-        token.priceRateProviderData.name === 'ConstantRateProvider'
-        ? '1'
-        : token.priceRate
+      return !token.useUnderlyingForAddRemove ? '1' : token.priceRate
     }
   )
   return bn(priceRates[0] || '1').div(priceRates[1] || '1')


### PR DESCRIPTION
only use a rate provider in an eclp when the token is _boosted_