### PR TITLE
Wait for tokens to be loaded before showing vebal manage page

### DIFF
--- a/apps/frontend-v3/app/(app)/vebal/manage/layout.tsx
+++ b/apps/frontend-v3/app/(app)/vebal/manage/layout.tsx
@@ -8,7 +8,9 @@ import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { TransactionStateProvider } from '@repo/lib/modules/transactions/transaction-steps/TransactionStateProvider'
 
 export default function VeBALManageLayout({ children }: PropsWithChildren) {
-  const { vebalBptToken } = useTokens()
+  const { vebalBptToken, isLoadingTokens } = useTokens()
+
+  if (isLoadingTokens) return undefined
 
   if (!vebalBptToken) throw new Error('vebalBptToken not found')
 


### PR DESCRIPTION
There was an error shown when going directly to the `vebal/manage` page.