### PR TITLE
Reclamm: fix price chart for pools w/ rate & w/o erc4626

### DIFF
--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -344,3 +344,8 @@ export function getRandomInt(min: number, max: number): number {
 export const safeToNumber = (val: string | number | undefined | null): number => {
   return isValidNumber(val) ? toNumber(val) : 0
 }
+
+// take the reciprocal of a number
+export function invert(value: number): number {
+  return value === 0 ? 0 : 1 / value
+}


### PR DESCRIPTION
Fixes #1400 


### Summary
By default, reclamm price chart shows pricing in underlying. However, if a token has a rate but is NOT an erc4626, we want to show the rate scaled pricing (i.e. `wstETH`)

### Reference Pools
**pool w/ erc4626:**
https://mono-frontend-v3-git-1400-reclamm-price-chart-balancer.vercel.app/pools/ethereum/v3/0x6cc9ef68864cd4c2af5a40ffb027c4b5428674a1

**pool w/o erc4626:**
https://mono-beets-v3-git-1400-reclamm-price-chart-beethovenx.vercel.app/pools/sonic/v3/0xbdc8ec2f249c37ce3a84177b9da6660b3659d60a

**pool w/ erc4626 where underlying also has rate ( combined rate provider ):**
- maybe fetch rate on chain for underlying token?
- the `priceRate` from API will be for the erc4626

### Questions
- should we fetch on chain for token rates? ( API `priceRate` seems a bit stale )