### PR TITLE
feat: add warning for external oracle rp

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -44,7 +44,7 @@ import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { AddLiquidityFormTabs } from './AddLiquidityFormTabs'
 import { UnbalancedAddError } from '@repo/lib/shared/components/errors/UnbalancedAddError'
 import { isUnbalancedAddError } from '@repo/lib/shared/utils/error-filters'
-import { supportsWethIsEth } from '../../../pool.helpers'
+import { poolHasRateProviderExternalOracle, supportsWethIsEth } from '../../../pool.helpers'
 import { UnbalancedNestedAddError } from '@repo/lib/shared/components/errors/UnbalancedNestedAddError'
 import { usePoolMetadata } from '../../../metadata/usePoolMetadata'
 import { useGetPoolRewards } from '../../../useGetPoolRewards'
@@ -179,6 +179,12 @@ function AddLiquidityMainForm() {
             <BalAlert
               content={poolMetadata.addLiquidityWarning.text}
               status={poolMetadata.addLiquidityWarning.type}
+            />
+          )}
+          {poolHasRateProviderExternalOracle(pool) && (
+            <BalAlert
+              content="This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk."
+              status="error"
             />
           )}
           {hasNoLiquidity(pool) && (

--- a/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
+++ b/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
@@ -11,6 +11,7 @@ import {
   hasReviewedHook,
   hasReviewedRateProvider,
   isV2Pool,
+  poolHasRateProviderExternalOracle,
 } from '../pool.helpers'
 import { shouldMigrateStake } from '../user-balance.helpers'
 import { VulnerabilityDataMap } from './pool-issues/PoolIssue.labels'
@@ -110,21 +111,6 @@ export function usePoolAlerts(pool: Pool) {
         alerts.push({
           identifier: `UnsafeRateProvider-${token.symbol}`,
           content: `The rate provider for ${token.symbol} has been reviewed as 'unsafe'. For your safety, you can't interact with this pool on this UI.`,
-          status: 'error',
-          isSoftWarning: true,
-        })
-      }
-
-      // Warning for tokens with an external oracle as the rate provider
-      if (
-        priceRateProviderData &&
-        priceRateProviderData?.warnings?.length &&
-        priceRateProviderData.warnings.includes('market-rate') &&
-        !alerts.find(alert => alert.identifier.startsWith('ExternalOracleRateProvider')) // one warning is enough here
-      ) {
-        alerts.push({
-          identifier: `ExternalOracleRateProvider-${token.symbol}`,
-          content: `This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk. The swap fee APR does NOT reflect expected returns. Please read through the "Pool risks" before adding liquidity to this pool.`,
           status: 'error',
           isSoftWarning: true,
         })
@@ -315,6 +301,18 @@ export function usePoolAlerts(pool: Pool) {
         isSoftWarning: false,
       })
     }
+
+    // Warning for any tokens with an external oracle as the rate provider
+    if (poolHasRateProviderExternalOracle(pool)) {
+      alerts.push({
+        identifier: 'ExternalOracleRateProvider',
+        content:
+          'This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk. The swap fee APR does NOT reflect expected returns. Please read through the "Pool risks" before adding liquidity to this pool.',
+        status: 'error',
+        isSoftWarning: true,
+      })
+    }
+
     return alerts
   }
 

--- a/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
+++ b/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
@@ -309,7 +309,7 @@ export function usePoolAlerts(pool: Pool) {
         content:
           'This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk. The swap fee APR does NOT reflect expected returns. Please read through the "Pool risks" before adding liquidity to this pool.',
         status: 'error',
-        isSoftWarning: true,
+        isSoftWarning: false,
       })
     }
 

--- a/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
+++ b/packages/lib/modules/pool/alerts/usePoolAlerts.tsx
@@ -206,7 +206,7 @@ export function usePoolAlerts(pool: Pool) {
 
           if (!hasReviewedRateProvider(nestedToken)) {
             alerts.push({
-              identifier: `NestedPriceProviderNotReviewed-${nestedToken.symbol}`,
+              identifier: `NestedRateProviderNotReviewed-${nestedToken.symbol}`,
               content: `The rate provider for ${nestedToken.symbol} in a nested pool has not been reviewed. For your safety, you can’t interact with this pool on this UI.`,
               status: 'error',
               isSoftWarning: true,
@@ -218,7 +218,7 @@ export function usePoolAlerts(pool: Pool) {
             nestedToken.priceRateProviderData?.summary !== 'safe'
           ) {
             alerts.push({
-              identifier: `UnsafeNestedPriceProvider-${nestedToken.symbol}`,
+              identifier: `UnsafeNestedRateProvider-${nestedToken.symbol}`,
               content: `The rate provider for ${nestedToken.symbol} in a nested pool has been reviewed as 'unsafe'. For your safety, you can't interact with this pool on this UI.`,
               status: 'error',
               isSoftWarning: true,

--- a/packages/lib/modules/pool/pool.helpers.ts
+++ b/packages/lib/modules/pool/pool.helpers.ts
@@ -520,3 +520,9 @@ export function poolTypeLabel(poolType: GqlPoolType) {
       return getPoolTypeLabel(poolType)
   }
 }
+
+export function poolHasRateProviderExternalOracle(pool: Pool): boolean {
+  return pool.poolTokens.some(token =>
+    token.priceRateProviderData?.warnings?.includes('market-rate')
+  )
+}


### PR DESCRIPTION
for pools where at least one token has an external oracle as the rate provider add a warning on the:

- pool detail page
- add liquidity modal

[example pool](https://balancer.fi/pools/arbitrum/v3/0xa978cc348a0b5de8bd564a1d8fe437787fd12664)

note: some pools also get this warning from metadata (so there is a duplicate warning), that will be cleaned up after merging this PR