### PR TITLE
Fix e2e tests

### DIFF
--- a/packages/e2e-tests/tests/dev/swap.spec.ts
+++ b/packages/e2e-tests/tests/dev/swap.spec.ts
@@ -1,4 +1,4 @@
-import { impersonate, setForkBalances } from '@/helpers/e2e.helpers'
+import { impersonate } from '@/helpers/e2e.helpers'
 import { expect, test } from '@playwright/test'
 import { defaultAnvilAccount } from '@repo/lib/test/utils/wagmi/fork.helpers'
 


### PR DESCRIPTION
the account that is being impersonated on fork has no balance of native asset `ETH` so changed to swap `WETH` for `USDC`

also i think `USDC` selector was broken because of recent API changes to token list. 

selecting the little button at the top now

<img width="1839" height="829" alt="image" src="https://github.com/user-attachments/assets/1f4473c9-5cbe-4127-a9ed-97246c75c7a7" />
