### PR TITLE
reCLAMM chart: Improve text legibility and colors on light mode

### DIFF
--- a/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
+++ b/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
@@ -310,8 +310,8 @@ export function useReclAmmChartLogic() {
                 borderWidth: 0.5,
                 color: isCurrentPriceBar
                   ? isPriceAdjusting
-                    ? ORANGE
-                    : GREEN
+                    ? warningFontColor
+                    : highlightFontColor
                   : getGradientColor(segment.gradientColors),
               },
             },

--- a/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
+++ b/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
@@ -37,7 +37,7 @@ export function useReclAmmChartLogic() {
   const dynamicXAxisNamePadding = useBreakpointValue({
     base: [0, 30, -128, 0],
     md: [0, 30, -128, 0],
-    lg: [0, 24, -80, 0],
+    lg: [0, 24, -75, 0],
   }) || [0, 24, -80, 0]
 
   const secondaryFontColor = selectColor('font', 'secondary')

--- a/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
+++ b/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
@@ -9,7 +9,7 @@ import { useBreakpoints } from '@repo/lib/shared/hooks/useBreakpoints'
 import { useSelectColor } from '@repo/lib/shared/hooks/useSelectColor'
 import { getPoolActionableTokens } from '@repo/lib/modules/pool/pool-tokens.utils'
 import { usePool } from '@repo/lib/modules/pool/PoolProvider'
-import { useBreakpointValue } from '@chakra-ui/react'
+import { useBreakpointValue, useColorMode } from '@chakra-ui/react'
 
 type ReclAmmChartContextType = ReturnType<typeof useReclAmmChartLogic>
 
@@ -32,6 +32,7 @@ export function useReclAmmChartLogic() {
   const [isReversed, setIsReversed] = useState(false)
   const selectColor = useSelectColor()
   const { pool } = usePool()
+  const { colorMode } = useColorMode()
 
   const dynamicXAxisNamePadding = useBreakpointValue({
     base: [0, 30, -128, 0],
@@ -193,17 +194,23 @@ export function useReclAmmChartLogic() {
     const gridBottomMobile =
       baseOrangeBarCount % 2 === 0 && !(showMinMaxValues && !showTargetValues) ? '24.5%' : '16%'
 
+    const isDarkMode = colorMode === 'dark'
+
     const baseGreyBarConfig = {
       count: baseGreyBarCount,
       value: isMobile ? 1 : 3,
-      gradientColors: ['rgba(160, 174, 192, 0.5)', 'rgba(160, 174, 192, 0.1)'],
+      gradientColors: isDarkMode
+        ? ['rgba(160, 174, 192, 0.5)', 'rgba(160, 174, 192, 0.1)']
+        : ['rgba(160, 174, 192, 1)', 'rgba(160, 174, 192, 0.5)'],
       borderRadius: 20,
     }
 
     const baseOrangeBarConfig = {
       count: baseOrangeBarCount,
       value: 100,
-      gradientColors: ['rgb(253, 186, 116)', 'rgba(151, 111, 69, 0.5)'],
+      gradientColors: isDarkMode
+        ? ['rgb(253, 186, 116)', 'rgba(151, 111, 69, 0.5)']
+        : ['rgba(250, 144, 71, 1)', 'rgba(250, 144, 71, 0.5)'],
       borderRadius: 20,
     }
 
@@ -211,7 +218,9 @@ export function useReclAmmChartLogic() {
       name: 'Green',
       count: baseGreenBarCount,
       value: 100,
-      gradientColors: ['rgb(99, 242, 190)', 'rgba(57, 140, 110, 0.5)'],
+      gradientColors: isDarkMode
+        ? ['rgb(99, 242, 190)', 'rgba(57, 140, 110, 0.5)']
+        : ['rgba(0, 184, 130, 1)', 'rgba(0, 184, 130, 0.5)'],
       borderRadius: 20,
     }
 

--- a/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
+++ b/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
@@ -11,9 +11,6 @@ import { getPoolActionableTokens } from '@repo/lib/modules/pool/pool-tokens.util
 import { usePool } from '@repo/lib/modules/pool/PoolProvider'
 import { useBreakpointValue } from '@chakra-ui/react'
 
-const GREEN = '#93F6D2'
-const ORANGE = 'rgb(253, 186, 116)'
-
 type ReclAmmChartContextType = ReturnType<typeof useReclAmmChartLogic>
 
 const ReclAmmChartContext = createContext<ReclAmmChartContextType | null>(null)
@@ -43,6 +40,8 @@ export function useReclAmmChartLogic() {
   }) || [0, 24, -80, 0]
 
   const secondaryFontColor = selectColor('font', 'secondary')
+  const highlightFontColor = selectColor('font', 'highlight')
+  const warningFontColor = selectColor('font', 'warning')
 
   function toggleIsReversed() {
     setIsReversed(!isReversed)
@@ -266,8 +265,8 @@ export function useReclAmmChartLogic() {
             itemStyle: {
               color: isCurrentPriceBar // Solid color for current price bar
                 ? isPriceAdjusting
-                  ? ORANGE
-                  : GREEN
+                  ? warningFontColor
+                  : highlightFontColor
                 : getGradientColor(segment.gradientColors),
               borderRadius: segment.borderRadius,
             },
@@ -280,7 +279,7 @@ export function useReclAmmChartLogic() {
     const baseRichProps = {
       fontSize: 12,
       lineHeight: 13,
-      color: '#A0AEC0',
+      color: secondaryFontColor,
       align: 'center',
     }
 
@@ -290,19 +289,19 @@ export function useReclAmmChartLogic() {
       base: baseRichProps,
       triangle: {
         ...baseRichProps,
-        fontSize: 10,
+        fontSize: 9,
         lineHeight: 12,
         color: '#718096',
       },
       current: {
         ...baseRichProps,
-        color: isPriceAdjusting ? ORANGE : GREEN,
+        color: isPriceAdjusting ? warningFontColor : highlightFontColor,
       },
       currentTriangle: {
         ...baseRichProps,
-        fontSize: 10,
-        lineHeight: 12,
-        color: isPriceAdjusting ? ORANGE : GREEN,
+        fontSize: 8,
+        lineHeight: 14,
+        color: isPriceAdjusting ? warningFontColor : highlightFontColor,
       },
       withRightPadding: {
         ...baseRichProps,
@@ -310,7 +309,7 @@ export function useReclAmmChartLogic() {
       },
       withRightBottomPadding: {
         ...baseRichProps,
-        padding: [0, paddingRight, 10, 0],
+        padding: [0, paddingRight, 5, 0],
       },
       withTopRightPadding: {
         ...baseRichProps,
@@ -360,6 +359,7 @@ export function useReclAmmChartLogic() {
             triangle: {
               ...richStyles.triangle,
               ...richStyles.withRightBottomPadding,
+              fontSize: 9,
             },
             labelText: {
               ...richStyles.base,

--- a/packages/lib/shared/components/badges/ClpBadge.tsx
+++ b/packages/lib/shared/components/badges/ClpBadge.tsx
@@ -20,12 +20,14 @@ export function ClpBadge({ icon, bodyText, headerText, bgColor }: ClpBadgeProps)
         borderRadius="sm"
         color="black"
         cursor="pointer"
+        h="32px"
         mb={['6px', '4px', '0px']} // to prevent jittering on mobile
-        p="2"
+        px="2"
+        shadow="md"
         w="max-content"
         zIndex="1"
       >
-        <HStack>
+        <HStack h="full" justifyContent="center">
           {icon && <Icon as={icon} />}
           <Text color="black" fontSize="sm" fontWeight="bold">
             {headerText}

--- a/packages/lib/shared/components/icons/WandIcon.tsx
+++ b/packages/lib/shared/components/icons/WandIcon.tsx
@@ -1,12 +1,29 @@
 import { SVGProps } from 'react'
 
-export function WandIcon(props: SVGProps<SVGSVGElement>) {
+export function WandIcon({ size = 24, ...props }: { size?: number } & SVGProps<SVGSVGElement>) {
   return (
-    <svg fill="none" viewBox="0 0 17 16" xmlns="http://www.w3.org/2000/svg" {...props}>
-      <path
-        d="M1 3a1 1 0 0 1 1-1h1V1a1 1 0 0 1 1 0v1h2a1 1 0 0 1 0 2H4v1a1 1 0 0 1-1 0V4H2a1 1 0 0 1-1-1Zm11 10h-1v-1a1 1 0 0 0-1 0v1H9a1 1 0 1 0 0 1h1v1a1 1 0 1 0 1 0v-1h1a1 1 0 1 0 0-1Zm4-4h-1V8a1 1 0 0 0-1 0v1h-1a1 1 0 1 0 0 2h1v1a1 1 0 1 0 1 0v-1h1a1 1 0 1 0 0-2Zm-1-5L4 15a1 1 0 0 1-2 0l-2-1a1 1 0 0 1 0-2L11 1a1 1 0 0 1 2 0l2 1a1 1 0 0 1 0 2Zm-5 3L9 5l-8 8 2 1 7-7Zm4-4-2-1-2 2 1 2 3-3Z"
-        fill="#2D3748"
-      />
+    <svg
+      fill="none"
+      viewBox="0 0 216 194"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      height={size}
+      width={size}
+    >
+      <g
+        clip-path="url(#a)"
+        stroke="#000"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"
+      >
+        <path d="M184 97v48m-24-24h48M48 9v48M24 33h48m64 120v32m-16-16h32M112 49l32 32m6-70L10 151c-3 3-3 8 0 11l21 21c3 3 8 3 11 0L182 43c3-3 3-8 0-11l-21-21c-3-3-8-3-11 0Z" />
+      </g>
+      <defs>
+        <clipPath id="a">
+          <path d="M0 0h216v194H0z" fill="#fff" />
+        </clipPath>
+      </defs>
     </svg>
   )
 }


### PR DESCRIPTION
- Fix broken icon in Pool readjusting status
- Using themed colors for better consistency and display on light mode
- Slightly smaller triangles
- Various padding adjustments

<img width="1898" height="2240" alt="cs 2025-07-16 at 09 55 23@2x" src="https://github.com/user-attachments/assets/e4649b65-8292-40b8-95d3-7998021daf32" />

<img width="1456" height="812" alt="cs 2025-07-16 at 09 59 39@2x" src="https://github.com/user-attachments/assets/a887f2cd-994f-477e-8e7f-63c0b381237a" />

