### PR TITLE
[#48] add margin for worst case scenario on pool activity chart

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolActivityChart/PoolActivityChart.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivityChart/PoolActivityChart.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import ReactECharts from 'echarts-for-react'
 import { Box, Divider, HStack, Skeleton, Text, useTheme } from '@chakra-ui/react'
 import { usePoolActivityChart } from './usePoolActivityChart'
@@ -45,7 +43,7 @@ export function PoolActivityChart() {
       {chartOption && (
         <Box>
           <motion.div
-            animate={{ height: chartHeight, opacity: isExpanded ? [0, 1] : 1 }}
+            animate={{ height: chartHeight, opacity: [0, 1] }}
             initial={{ height: 90 }}
             transition={{ duration: 0.2, ease: easeOut }}
           >
@@ -58,13 +56,10 @@ export function PoolActivityChart() {
           </motion.div>
         </Box>
       )}
-      {isExpanded && (
-        <AnimateOpacity>
-          <Divider mb="4" pt="2" />
-        </AnimateOpacity>
-      )}
+
       {!isLoading && isExpanded && (
         <AnimateOpacity>
+          <Divider mb="4" pt="2" />
           <HStack px={['1', '2']} spacing="4">
             {legendTabs.map((tab, index) => (
               <HStack alignItems="center" gap="2" key={index}>

--- a/packages/lib/modules/pool/PoolDetail/PoolActivityChart/usePoolActivityChart.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolActivityChart/usePoolActivityChart.tsx
@@ -48,8 +48,8 @@ const getDefaultPoolActivityChartOptions = (
   return {
     grid: {
       left: isExpanded ? (isMobile ? '15%' : '60') : '2.5%',
-      right: '10',
-      top: '7.5%',
+      right: '40', // Smallest margin for worst case scenario (big ball at the edge)
+      top: '40',
       bottom: isExpanded ? '10.5%' : '50%',
       containLabel: false,
     },


### PR DESCRIPTION
Closes #48 

Pool https://balancer.fi/pools/ethereum/v3/0x57c23c58b1d8c3292c15becf07c62c5c52457a42 is an example where circles get cut off in the expanded and collapsed states.