### PR TITLE
fix: scale back tokens with a rate provider in reclamms

### DIFF
--- a/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
+++ b/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
@@ -94,14 +94,27 @@ export function useReclAmmChartLogic() {
       virtualBalanceB: vBalanceB,
     })
 
-    let minPriceValue = bn(virtualBalanceB).pow(2).div(invariant).toNumber()
-    let maxPriceValue = bn(invariant).div(bn(virtualBalanceA).pow(2)).toNumber()
+    // reclamm will use underlying for tokens with a rate provider so we need to scale back here
+    const rateProviderScaleBackFactor = bn(pool.poolTokens[0].priceRate).div(
+      pool.poolTokens[1].priceRate
+    )
 
-    let lowerMarginValue = bn(invariant).div(bn(lowerMargin).pow(2)).toNumber()
-    let upperMarginValue = bn(invariant).div(bn(upperMargin).pow(2)).toNumber()
+    let minPriceValue = rateProviderScaleBackFactor
+      .times(bn(virtualBalanceB).pow(2).div(invariant))
+      .toNumber()
+    let maxPriceValue = rateProviderScaleBackFactor
+      .times(bn(invariant).div(bn(virtualBalanceA).pow(2)))
+      .toNumber()
 
-    let currentPriceValue = bn(bn(balanceB).plus(virtualBalanceB))
-      .div(bn(balanceA).plus(virtualBalanceA))
+    let lowerMarginValue = rateProviderScaleBackFactor
+      .times(bn(invariant).div(bn(lowerMargin).pow(2)))
+      .toNumber()
+    let upperMarginValue = rateProviderScaleBackFactor
+      .times(bn(invariant).div(bn(upperMargin).pow(2)))
+      .toNumber()
+
+    let currentPriceValue = rateProviderScaleBackFactor
+      .times(bn(bn(balanceB).plus(virtualBalanceB)).div(bn(balanceA).plus(virtualBalanceA)))
       .toNumber()
 
     if (isReversed) {

--- a/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
+++ b/packages/lib/modules/reclamm/ReclAmmChartProvider.tsx
@@ -124,13 +124,14 @@ export function useReclAmmChartLogic() {
       const invertedMaxPriceValue = invert(minPriceValue)
       const invertedLowerMarginValue = invert(upperMarginValue)
       const invertedUpperMarginValue = invert(lowerMarginValue)
+      const invertedCurrentPriceValue = invert(currentPriceValue)
 
       // Swap min/max and lower/upper
       minPriceValue = invertedMinPriceValue
       maxPriceValue = invertedMaxPriceValue
       lowerMarginValue = invertedLowerMarginValue
       upperMarginValue = invertedUpperMarginValue
-      currentPriceValue = invert(currentPriceValue)
+      currentPriceValue = invertedCurrentPriceValue
     }
 
     const isPoolWithinRange =


### PR DESCRIPTION
for tokens with a rate provider reclamm uses the underlying to calculate all price values
however in the ui we want to show the rate for the LST token(s) so we need to scale back using the price rate