### PR TITLE
fix: use project name in merkl rewards alert

### DIFF
--- a/packages/lib/modules/portfolio/merkl/MerklAlert.tsx
+++ b/packages/lib/modules/portfolio/merkl/MerklAlert.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, Flex, Alert, Button, HStack, Link } from '@chakra-ui/react'
 import { LightbulbIcon } from '@repo/lib/shared/components/icons/LightbulbIcon'
 import { ArrowUpRight } from 'react-feather'
+import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
 export function MerklAlert() {
   return (
@@ -24,7 +25,7 @@ function MerklTitle() {
           <LightbulbIcon height="24" width="24" />
         </Box>
         <Text color="font.dark" fontWeight="medium">
-          You may have additional claimable Merkl rewards from your Balancer activity
+          {`You may have additional claimable Merkl rewards from your ${PROJECT_CONFIG.projectName} activity`}
         </Text>
       </HStack>
       <Button


### PR DESCRIPTION
<img width="602" height="83" alt="image" src="https://github.com/user-attachments/assets/33ae6e7c-36de-4d8e-83bc-fb4a26b8aa3a" />
<img width="582" height="83" alt="image" src="https://github.com/user-attachments/assets/24d7ec2d-2eab-44e5-a28d-c7abfcca052b" />
