### PR TITLE
Reposition token toggle for reCLAMM and ECLP charts

### DIFF
--- a/packages/lib/modules/eclp/components/EclpChart.tsx
+++ b/packages/lib/modules/eclp/components/EclpChart.tsx
@@ -2,15 +2,13 @@
 import { Box } from '@chakra-ui/react'
 import ReactECharts from 'echarts-for-react'
 import { useEclpChart } from '../hooks/EclpChartProvider'
-import { ReversedToggleButton } from '@repo/lib/shared/components/btns/ReversedToggleButton'
 
 export function EclpChart() {
-  const { options, toggleIsReversed } = useEclpChart()
+  const { options } = useEclpChart()
 
   return (
     <Box h="full" position="relative" w="full">
       <ReactECharts option={options} style={{ height: '100%', width: '100%' }} />
-      <ReversedToggleButton toggleIsReversed={toggleIsReversed} />
     </Box>
   )
 }

--- a/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
+++ b/packages/lib/modules/eclp/hooks/EclpChartProvider.tsx
@@ -2,7 +2,6 @@ import { useGetECLPLiquidityProfile } from '@repo/lib/modules/eclp/hooks/useGetE
 import { bn, fNum } from '@repo/lib/shared/utils/numbers'
 import { usePool } from '../../pool/PoolProvider'
 import { useTheme as useChakraTheme } from '@chakra-ui/react'
-import { useBreakpointValue } from '@chakra-ui/react'
 import { createContext, PropsWithChildren, useMemo } from 'react'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { getPoolActionableTokens } from '../../pool/pool-tokens.utils'
