### PR TITLE
Hover states on promo tiles on Pools page

### DIFF
--- a/packages/lib/config/config.types.ts
+++ b/packages/lib/config/config.types.ts
@@ -163,6 +163,7 @@ type PartnerCard = {
 export type PromoItem = {
   id: number
   icon: string
+  label: string
   title: string
   description: string
   buttonText?: string

--- a/packages/lib/config/projects/balancer.ts
+++ b/packages/lib/config/projects/balancer.ts
@@ -186,6 +186,7 @@ export const ProjectConfigBalancer: ProjectConfig = {
     {
       id: 0,
       icon: 'boosted',
+      label: 'Boosted Pools',
       title: '100% Boosted Pools on Balancer v3',
       description:
         'A simple, capital efficient strategy for LPs to get boosted yield. Partnering with leading lending protocols like Aave and Morpho.',
@@ -207,6 +208,7 @@ export const ProjectConfigBalancer: ProjectConfig = {
     {
       id: 1,
       icon: 'v3',
+      label: 'Balancer v3',
       title: 'Balancer v3 is live and thriving!',
       description:
         'A simple, flexible, powerful platform to innovate upon and build the future of AMMs. Battle-tested on-chain since November.',
@@ -227,6 +229,7 @@ export const ProjectConfigBalancer: ProjectConfig = {
     {
       id: 2,
       icon: 'gyro',
+      label: 'Gyroscope',
       title: 'Superliquidity, made simple',
       description:
         'Next generation Gyroscope pools are now live on Balancer v3. Manage liquidity directly within the Balancer UI.',
@@ -247,6 +250,7 @@ export const ProjectConfigBalancer: ProjectConfig = {
     {
       id: 3,
       icon: 'hook',
+      label: 'StableSurge Hook',
       title: 'StableSurge Hook',
       description:
         'A dynamic directional surge swap fee in times of volatility to help defend the peg. LPs get MEV protection and increased fees.',

--- a/packages/lib/config/projects/beets.ts
+++ b/packages/lib/config/projects/beets.ts
@@ -120,6 +120,7 @@ export const ProjectConfigBeets: ProjectConfig = {
     {
       id: 0,
       icon: 'boosted',
+      label: 'Boosted Pools',
       title: '100% Boosted Pools on Balancer v3',
       description:
         'A simple, capital efficient strategy for LPs to get boosted yield. Partnering with leading lending protocols like Aave and Morpho.',
@@ -141,6 +142,7 @@ export const ProjectConfigBeets: ProjectConfig = {
     {
       id: 1,
       icon: 'v3',
+      label: 'Balancer v3',
       title: 'Balancer v3 is live and thriving!',
       description:
         'A simple, flexible, powerful platform to innovate upon and build the future of AMMs. Battle-tested on-chain since November.',
@@ -161,6 +163,7 @@ export const ProjectConfigBeets: ProjectConfig = {
     {
       id: 2,
       icon: 'gyro',
+      label: 'Gyroscope',
       title: 'Superliquidity, made simple',
       description:
         'Next generation Gyroscope pools are now live on Balancer v3. Manage liquidity directly within the Balancer UI.',
@@ -181,6 +184,7 @@ export const ProjectConfigBeets: ProjectConfig = {
     {
       id: 3,
       icon: 'hook',
+      label: 'StableSurge Hook',
       title: 'StableSurge Hook',
       description:
         'A dynamic directional surge swap fee in times of volatility to help defend the peg. LPs get MEV protection and increased fees.',

--- a/packages/lib/shared/components/promos/PromoBanners.tsx
+++ b/packages/lib/shared/components/promos/PromoBanners.tsx
@@ -354,13 +354,29 @@ export function PromoBanners() {
                         _groupHover={{
                           color: colorMode === 'dark' ? 'font.maxContrast' : 'brown.500',
                           opacity: 1,
+                          transform: 'translateY(-6px)',
                         }}
                         color={colorMode === 'dark' ? 'font.secondary' : 'brown.400'}
                         opacity="0.8"
-                        transition="color 0.3s var(--ease-out-cubic), opacity 0.3s var(--ease-out-cubic), box-shadow 0.15s var(--ease-out-cubic)"
+                        transition="color 0.3s var(--ease-out-cubic), opacity 0.3s var(--ease-out-cubic), transform 0.3s var(--ease-out-cubic), box-shadow 0.15s var(--ease-out-cubic)"
                       >
                         {item.iconElement}
                       </Box>
+                      <Text
+                        _groupHover={{
+                          color: colorMode === 'dark' ? 'font.maxContrast' : 'brown.500',
+                          opacity: 1,
+                        }}
+                        bottom="24px"
+                        display={{ base: 'none', xl: 'block' }}
+                        fontSize="xs"
+                        opacity="0"
+                        position="absolute"
+                        textAlign="center"
+                        transition="color 0.3s var(--ease-out-cubic), opacity 0.3s var(--ease-out-cubic)"
+                      >
+                        {item.label}
+                      </Text>
                     </Flex>
                   </Center>
                 </Box>

--- a/packages/lib/shared/components/promos/PromoBanners.tsx
+++ b/packages/lib/shared/components/promos/PromoBanners.tsx
@@ -368,8 +368,8 @@ export function PromoBanners() {
                           opacity: 1,
                         }}
                         bottom="24px"
-                        display={{ base: 'none', xl: 'block' }}
-                        fontSize="xs"
+                        display={{ base: 'none', lg: 'block' }}
+                        fontSize={{ base: '11px', xl: 'xs' }}
                         opacity="0"
                         position="absolute"
                         textAlign="center"


### PR DESCRIPTION

Introduce a new hover state on large screens and up on the promo tiles on the `/pools` page:

![cs 2025-07-07 at 12 50 33@2x](https://github.com/user-attachments/assets/886d6458-4d49-47bf-9311-5cfe1fb76f34)
