### PR TITLE
fix: check if link is external

### DIFF
--- a/packages/lib/shared/components/navs/MobileNav.tsx
+++ b/packages/lib/shared/components/navs/MobileNav.tsx
@@ -54,7 +54,7 @@ function NavLinks({ appLinks, onClick, customLinks }: NavLinkProps) {
           fontSize="xl"
           gap="xs"
           href={link.href}
-          isExternal
+          isExternal={link.isExternal}
           key={link.href}
           onClick={onClick}
           prefetch


### PR DESCRIPTION
fixes #1308

check if link is external instead of always opening links externally
