### PR TITLE
Make Feedback options more globally available 

### DIFF
--- a/packages/lib/config/projects/balancer.ts
+++ b/packages/lib/config/projects/balancer.ts
@@ -84,6 +84,7 @@ export const ProjectConfigBalancer: ProjectConfig = {
       },
     ],
     legalLinks: [
+      { label: 'Feedback' },
       { label: 'Terms of use', href: '/terms-of-use' },
       { label: 'Privacy policy', href: '/privacy-policy' },
       { label: 'Cookies policy', href: '/cookies-policy' },

--- a/packages/lib/modules/user/UserFeedback.tsx
+++ b/packages/lib/modules/user/UserFeedback.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { Button } from '@chakra-ui/react'
+import { ThumbsUp } from 'react-feather'
+import { useAppzi } from '@repo/lib/shared/hooks/useAppzi'
+
+export function UserFeedback() {
+  const { openNpsModal } = useAppzi()
+
+  return (
+    <Button onClick={openNpsModal} p="0" variant="tertiary">
+      <ThumbsUp size={18} />
+    </Button>
+  )
+}

--- a/packages/lib/shared/components/modals/ActionModalFooter.tsx
+++ b/packages/lib/shared/components/modals/ActionModalFooter.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Button, Divider, HStack, ModalFooter, VStack, Link } from '@chakra-ui/react'
+import { Button, Divider, HStack, ModalFooter, VStack, Link, useColorMode } from '@chakra-ui/react'
 import { useStepWithTxBatch } from '@repo/lib/modules/web3/safe.hooks'
 import { useAppzi } from '@repo/lib/shared/hooks/useAppzi'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -18,6 +18,7 @@ export function SuccessActions({
   returnAction?: () => void
 }) {
   const { openNpsModal } = useAppzi()
+  const { colorMode } = useColorMode()
   const {
     options: { showVeBal },
   } = PROJECT_CONFIG
@@ -46,14 +47,20 @@ export function SuccessActions({
           </Button>
         )}
         <Button
+          _hover={{
+            color: 'font.maxContrast',
+            textDecoration: 'none',
+            background: colorMode === 'light' ? 'gray.100' : 'whiteAlpha.200',
+          }}
           as={Link}
+          fontSize="xs !important"
           href={getDiscordLink()}
           isExternal
           leftIcon={<MessageSquare size="14" />}
           size="xs"
           variant="ghost"
         >
-          Ask questions
+          Ask on Discord
         </Button>
       </HStack>
     </VStack>

--- a/packages/lib/shared/components/navs/Footer.tsx
+++ b/packages/lib/shared/components/navs/Footer.tsx
@@ -11,6 +11,7 @@ import { LinkSection } from './footer.types'
 import { ReactNode } from 'react'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { SocialIcon } from './SocialIcon'
+import { useAppzi } from '@repo/lib/shared/hooks/useAppzi'
 
 type CardContentProps = {
   linkSections: LinkSection[]
@@ -111,6 +112,8 @@ function SocialLinks({ socialLinks }: { socialLinks: AppLink[] }) {
 }
 
 function LegalLinks({ legalLinks }: { legalLinks: AppLink[] }) {
+  const { openNpsModal } = useAppzi()
+
   return (
     <HStack
       justify={{ base: 'start', lg: 'end' }}
@@ -119,17 +122,36 @@ function LegalLinks({ legalLinks }: { legalLinks: AppLink[] }) {
       w="full"
       wrap="wrap"
     >
-      {legalLinks.map(link => (
-        <Link
-          as={NextLink}
-          color="font.secondary"
-          fontSize={{ base: 'xs', md: 'sm' }}
-          href={link.href}
-          key={link.href}
-        >
-          {link.label}
-        </Link>
-      ))}
+      {legalLinks.map(link => {
+        const key = link.href || link.label
+        const isFeedback = link.label === 'Feedback'
+
+        if (isFeedback) {
+          return (
+            <Link
+              color="font.secondary"
+              cursor="pointer"
+              fontSize={{ base: 'xs', md: 'sm' }}
+              key={key}
+              onClick={openNpsModal}
+            >
+              {link.label}
+            </Link>
+          )
+        }
+
+        return (
+          <Link
+            as={NextLink}
+            color="font.secondary"
+            fontSize={{ base: 'xs', md: 'sm' }}
+            href={link.href || '#'}
+            key={key}
+          >
+            {link.label}
+          </Link>
+        )
+      })}
     </HStack>
   )
 }

--- a/packages/lib/shared/components/navs/MobileNav.tsx
+++ b/packages/lib/shared/components/navs/MobileNav.tsx
@@ -49,7 +49,7 @@ function NavLinks({ appLinks, onClick, customLinks }: NavLinkProps) {
         <Link
           alignItems="center"
           as={NextLink}
-          color={linkColorFor(link.href)}
+          color={linkColorFor(link.href || '')}
           display="flex"
           fontSize="xl"
           gap="xs"

--- a/packages/lib/shared/components/navs/NavBar.tsx
+++ b/packages/lib/shared/components/navs/NavBar.tsx
@@ -18,6 +18,7 @@ import { useThemeSettings } from '../../services/chakra/useThemeSettings'
 import { ArrowUpRight } from 'react-feather'
 import { DevToolsDrawerButton } from '@repo/lib/modules/dev-tools/DevToolsDrawer'
 import { isCowAmm } from '@repo/lib/config/getProjectConfig'
+import { UserFeedback } from '@repo/lib/modules/user/UserFeedback'
 
 type Props = {
   mobileNav?: ReactNode
@@ -60,27 +61,30 @@ function NavLinks({
 
   return (
     <HStack fontWeight="medium" spacing="lg" {...props}>
-      {appLinks.map(link => (
-        <Box as={motion.div} key={link.href} variants={fadeIn}>
-          <Link
-            as={NextLink}
-            color={linkColorFor(link.href)}
-            href={link.href}
-            isExternal={link.isExternal}
-            prefetch
-            variant="nav"
-          >
-            <HStack gap="xxs">
-              <Box as="span">{link.label}</Box>
-              {link.isExternal && (
-                <Box as="span" color="grayText" position="relative" top="-4px">
-                  <ArrowUpRight size={12} />
-                </Box>
-              )}
-            </HStack>
-          </Link>
-        </Box>
-      ))}
+      {appLinks.map(link => {
+        if (!link.href) return null
+        return (
+          <Box as={motion.div} key={link.href} variants={fadeIn}>
+            <Link
+              as={NextLink}
+              color={linkColorFor(link.href || '')}
+              href={link.href}
+              isExternal={link.isExternal}
+              prefetch
+              variant="nav"
+            >
+              <HStack gap="xxs">
+                <Box as="span">{link.label}</Box>
+                {link.isExternal && (
+                  <Box as="span" color="grayText" position="relative" top="-4px">
+                    <ArrowUpRight size={12} />
+                  </Box>
+                )}
+              </HStack>
+            </Link>
+          </Box>
+        )
+      })}
       {customLinks}
       {!isCowAmm && (isDev || isStaging) && (
         <>
@@ -164,6 +168,10 @@ export function NavActions({
     const defaultActions = [
       {
         el: <UserSettings />,
+        display: { base: 'none', lg: 'block' },
+      },
+      {
+        el: <UserFeedback />,
         display: { base: 'none', lg: 'block' },
       },
       {

--- a/packages/lib/shared/components/navs/useNav.tsx
+++ b/packages/lib/shared/components/navs/useNav.tsx
@@ -4,11 +4,12 @@ import { ReactNode } from 'react'
 import { IconType } from './SocialIcon'
 
 export type AppLink = {
-  href: string
+  href?: string
   label?: string
   icon?: ReactNode
   isExternal?: boolean
   iconType?: IconType
+  onClick?: () => void
 }
 
 export function useNav() {


### PR DESCRIPTION
Currently users can only give feedback at the end of a successful transaction. 

- This PR places feedback options persistently in the header on large screens and within the footer. 
- It also makes a minor typography bug fix for the "Ask questions" link besides the "Give feedback" action in the successful transaction screen. 