### PR TITLE
fix: show staking boost on beets app

### DIFF
--- a/packages/lib/shared/hooks/useAprTooltip.ts
+++ b/packages/lib/shared/hooks/useAprTooltip.ts
@@ -101,7 +101,9 @@ export function useAprTooltip({
   } = PROJECT_CONFIG
 
   const hasVeBalBoost =
-    showVeBal && !!aprItems.find(item => item.type === GqlPoolAprItemType.StakingBoost)
+    // optimism is the exception here as it's available in the balancer app and beets app
+    (showVeBal || chain === GqlChain.Optimism) &&
+    !!aprItems.find(item => item.type === GqlPoolAprItemType.StakingBoost)
 
   // Swap fees
   const swapFee = aprItems.find(item => item.type === GqlPoolAprItemType.SwapFee_24H)


### PR DESCRIPTION
the chain `Optimism` is available on both the balancer and beets app

currently it is only showing the vebal staking boost apr on Optimism through the balancer app
this PR adds showing the extra apr through the beets app too

before:
![image](https://github.com/user-attachments/assets/05598a20-d49b-41c8-a5d6-6754388cc5c1)

after:
![image](https://github.com/user-attachments/assets/f2da1aaa-9322-41b9-9262-baea4fd63c94)