### PR TITLE
[LBP] fix: use collateral token from persistent storage

### DIFF
--- a/packages/lib/modules/lbp/steps/SaleStructureStep.tsx
+++ b/packages/lib/modules/lbp/steps/SaleStructureStep.tsx
@@ -365,7 +365,7 @@ function CollateralTokenAddressInput({
         render={({ field }) => (
           <TokenSelectInput
             chain={selectedChain}
-            defaultTokenAddress={collateralTokens?.[0]}
+            defaultTokenAddress={field.value || collateralTokens?.[0]}
             onChange={newValue => {
               field.onChange(newValue as GqlChain)
             }}


### PR DESCRIPTION
how to reproduce the issue:

1. choose collateral token
2. refresh ui
3. collateral token is set again to the first token from the network's collateral tokens array
