### PR TITLE
fix: pool weight chart legend colors

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChart.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChart.tsx
@@ -72,6 +72,22 @@ export const DEFAULT_POOL_WEIGHT_CHART_COLORS: PoolWeightChartColorDef[] = [
     from: '#30CEF0',
     to: '#02A2FE',
   },
+  {
+    from: '#9C68AA',
+    to: '#C03BE4',
+  },
+  {
+    from: '#FFBD91',
+    to: '#FF957B',
+  },
+  {
+    from: '#30CEF0',
+    to: '#02A2FE',
+  },
+  {
+    from: '#30CEF0',
+    to: '#02A2FE',
+  },
 ]
 
 const defaultColor: PoolWeightChartColorDef = {

--- a/packages/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChartLegend.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolWeightCharts/PoolWeightChartLegend.tsx
@@ -10,7 +10,7 @@ export default function PoolWeightChartLegend({
   colors?: PoolWeightChartColorDef[]
 }) {
   return (
-    <HStack mt="4" spacing="4" zIndex={2}>
+    <HStack justify="center" mt="4" spacing="4" wrap="wrap" zIndex={2}>
       {displayTokens.map((token, i) => {
         return (
           <Box


### PR DESCRIPTION
because of the nested pools this pool has a lot of tokens to display: https://balancer.fi/pools/arbitrum/v3/0x84efc4f8e9f15c29674e87b48a0b560bb1b67c26
so there weren't enough colors for all in the legend

- add more colors to prevent undefined
- wrap and center the legend items