### PR TITLE
Avoid showing token icons when they are not available

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolStats/PoolSnapshot/PoolSnapshotValues.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolStats/PoolSnapshot/PoolSnapshotValues.tsx
@@ -20,12 +20,17 @@ type PoolStatsValues = {
 }
 
 export function PoolSnapshotValues() {
-  const { chain, pool, tvl } = usePool()
+  const { chain, pool, tvl, isLoading: isLoadingPool } = usePool()
   const { toCurrency } = useCurrency()
 
   const MemoizedMainAprTooltip = memo(MainAprTooltip)
 
-  const { tokens, weeklyRewards, weeklyRewardsByToken } = useGetPoolRewards(pool)
+  const {
+    tokens,
+    weeklyRewards,
+    weeklyRewardsByToken,
+    isLoading: isLoadingTokens,
+  } = useGetPoolRewards(pool)
 
   const poolStatsValues: PoolStatsValues | undefined = pool
     ? {
@@ -47,10 +52,13 @@ export function PoolSnapshotValues() {
           <Text fontSize="sm" fontWeight="semibold" mt="xxs" variant="secondary">
             TVL
           </Text>
-          {poolStatsValues ? (
-            <PoolTotalLiquidityDisplay size="h4" totalLiquidity={poolStatsValues.totalLiquidity} />
-          ) : (
+          {isLoadingPool && !Number(tvl) ? ( // Only show loading state when we have no TVL
             <Skeleton height="28px" w="100px" />
+          ) : (
+            <PoolTotalLiquidityDisplay
+              size="h4"
+              totalLiquidity={poolStatsValues?.totalLiquidity || ''}
+            />
           )}
         </VStack>
       </FadeInOnView>
@@ -107,7 +115,11 @@ export function PoolSnapshotValues() {
           {poolStatsValues ? (
             <HStack>
               <Heading size="h4">
-                {poolStatsValues.weeklyRewards ? poolStatsValues.weeklyRewards : 'N/A'}
+                {isLoadingTokens ? (
+                  <Skeleton height="8" width="28" />
+                ) : (
+                  poolStatsValues.weeklyRewards
+                )}
               </Heading>
               <TokenStackPopover
                 chain={chain}
@@ -115,7 +127,13 @@ export function PoolSnapshotValues() {
                 rewardsByToken={weeklyRewardsByToken}
                 tokens={tokens}
               >
-                <TokenIconStack chain={chain} disablePopover size={20} tokens={tokens} />
+                <TokenIconStack
+                  chain={chain}
+                  disablePopover
+                  isLoading={isLoadingTokens}
+                  size={20}
+                  tokens={tokens}
+                />
               </TokenStackPopover>
             </HStack>
           ) : (

--- a/packages/lib/modules/tokens/TokenIconStack.tsx
+++ b/packages/lib/modules/tokens/TokenIconStack.tsx
@@ -1,4 +1,4 @@
-import { Box, HStack, StackProps } from '@chakra-ui/react'
+import { Box, HStack, SkeletonCircle, StackProps } from '@chakra-ui/react'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { ApiToken } from './token.types'
 import { TokenIcon } from './TokenIcon'
@@ -14,6 +14,7 @@ type Props = {
   size?: number
   tokenBalances?: TokenBalances
   tokens: ApiToken[]
+  isLoading?: boolean
 }
 
 export function TokenIconStack({
@@ -21,6 +22,7 @@ export function TokenIconStack({
   disablePopover,
   size = 64,
   tokens,
+  isLoading,
   ...rest
 }: Props & StackProps) {
   const getNestingMargin = () => {
@@ -40,19 +42,23 @@ export function TokenIconStack({
             borderColor="background.base"
             borderRadius="100%"
             height={`${size + 4}px`}
-            key={tokenAddress + i}
+            key={`icon-${i}`}
             ml={i > 0 ? getNestingMargin() : 0}
             width={`${size + 4}px`}
             zIndex={9 - i}
           >
-            <TokenIcon
-              address={tokenAddress}
-              alt={token?.symbol || tokenAddress}
-              chain={chain}
-              disablePopover={disablePopover}
-              logoURI={token?.logoURI}
-              size={size}
-            />
+            {isLoading ? (
+              <SkeletonCircle size={`${size + 4}px`} />
+            ) : (
+              <TokenIcon
+                address={tokenAddress}
+                alt={token?.symbol || tokenAddress}
+                chain={chain}
+                disablePopover={disablePopover}
+                logoURI={token?.logoURI}
+                size={size}
+              />
+            )}
           </Box>
         )
       })}

--- a/packages/lib/modules/tokens/TokenStackPopover.tsx
+++ b/packages/lib/modules/tokens/TokenStackPopover.tsx
@@ -15,6 +15,7 @@ import TokenRow from './TokenRow/TokenRow'
 import { Address } from 'viem'
 import { Numberish } from '@repo/lib/shared/utils/numbers'
 import { useBreakpoints } from '@repo/lib/shared/hooks/useBreakpoints'
+import { hasDefinedValues } from '@repo/lib/shared/utils/array'
 
 type RewardsByToken = {
   [address: string]: Numberish
@@ -37,7 +38,7 @@ export function TokenStackPopover({
 }: TokenStackPopoverProps) {
   const { isMobile } = useBreakpoints()
 
-  if (!tokens || tokens.length === 0) {
+  if (!hasDefinedValues(tokens)) {
     return <>{children}</>
   }
 

--- a/packages/lib/shared/utils/array.ts
+++ b/packages/lib/shared/utils/array.ts
@@ -3,3 +3,7 @@ import { uniq } from 'lodash'
 export function allEqual<T>(array: T[]): boolean {
   return uniq(array).length === 1
 }
+
+export function hasDefinedValues<T>(array: T[]) {
+  return array.filter(value => value !== undefined).length > 0
+}


### PR DESCRIPTION
A non existent token appeared on the weekly incentives at pool detail page.

<img width="397" height="311" alt="Screenshot 2025-08-12 at 18 32 38" src="https://github.com/user-attachments/assets/3019143c-32e1-41f1-a9d5-101414d81547" />

https://balancer.fi/pools/ethereum/v3/0x6c5972311191097d002e804a9bf97c96c54059ed