### PR TITLE
fix: make type partial

### DIFF
--- a/packages/lib/styles/token-colors.ts
+++ b/packages/lib/styles/token-colors.ts
@@ -8,7 +8,7 @@ export type TokenColorDef = {
   to: string
 }
 
-const tokenColors: Record<GqlChain, Record<Address, TokenColorDef>> = {
+const tokenColors: Partial<Record<GqlChain, Record<Address, TokenColorDef>>> = {
   [GqlChain.Mainnet]: {
     '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee': { from: '#627EEA', to: '#627EEA' }, // 'ETH'
     '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2': { from: '#627EEA', to: '#627EEA' }, // 'WETH' // FIXME!
@@ -114,7 +114,7 @@ export function getTokenColor(
   const defaultColorIndex = i === undefined ? getRandomInt(0, 15) : i
 
   return (
-    tokenColors[normalizedChain][normalizedAddress] ||
+    (tokenColors[normalizedChain] && tokenColors[normalizedChain][normalizedAddress]) ||
     DEFAULT_TOKEN_COLORS[defaultColorIndex] ||
     defaultColor
   )


### PR DESCRIPTION
api added a new chain which breaks the build (see below)
making the type partial now won't break the build in the future when the api adds new chains

```
07:39:04.849
 beets-frontend-v3:build:no-lint: ../../packages/lib/styles/token-colors.ts:11:7
07:39:04.849
 beets-frontend-v3:build:no-lint: Type error: Property '[GqlChain.Plasma]' is missing in type '{ MAINNET: { '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee': { from: string; to: string; }; '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2': { from: string; to: string; }; '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': { ...; }; ... 13 more ...; '0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f': { ...; }; }; ... 12 more ...; S...' but required in type 'Record<GqlChain, Record<`0x${string}`, TokenColorDef>>'.
07:39:04.849
```