### PR TITLE
fix: mabeets apr display

### DIFF
--- a/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
+++ b/packages/lib/shared/components/tooltips/apr-tooltip/BaseAprTooltip.tsx
@@ -194,7 +194,7 @@ function BaseAprTooltip({
           </>
         ) : null}
       </TooltipAprItem>
-      {isMaBeetsPresent && (
+      {isMaBeetsPresent && !maBeetsRewardsDisplayed.isZero() && (
         <TooltipAprItem
           {...basePopoverAprItemProps}
           apr={maBeetsRewardsDisplayed}
@@ -370,17 +370,19 @@ function BaseAprTooltip({
         <>
           <Divider />
           <Stack gap={0} roundedBottom="md">
-            <TooltipAprItem
-              {...basePopoverAprItemProps}
-              apr={maxMaBeetsRewardDisplayed}
-              displayValueFormatter={usedDisplayValueFormatter}
-              fontColor={colorMode == 'light' ? 'gray.600' : 'gray.400'}
-              fontWeight={500}
-              pl={6}
-              pt={3}
-              title="Extra BEETS (max maturity boost)"
-              tooltipText={maBeetsRewardTooltipText}
-            />
+            {!maxMaBeetsRewardDisplayed.isZero() && (
+              <TooltipAprItem
+                {...basePopoverAprItemProps}
+                apr={maxMaBeetsRewardDisplayed}
+                displayValueFormatter={usedDisplayValueFormatter}
+                fontColor={colorMode == 'light' ? 'gray.600' : 'gray.400'}
+                fontWeight={500}
+                pl={6}
+                pt={3}
+                title="Extra BEETS (max maturity boost)"
+                tooltipText={maBeetsRewardTooltipText}
+              />
+            )}
             <TooltipAprItem
               {...basePopoverAprItemProps}
               apr={maxMaBeetsVotingRewardDisplayed}
@@ -388,6 +390,7 @@ function BaseAprTooltip({
               fontColor={colorMode == 'light' ? 'gray.600' : 'gray.400'}
               fontWeight={500}
               pl={6}
+              pt={maxMaBeetsRewardDisplayed.isZero() ? 3 : 0}
               title="Extra Voting APR"
               tooltipText={maBeetsVotingRewardsTooltipText}
             />

--- a/packages/lib/shared/hooks/useAprTooltip.ts
+++ b/packages/lib/shared/hooks/useAprTooltip.ts
@@ -204,7 +204,7 @@ export function useAprTooltip({
     .plus(maxMaBeetsRewardDisplayed)
     .plus(maxMaBeetsVotingRewardDisplayed)
 
-  const isMaBeetsPresent = !maBeetsRewardsDisplayed.isZero()
+  const isMaBeetsPresent = !maBeetsTotalAprDisplayed.isZero()
 
   const totalBase = aprItems
     .filter(item => TOTAL_BASE_APR_TYPES.includes(item.type))


### PR DESCRIPTION
voting apr went missing in the breakdown

before:
<img width="333" height="252" alt="image" src="https://github.com/user-attachments/assets/61a9664e-0c5a-4c7f-8722-966d01546480" />

after:
<img width="339" height="331" alt="image" src="https://github.com/user-attachments/assets/59fe6e78-c9d4-46e6-896d-d50cf7f70c1d" />
