### PR TITLE
fix: show staking popup for Optimism on Beets

### DIFF
--- a/packages/lib/modules/pool/PoolDetail/PoolMyLiquidity.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolMyLiquidity.tsx
@@ -502,10 +502,18 @@ function StakeButton({ pool }: StakeButtonProps) {
   // Optimism is a Beets & Balancer collaboration with Balancer & Aura staking
   const isBeetsAndOptimism = isBeets && pool.chain === GqlChain.Optimism
 
+  // networks where Aura is NOT deployed
+  const auraNonSupportedNetworks = [
+    GqlChain.Mode,
+    GqlChain.Fraxtal,
+    GqlChain.Zkevm,
+    GqlChain.Hyperevm,
+  ]
+
   const stakeOnBalancer = () => router.push(`${pathname}/stake`)
   const stakeOnAura = () => auraDisclosure.onOpen()
 
-  if (!(isBalancer || isBeetsAndOptimism)) {
+  if (auraNonSupportedNetworks.includes(pool.chain) || !(isBalancer || isBeetsAndOptimism)) {
     return (
       <Button
         flex="1"

--- a/packages/lib/modules/pool/PoolDetail/PoolMyLiquidity.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolMyLiquidity.tsx
@@ -55,7 +55,7 @@ import {
 } from '../pool.helpers'
 import { getCanStake, migrateStakeTooltipLabel } from '../actions/stake.helpers'
 import { InfoOutlineIcon } from '@chakra-ui/icons'
-import { GqlPoolStakingType } from '@repo/lib/shared/services/api/generated/graphql'
+import { GqlChain, GqlPoolStakingType } from '@repo/lib/shared/services/api/generated/graphql'
 import { ArrowUpRight, ChevronUp } from 'react-feather'
 import { getChainId } from '@repo/lib/config/app.config'
 import {
@@ -71,7 +71,7 @@ import { BalancerIconCircular } from '@repo/lib/shared/components/icons/logos/Ba
 import { ProtocolIcon } from '@repo/lib/shared/components/icons/ProtocolIcon'
 import { Protocol } from '../../protocols/useProtocols'
 import { useVebalBoost } from '../../vebal/useVebalBoost'
-import { isBalancer } from '@repo/lib/config/getProjectConfig'
+import { isBalancer, isBeets } from '@repo/lib/config/getProjectConfig'
 
 function getTabs(isVeBalPool: boolean) {
   return [
@@ -499,10 +499,13 @@ function StakeButton({ pool }: StakeButtonProps) {
   const vebalBoost = veBalBoostMap[pool.address]
   const [, balancerMaxApr] = getTotalApr(pool.dynamicData.aprItems, vebalBoost)
 
+  // Optimism is a Beets & Balancer collaboration with Balancer & Aura staking
+  const isBeetsAndOptimism = isBeets && pool.chain === GqlChain.Optimism
+
   const stakeOnBalancer = () => router.push(`${pathname}/stake`)
   const stakeOnAura = () => auraDisclosure.onOpen()
 
-  if (!isBalancer) {
+  if (!(isBalancer || isBeetsAndOptimism)) {
     return (
       <Button
         flex="1"


### PR DESCRIPTION
- show button w/ staking options popup on Beets on Optimism
- show 'regular' stake button on Balancer on networks where Aura is not deployed