### PR TITLE
Fix broken link to testing instructions in README

### DIFF
--- a/apps/frontend-v3/README.md
+++ b/apps/frontend-v3/README.md
@@ -67,7 +67,7 @@ pnpm dev:webpack
 
 ## Testing
 
-See [TESTING.md](./test/TESTING.md).
+See [Testing instructions](../../README.md#testing).
 
 ## Developing in Windows
 


### PR DESCRIPTION
Replaced the outdated link to the non-existent TESTING.md file with a correct link to the "Testing" section in the root README.md. This ensures users can easily find up-to-date testing instructions for the project.