### PR TITLE
fix: remove rounding from tokenScalingFactor

### DIFF
--- a/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
+++ b/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
@@ -19,7 +19,7 @@ export function useGetECLPLiquidityProfile(pool: Pool) {
   const tokenRateScalingFactorString = useMemo(() => {
     if (!tokenRates) return
 
-    return bn(tokenRates[0]).div(bn(tokenRates[1])).toFixed(4)
+    return bn(tokenRates[0]).div(bn(tokenRates[1])).toString()
   }, [tokenRates])
 
   const liquidityData = useMemo(


### PR DESCRIPTION
see [this pool](https://beets.fi/pools/sonic/v2/0x1be3de1d5b5aaf9076071228bc091f8f100f967e000200000000000000000115), range should be 2500-3500 in reverse

before:
<img width="952" height="505" alt="image" src="https://github.com/user-attachments/assets/bca99f04-4a50-43e0-a903-5ee500ba1d53" />

after:
<img width="957" height="499" alt="image" src="https://github.com/user-attachments/assets/3b3b170f-c378-4360-bd97-714cdf81c24d" />
