### PR TITLE
fix: increase margin for eclps

### DIFF
--- a/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
+++ b/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
@@ -61,7 +61,7 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
   const yMax = useMemo(() => (data ? Math.max(...data.map(([, y]) => y)) : 0), [data])
 
   const poolIsInRange = useMemo(() => {
-    const margin = 0.00001 // if spot price is within the margin on both sides it's considered out of range
+    const margin = 0.0001 // if spot price is within the margin on both sides it's considered out of range
 
     return (
       bn(poolSpotPrice || 0).gt(xMin * (1 + margin)) &&


### PR DESCRIPTION
increase margin for eclp isInRange check

the margin needs a small increase so a pool will display it is out of or in range more accurate