### PR TITLE
Allow gas BPT approvals when the wallet does not allow signatures

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/handlers/BoostedUnbalancedAddLiquidityV3.handler.integration.spec.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/handlers/BoostedUnbalancedAddLiquidityV3.handler.integration.spec.ts
@@ -14,7 +14,7 @@ describe('When adding unbalanced liquidity for a V3 BOOSTED pool', async () => {
   const handler = selectAddLiquidityHandler(v3Pool) as BoostedUnbalancedAddLiquidityV3Handler
 
   const humanAmountsIn: HumanTokenAmountWithAddress[] = [
-    { humanAmount: '1', tokenAddress: usdcAddress, symbol: 'USDC' },
+    { humanAmount: '0', tokenAddress: usdcAddress, symbol: 'USDC' },
     { humanAmount: '1', tokenAddress: usdtAddress, symbol: 'USDT' },
   ]
 

--- a/packages/lib/modules/pool/actions/remove-liquidity/useBptTokenApprovals.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/useBptTokenApprovals.tsx
@@ -7,6 +7,7 @@ import { Address } from 'viem'
 import { useTokenApprovalSteps } from '@repo/lib/modules/tokens/approvals/useTokenApprovalSteps'
 import { SdkQueryRemoveLiquidityOutput } from './remove-liquidity.types'
 import { NestedProportionalQueryRemoveLiquidityOutput } from './handlers/NestedProportionalRemoveLiquidity.handler'
+import { useUserSettings } from '@repo/lib/modules/user/settings/UserSettingsProvider'
 
 /*
   Only used by useRemoveLiquiditySteps to get the BPT approval when removing V3 liquidity when signatures are disabled (or when using a Safe account)
@@ -16,6 +17,7 @@ export function useBptTokenApprovals(
   simulationQuery: RemoveLiquiditySimulationQueryResult
 ): { isLoadingTokenApprovalSteps: boolean; tokenApprovalSteps: TransactionStep[] } {
   const isSafeAccount = useIsSafeAccount()
+  const { shouldUseSignatures } = useUserSettings()
   const { spenderAddress, rawAmount } = getSimulationQueryData(simulationQuery)
 
   const bptAmount: RawAmount = {
@@ -30,7 +32,7 @@ export function useBptTokenApprovals(
       chain: pool.chain,
       approvalAmounts: [bptAmount],
       actionType: 'RemoveLiquidity',
-      enabled: isSafeAccount,
+      enabled: !shouldUseSignatures || isSafeAccount,
     })
 
   return { isLoadingTokenApprovalSteps, tokenApprovalSteps }

--- a/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquiditySteps.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/useRemoveLiquiditySteps.tsx
@@ -39,6 +39,7 @@ export function useRemoveLiquiditySteps(params: RemoveLiquidityStepParams): Tran
 
   // Only used for v3 pools + Safe account scenario
   // Standard permit signatures are not supported by Safe accounts (signer != owner) so we use an Approval BPT Tx step instead
+  // Also used when not allowing signatures in settings
   const { isLoadingTokenApprovalSteps, tokenApprovalSteps } = useBptTokenApprovals(
     pool,
     simulationQuery


### PR DESCRIPTION
Bug that didn't allow to remove liquidity if signatures where disabled in settings.