### PR TITLE
Bring back randomized promo banners

### DIFF
--- a/packages/lib/shared/components/promos/PromoBanners.tsx
+++ b/packages/lib/shared/components/promos/PromoBanners.tsx
@@ -22,7 +22,7 @@ import { PromoBoostedIcon } from '../icons/promos/PromoBoostedIcon'
 import { PromoReclammIcon } from '../icons/promos/PromoReclammIcon'
 import { PromoItem } from '@repo/lib/config/config.types'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
-// import { getRandomInt } from '@repo/lib/shared/utils/numbers'
+import { getRandomInt } from '@repo/lib/shared/utils/numbers'
 
 function getIconElement(icon: string) {
   switch (icon) {
@@ -49,8 +49,7 @@ const promoData: (PromoItem & { iconElement: React.ReactNode })[] =
 
 export function PromoBanners() {
   const { colorMode } = useColorMode()
-  // const [activeIndex, setActiveIndex] = useState(getRandomInt(0, promoData.length - 1)) // random selection
-  const [activeIndex, setActiveIndex] = useState(0) // temporarily used for feature launches
+  const [activeIndex, setActiveIndex] = useState(getRandomInt(0, promoData.length - 1))
   const isSmallScreen = useBreakpointValue({ base: true, md: false }, { fallback: 'md' }) ?? false
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 


### PR DESCRIPTION

- Randomize the promo banners again
- The promo banners were set to display the reCLAMM banner first by default for the launch.