### PR TITLE
fix: update broken TESTING.md link in beets-frontend-v3 README

### DIFF
--- a/apps/beets-frontend-v3/README.md
+++ b/apps/beets-frontend-v3/README.md
@@ -63,7 +63,7 @@ pnpm dev:beets:webpack
 
 ## Testing
 
-See [TESTING.md](../../packages/lib/test/TESTING.md).
+See [Testing instructions](../../README.md#testing).
 
 ## Developing in Windows
 


### PR DESCRIPTION
Fix broken link to TESTING.md in beets-frontend-v3 README by pointing 
to the correct location in packages/lib/test/TESTING.md