### PR TITLE
fix: portfolio page with range aprs

### DIFF
--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
@@ -30,7 +30,7 @@ import { usePortfolioSorting } from './usePortfolioSorting'
 
 const rowProps = (addExtraColumn: boolean, needsLastColumnWider: boolean) => ({
   px: [0, 4],
-  gridTemplateColumns: `32px minmax(320px, 1fr) minmax(140px, max-content) minmax(100px, max-content) 126px ${addExtraColumn ? '120px' : ''} ${needsLastColumnWider ? '150px' : 'minmax(100px, max-content)'}`,
+  gridTemplateColumns: `32px minmax(320px, 1fr) minmax(140px, max-content) minmax(100px, max-content) 126px ${addExtraColumn ? '120px' : ''} ${needsLastColumnWider ? '160px' : 'minmax(100px, max-content)'}`,
   alignItems: 'center',
   gap: { base: 'xxs', xl: 'lg' },
 })


### PR DESCRIPTION
pools with an apr which has a range break the layout

before:
<img width="1340" height="223" alt="image" src="https://github.com/user-attachments/assets/9b14c7f6-6adb-4479-bf10-b3a5a13f84be" />

after:
<img width="1323" height="196" alt="image" src="https://github.com/user-attachments/assets/1656f988-1a58-45b7-99f8-4f58de7378c1" />