@@ -14,12 +13,6 @@ const EclpChartContext = createContext<EclpChartContextType | null>(null)
 
 export function useEclpChartLogic() {
   const { pool } = usePool()
-
-  const dynamicXAxisNamePadding = useBreakpointValue({
-    base: [0, 30, -56, 0],
-    md: [0, 30, -54, 0],
-    lg: [0, 24, -54, 0],
-  }) || [0, 24, -54, 0]
 
   const {
     data,
@@ -69,7 +62,7 @@ export function useEclpChartLogic() {
         left: '1%',
         right: '1%',
         top: '7%',
-        bottom: '15%',
+        bottom: '9%',
       },
       tooltip: {
         show: true,
@@ -92,15 +85,6 @@ export function useEclpChartLogic() {
       },
       xAxis: {
         type: 'value',
-        name: `Price: ${tokens}`,
-        nameLocation: 'end',
-        nameGap: 5,
-        nameTextStyle: {
-          align: 'right',
-          verticalAlign: 'bottom',
-          padding: dynamicXAxisNamePadding,
-          color: secondaryFontColor,
-        },
         min: xMin - 0.1 * (xMax - xMin),
         max: xMax + 0.1 * (xMax - xMin),
         axisLabel: {
@@ -452,6 +436,7 @@ export function useEclpChartLogic() {
     isLoading,
     outOfRangeText,
     inRangeText,
+    tokens,
   }
 }
 

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsContainer.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsContainer.tsx
@@ -32,6 +32,7 @@ import {
   useReclAmmChart,
 } from '@repo/lib/modules/reclamm/ReclAmmChartProvider'
 import { ReclAmmChart } from '@repo/lib/modules/reclamm/ReclAmmChart'
+import { ReversedToggleButton } from '@repo/lib/shared/components/btns/ReversedToggleButton'
 import { ThumbsDown, ThumbsUp } from 'react-feather'
 import { WandIcon } from '@repo/lib/shared/components/icons/WandIcon'
 
@@ -78,11 +79,11 @@ function PoolChartsContent({ ...props }: any) {
   const {
     hasChartData: hasReclAmmChartData,
     isLoading: isLoadingReclAmmChartData,
-    isPoolWithinTargetRange,
     outOfRangeText: reclammOutOfRangeText,
     inRangeText: reclammInRangeText,
-    inRangeReadjustingText: reclammInRangeReadjustingText,
     isPoolWithinRange,
+    toggleIsReversed,
+    tokens,
   } = useReclAmmChart()
 
   const {
@@ -109,14 +110,10 @@ function PoolChartsContent({ ...props }: any) {
       icon: poolIsInRange ? ThumbsUp : ThumbsDown,
     },
     reclamm: {
-      bgColor: isPoolWithinTargetRange ? 'green.400' : isPoolWithinRange ? 'orange.300' : 'red.400',
-      bodyText: isPoolWithinTargetRange
-        ? reclammInRangeText
-        : isPoolWithinRange
-          ? reclammInRangeReadjustingText
-          : reclammOutOfRangeText,
-      headerText: isPoolWithinTargetRange ? 'Pool in range' : 'Pool readjusting',
-      icon: isPoolWithinTargetRange ? ThumbsUp : WandIcon,
+      bgColor: isPoolWithinRange ? 'green.400' : 'red.400',
+      bodyText: isPoolWithinRange ? reclammInRangeText : reclammOutOfRangeText,
+      headerText: isPoolWithinRange ? 'Pool in range' : 'Pool readjusting',
+      icon: isPoolWithinRange ? ThumbsUp : WandIcon,
     },
   }
 
@@ -137,6 +134,9 @@ function PoolChartsContent({ ...props }: any) {
                     options={tabsList}
                     size="xxs"
                   />
+                  {showReclammChart && (
+                    <ReversedToggleButton toggleIsReversed={toggleIsReversed} tokenPair={tokens} />
+                  )}
                   {showPoolCharts && <PeriodSelect />}
                 </HStack>
                 <VStack

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsContainer.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsContainer.tsx
@@ -127,8 +127,8 @@ function PoolChartsContent({ ...props }: any) {
         ) : hasChartData ? (
           <NoisyCard {...COMMON_NOISY_CARD_PROPS}>
             <VStack h="full" p={{ base: 'sm', md: 'md' }} w="full">
-              <Stack direction={{ base: 'column', md: 'row' }} w="full">
-                <HStack alignSelf="flex-start">
+              <Stack direction={{ base: 'column', md: 'row' }} w="full" wrap="wrap">
+                <HStack alignSelf="flex-start" wrap="wrap">
                   <ButtonGroup
                     currentOption={activeTab}
                     groupId="chart"

--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsContainer.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolCharts/PoolChartsContainer.tsx
@@ -74,6 +74,8 @@ function PoolChartsContent({ ...props }: any) {
     poolIsInRange,
     outOfRangeText: eclpOutOfRangeText,
     inRangeText: eclpInRangeText,
+    toggleIsReversed: toggleIsReversedEclp,
+    tokens: tokensEclp,
   } = useEclpChart()
 
   const {
@@ -136,6 +138,12 @@ function PoolChartsContent({ ...props }: any) {
                   />
                   {showReclammChart && (
                     <ReversedToggleButton toggleIsReversed={toggleIsReversed} tokenPair={tokens} />
+                  )}
+                  {showLiquidityProfileChart && (
+                    <ReversedToggleButton
+                      toggleIsReversed={toggleIsReversedEclp}
+                      tokenPair={tokensEclp}
+                    />
                   )}
                   {showPoolCharts && <PeriodSelect />}
                 </HStack>

--- a/packages/lib/modules/reclamm/ReclAmmChart.tsx
+++ b/packages/lib/modules/reclamm/ReclAmmChart.tsx
@@ -1,14 +1,12 @@
-import { ReversedToggleButton } from '@repo/lib/shared/components/btns/ReversedToggleButton'
 import { Box } from '@chakra-ui/react'
 import { useReclAmmChart } from './ReclAmmChartProvider'
 import ReactECharts from 'echarts-for-react'
 import { useRef, useEffect } from 'react'
 
 export function ReclAmmChart() {
-  const { options, toggleIsReversed, setChartInstance } = useReclAmmChart()
+  const { options, setChartInstance } = useReclAmmChart()
   const chartRef = useRef<any>(null)
 
-  // When the chart instance is available, store it in the context
   useEffect(() => {
     if (chartRef.current && chartRef.current.getEchartsInstance) {
       const instance = chartRef.current.getEchartsInstance()
@@ -20,13 +18,7 @@ export function ReclAmmChart() {
 
   return (
     <Box h="full" position="relative" w="full">
-      <ReactECharts
-        className="reclamm-chart"
-        option={options}
-        ref={chartRef}
-        style={{ height: '100%', width: '100%' }}
-      />
-      <ReversedToggleButton toggleIsReversed={toggleIsReversed} />
+      <ReactECharts option={options} style={{ height: '100%', width: '100%' }} />
     </Box>
   )
 }

--- a/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
+++ b/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
@@ -9,7 +9,7 @@ import { useBreakpoints } from '@repo/lib/shared/hooks/useBreakpoints'
 import { useSelectColor } from '@repo/lib/shared/hooks/useSelectColor'
 import { getPoolActionableTokens } from '@repo/lib/modules/pool/pool-tokens.utils'
 import { usePool } from '@repo/lib/modules/pool/PoolProvider'
-import { useBreakpointValue, useColorMode } from '@chakra-ui/react'
+import { useColorMode } from '@chakra-ui/react'
 
 type ReclAmmChartContextType = ReturnType<typeof useReclAmmChartLogic>
 
@@ -34,12 +34,6 @@ export function useReclAmmChartLogic() {
   const selectColor = useSelectColor()
   const { pool } = usePool()
   const { colorMode } = useColorMode()
-
-  const dynamicXAxisNamePadding = useBreakpointValue({
-    base: [0, 30, -128, 0],
-    md: [0, 30, -128, 0],
-    lg: [0, 24, -75, 0],
-  }) || [0, 24, -80, 0]
 
   const secondaryFontColor = selectColor('font', 'secondary')
   const highlightFontColor = selectColor('font', 'highlight')
@@ -192,7 +186,7 @@ export function useReclAmmChartLogic() {
     const totalBars = 2 * baseGreyBarCount + 2 * baseOrangeBarCount + baseGreenBarCount
 
     // for some reason the number of orange (or green) bars matters to echarts in the grid
-    const gridBottomDesktop = baseOrangeBarCount % 2 === 0 ? '19.5%' : '8%'
+    const gridBottomDesktop = baseOrangeBarCount % 2 === 0 ? '19.5%' : '3%'
     const gridBottomMobile =
       baseOrangeBarCount % 2 === 0 && !(showMinMaxValues && !showTargetValues) ? '24.5%' : '16%'
 
@@ -454,16 +448,6 @@ export function useReclAmmChartLogic() {
               padding: [showMinMaxValues && !showTargetValues ? 0 : 110, 10, 0, 0],
             },
           },
-        },
-        name: `Price: ${tokens}`,
-        nameLocation: 'end',
-        nameGap: 5,
-        nameTextStyle: {
-          align: 'right',
-          verticalAlign: 'bottom',
-          padding:
-            showMinMaxValues && !showTargetValues ? [0, 30, -85, 0] : dynamicXAxisNamePadding,
-          color: secondaryFontColor,
         },
       },
       yAxis: {
@@ -774,6 +758,7 @@ export function useReclAmmChartLogic() {
     inRangeText,
     inRangeReadjustingText,
     isPoolWithinRange: currentChartData.isPoolWithinRange,
+    tokens,
     setChartInstance,
   }
 }

--- a/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
+++ b/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
@@ -186,7 +186,7 @@ export function useReclAmmChartLogic() {
     const totalBars = 2 * baseGreyBarCount + 2 * baseOrangeBarCount + baseGreenBarCount
 
     // for some reason the number of orange (or green) bars matters to echarts in the grid
-    const gridBottomDesktop = baseOrangeBarCount % 2 === 0 ? '19.5%' : '3%'
+    const gridBottomDesktop = baseOrangeBarCount % 2 === 0 ? '19.5%' : '1%'
     const gridBottomMobile =
       baseOrangeBarCount % 2 === 0 && !(showMinMaxValues && !showTargetValues) ? '24.5%' : '16%'
 

--- a/packages/lib/shared/components/btns/ReversedToggleButton.tsx
+++ b/packages/lib/shared/components/btns/ReversedToggleButton.tsx
@@ -1,28 +1,38 @@
-import { Button } from '@chakra-ui/react'
+import { Button, Flex, Text } from '@chakra-ui/react'
 import { Icon } from '@chakra-ui/react'
 import { Repeat } from 'react-feather'
 
-export function ReversedToggleButton({ toggleIsReversed }: { toggleIsReversed: () => void }) {
+interface ReversedToggleButtonProps {
+  toggleIsReversed: () => void
+  tokenPair?: string
+}
+
+export function ReversedToggleButton({ toggleIsReversed, tokenPair }: ReversedToggleButtonProps) {
   return (
     <Button
-      bottom={0}
       cursor="pointer"
       fontSize="xs"
       fontWeight="medium"
-      height="20px !important"
-      minWidth="20px !important"
+      height="28px !important"
+      minWidth={tokenPair ? 'auto' : '20px !important'}
+      ml={0.5}
       onClick={toggleIsReversed}
-      p="0 !important"
-      position="absolute"
-      right={0}
+      px={tokenPair ? '2' : '0 !important'}
+      py="0 !important"
       rounded="sm !important"
       shadow="md"
       size="xs"
-      variant="primary"
-      width="20px !important"
-      zIndex={1}
+      variant="tertiary"
+      width={tokenPair ? 'auto' : '20px !important'}
     >
-      <Icon as={Repeat} />
+      <Flex alignItems="center" gap="1.5">
+        <Icon as={Repeat} />
+        {tokenPair && (
+          <Text fontSize="xs" fontWeight="medium">
+            {tokenPair}
+          </Text>
+        )}
+      </Flex>
     </Button>
   )
 }


### PR DESCRIPTION
This repositions the toggle button to the top. This keeps the layout cleaner and keeps all interactive chart components near the top. It also allows use to use more vertical space for the chart itself.

- Create a new token toggle button
- Position it besides the chart tabs ButtonGroup (where the time period selector is placed for Vol, TVL, Fees)
- Remove the labels positioned at the bottom within the chart providers
- Make the layout with toggle responsive and mobile friendly

**reCLAMMs:**

<img width="1844" height="2264" alt="cs 2025-07-16 at 16 00 25@2x" src="https://github.com/user-attachments/assets/bb735343-665e-44de-83a1-40b2ba088c2a" />

**ECLPs:**

<img width="1844" height="2276" alt="cs 2025-07-16 at 16 00 34@2x" src="https://github.com/user-attachments/assets/113a3b3f-ed9d-4018-91f2-312319f59f53" />
