### PR TITLE
New reCLAMM promo banner

### DIFF
--- a/packages/lib/config/projects/balancer.ts
+++ b/packages/lib/config/projects/balancer.ts
@@ -190,9 +190,9 @@ export const ProjectConfigBalancer: ProjectConfig = {
       id: 0,
       icon: 'reclamm',
       label: 'reCLAMM pools',
-      title: 'New readjusting Concentrated liquidity pools',
+      title: 'New readjusting Concentrated Liquidity Pools',
       description:
-        'Maximize yield with reCLAMM pools: Auto-readjusting concentrated liquidity—no micro-management needed.',
+        'Maximize yield with reCLAMM pools: Auto-readjusting concentrated liquidity—no micro-management of positions needed.',
       buttonText: 'View pools',
       buttonLink: '/pools?poolTypes=RECLAMM',
       linkText: 'Learn more',

--- a/packages/lib/config/projects/balancer.ts
+++ b/packages/lib/config/projects/balancer.ts
@@ -188,13 +188,13 @@ export const ProjectConfigBalancer: ProjectConfig = {
   promoItems: [
     {
       id: 0,
-      icon: 'boosted',
-      label: 'Boosted Pools',
-      title: '100% Boosted Pools on Balancer v3',
+      icon: 'reclamm',
+      label: 'reCLAMM pools',
+      title: 'New readjusting Concentrated liquidity pools',
       description:
-        'A simple, capital efficient strategy for LPs to get boosted yield. Partnering with leading lending protocols like Aave and Morpho.',
+        'Maximize yield with reCLAMM pools: Auto-readjusting concentrated liquidity—no micro-management needed.',
       buttonText: 'View pools',
-      buttonLink: '/pools?poolTags=BOOSTED',
+      buttonLink: '/pools?poolTypes=RECLAMM',
       linkText: 'Learn more',
       linkURL:
         'https://docs.balancer.fi/concepts/explore-available-balancer-pools/boosted-pool.html',
@@ -210,15 +210,16 @@ export const ProjectConfigBalancer: ProjectConfig = {
     },
     {
       id: 1,
-      icon: 'v3',
-      label: 'Balancer v3',
-      title: 'Balancer v3 is live and thriving!',
+      icon: 'boosted',
+      label: 'Boosted Pools',
+      title: '100% Boosted Pools on Balancer v3',
       description:
-        'A simple, flexible, powerful platform to innovate upon and build the future of AMMs. Battle-tested on-chain since November.',
+        'A simple, capital efficient strategy for LPs to get boosted yield. Partnering with leading lending protocols like Aave and Morpho.',
       buttonText: 'View pools',
-      buttonLink: 'pools?protocolVersion=3',
+      buttonLink: '/pools?poolTags=BOOSTED',
       linkText: 'Learn more',
-      linkURL: 'https://docs.balancer.fi/partner-onboarding/balancer-v3/v3-overview.html',
+      linkURL:
+        'https://docs.balancer.fi/concepts/explore-available-balancer-pools/boosted-pool.html',
       linkExternal: true,
       bgImageActive: {
         directory: '/images/promos/promo-banner/',

--- a/packages/lib/config/projects/balancer.ts
+++ b/packages/lib/config/projects/balancer.ts
@@ -192,12 +192,12 @@ export const ProjectConfigBalancer: ProjectConfig = {
       label: 'reCLAMM pools',
       title: 'New readjusting Concentrated Liquidity Pools',
       description:
-        'Maximize yield with reCLAMM pools: Auto-readjusting concentrated liquidity—no micro-management of positions needed.',
+        'Maximize capital efficiency with reCLAMMs: Auto-readjusting concentrated liquidity—no micro-management of positions needed.',
       buttonText: 'View pools',
       buttonLink: '/pools?poolTypes=RECLAMM',
       linkText: 'Learn more',
       linkURL:
-        'https://docs.balancer.fi/concepts/explore-available-balancer-pools/boosted-pool.html',
+        'https://medium.com/balancer-protocol/introducing-reclamms-self-readjusting-trustless-passive-lping-for-clamms-b5528429588e',
       linkExternal: true,
       bgImageActive: {
         directory: '/images/promos/promo-banner/',

--- a/packages/lib/shared/components/icons/promos/PromoReclammIcon.tsx
+++ b/packages/lib/shared/components/icons/promos/PromoReclammIcon.tsx
@@ -1,0 +1,22 @@
+import { SVGProps } from 'react'
+
+export function PromoReclammIcon({
+  size = 24,
+  ...props
+}: { size?: number } & SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      fill="none"
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      height={size}
+      width={size}
+    >
+      <path
+        d="M12 25v-2l-5-4a1 1 0 1 0-1 1l4 4-4 4a1 1 0 0 0 1 1l5-4ZM2 24v1h9v-2H2v1ZM15 9a3 3 0 0 1 5 0v31a3 3 0 0 1-5 0V9Zm7 0a3 3 0 0 1 5 0v31a3 3 0 0 1-5 0V9Zm7 0a3 3 0 0 1 5 0v31a3 3 0 0 1-5 0V9Zm7 14v2l5 4a1 1 0 0 0 1-1l-4-4 4-4a1 1 0 0 0-1-1l-5 4Zm10 1v-1h-9v2h9v-1Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/packages/lib/shared/components/promos/PromoBanners.tsx
+++ b/packages/lib/shared/components/promos/PromoBanners.tsx
@@ -19,9 +19,10 @@ import { PromoHookIcon } from '../icons/promos/PromoHookIcon'
 import { PromoGyroIcon } from '../icons/promos/PromoGyroIcon'
 import { PromoVThreeIcon } from '../icons/promos/PromoVThreeIcon'
 import { PromoBoostedIcon } from '../icons/promos/PromoBoostedIcon'
+import { PromoReclammIcon } from '../icons/promos/PromoReclammIcon'
 import { PromoItem } from '@repo/lib/config/config.types'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
-import { getRandomInt } from '@repo/lib/shared/utils/numbers'
+// import { getRandomInt } from '@repo/lib/shared/utils/numbers'
 
 function getIconElement(icon: string) {
   switch (icon) {
@@ -33,6 +34,8 @@ function getIconElement(icon: string) {
       return <PromoGyroIcon size={44} />
     case 'hook':
       return <PromoHookIcon size={44} />
+    case 'reclamm':
+      return <PromoReclammIcon size={44} />
     default:
       return null
   }
@@ -46,7 +49,8 @@ const promoData: (PromoItem & { iconElement: React.ReactNode })[] =
 
 export function PromoBanners() {
   const { colorMode } = useColorMode()
-  const [activeIndex, setActiveIndex] = useState(getRandomInt(0, promoData.length - 1))
+  // const [activeIndex, setActiveIndex] = useState(getRandomInt(0, promoData.length - 1)) // random selection
+  const [activeIndex, setActiveIndex] = useState(0) // temporarily used for feature launches
   const isSmallScreen = useBreakpointValue({ base: true, md: false }, { fallback: 'md' }) ?? false
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 

--- a/packages/lib/shared/components/promos/PromoBanners.tsx
+++ b/packages/lib/shared/components/promos/PromoBanners.tsx
@@ -235,7 +235,7 @@ export function PromoBanners() {
                             fontSize={{ base: 'xs', sm: 'sm', lg: 'md' }}
                             fontWeight="medium"
                             lineHeight="1.25"
-                            maxW="46ch"
+                            maxW="48ch"
                             opacity={colorMode === 'dark' ? '0.75' : '1'}
                             sx={{
                               textWrap: 'balance',


### PR DESCRIPTION
- Update promo tiles on pools page
- Replace Balancer v3 is live with reCLAMMs promo
- Temporarily set the active index to start on the reCLAMM promo
  - Ideally set it back to random in a couple of days

<img width="2798" height="646" alt="cs 2025-07-16 at 11 42 37@2x" src="https://github.com/user-attachments/assets/fedbb355-8d92-406d-b3f7-39c3c9134799" />
