### PR TITLE
fix: remove unusable reward tokens

### DIFF
--- a/packages/lib/modules/portfolio/PortfolioClaim/useProtocolRewards.ts
+++ b/packages/lib/modules/portfolio/PortfolioClaim/useProtocolRewards.ts
@@ -10,9 +10,6 @@ import { isBalancer } from '@repo/lib/config/getProjectConfig'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 
 export const claimableVeBalRewardsTokens: string[] = [
-  '0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2', // bb-a-USD v1
-  '0xA13a9247ea42D743238089903570127DdA72fE44', // bb-a-USD v2
-  '0xfeBb0bbf162E64fb9D0dfe186E517d84C395f016', // bb-a-USD v3
   '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
   '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
 ]


### PR DESCRIPTION
remove the (unusable) boosted tokens from the protocol revenue rewards array
this saves quite some gas on mainnet