### PR TITLE
fix: use poolTokens data here

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolInfo/Erc4626Info.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolInfo/Erc4626Info.tsx
@@ -17,10 +17,10 @@ import Link from 'next/link'
 import { ArrowUpRight } from 'react-feather'
 import { getWarnings } from '../../pool.helpers'
 import { PropsWithChildren } from 'react'
-import { ApiToken } from '@repo/lib/modules/tokens/token.types'
+import { InfoPopoverToken } from '@repo/lib/modules/tokens/token.types'
 
 type Erc4626InfoPopOverProps = {
-  token: ApiToken
+  token: InfoPopoverToken
   data: Erc4626ReviewData | undefined | null
   level: number
 } & PropsWithChildren

--- a/packages/lib/modules/pool/PoolDetail/PoolInfo/RateProviderInfo.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolInfo/RateProviderInfo.tsx
@@ -17,10 +17,10 @@ import Link from 'next/link'
 import { ArrowUpRight } from 'react-feather'
 import { getWarnings } from '../../pool.helpers'
 import { PropsWithChildren } from 'react'
-import { ApiToken } from '@repo/lib/modules/tokens/token.types'
+import { InfoPopoverToken } from '@repo/lib/modules/tokens/token.types'
 
 type RateProviderInfoPopOverProps = {
-  token: ApiToken
+  token: InfoPopoverToken
   data: GqlPriceRateProviderData | null
   level: number
 } & PropsWithChildren

--- a/packages/lib/modules/tokens/token.types.ts
+++ b/packages/lib/modules/tokens/token.types.ts
@@ -63,3 +63,9 @@ export type CustomToken = {
 }
 
 export type BalanceForFn = (token: TokenBase | string) => TokenAmount | undefined
+
+export type InfoPopoverToken = {
+  address: Address
+  symbol: string
+  chain: GqlChain
+}


### PR DESCRIPTION
- use data from `poolTokens` to show rate providers and tokenized vaults

before:
![image](https://github.com/user-attachments/assets/2c3478d0-4664-43bd-ab03-48ce4a45a0ea)

after:
![image](https://github.com/user-attachments/assets/498e0079-01f9-4658-a29c-133b3680dae3)
