### PR TITLE
fix: apr tooltip for reclamm in portfolio

### DIFF
--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioFiltersProvider.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioFiltersProvider.tsx
@@ -12,10 +12,12 @@ import {
   StakingFilterKeyType,
   useExpandedPools,
   STAKING_FILTER_MAP,
+  ExpandedPoolInfo,
 } from './useExpandedPools'
 import { usePortfolio } from '../PortfolioProvider'
 import { poolTypeLabel } from '../../pool/pool.helpers'
 import { hasTinyBalance } from '../../pool/user-balance.helpers'
+import { removeHookDataFromPoolIfNecessary } from '@repo/lib/modules/pool/pool.utils'
 
 export type UsePortfolioFiltersResult = ReturnType<typeof usePortfolioFiltersLogic>
 
@@ -172,7 +174,7 @@ export function usePortfolioFiltersLogic() {
       filtered = filtered.filter(pool => targetPoolTypes.includes(pool.poolType))
     }
 
-    return filtered
+    return filtered.map(pool => removeHookDataFromPoolIfNecessary(pool)) as ExpandedPoolInfo[]
   }, [expandedPools, selectedNetworks, selectedPoolTypes, selectedStakingTypes])
 
   return {


### PR DESCRIPTION
in the portfolio pools list any hook which pointed to the pool itself wasn't  yet removed
this caused the apr tooltip to split swap fees when that is not neccessary
this is now fixed

before:
<img width="1413" height="282" alt="image" src="https://github.com/user-attachments/assets/813208e7-26f0-4109-9713-c7302d5333f9" />

after:
<img width="1562" height="243" alt="image" src="https://github.com/user-attachments/assets/dc2af4f6-7146-4f06-944e-2dbe462ffaae" />
