### PR TITLE
fix: pool creator reclamm options

### DIFF
--- a/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
@@ -10,7 +10,6 @@ import { NumberInput } from '@repo/lib/shared/components/inputs/NumberInput'
 import { bn } from '@repo/lib/shared/utils/numbers'
 import { getPercentFromPrice } from '../../helpers'
 import { formatNumber } from '../../helpers'
-//import { PoolCreationCheckbox } from '../../PoolCreationCheckbox'
 import { RadioCard } from '@repo/lib/shared/components/inputs/RadioCardGroup'
 
 export function ReClammConfiguration() {

--- a/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
@@ -148,7 +148,7 @@ function ConfigOptionsGroup({
             placeholder={
               initialTargetPrice ? bn(initialTargetPrice).times(0.9).toString().slice(0, 7) : ''
             }
-            validate={(value: number) => {
+            validate={value => {
               if (Number(value) >= Number(initialTargetPrice)) {
                 return 'Range low price must be less than target price'
               }
@@ -170,7 +170,7 @@ function ConfigOptionsGroup({
             placeholder={
               initialTargetPrice ? formatNumber(bn(initialTargetPrice).times(1.1).toString()) : ''
             }
-            validate={(value: number) => {
+            validate={value => {
               if (Number(value) <= Number(initialTargetPrice)) {
                 return 'Range high price must be greater than target price'
               }
@@ -193,7 +193,7 @@ function ConfigOptionsGroup({
             isCustomTargetPrice ? getPercentFromPrice(formValue, options[1].rawValue) : ''
           }
           placeholder={options[1].displayValue.replace('%', '')}
-          validate={(value: number) => validateFn(Number.isNaN(value) ? '' : value.toString())}
+          validate={value => validateFn(Number.isNaN(value) ? '' : value.toString())}
           width="full"
         />
       ) : null}

--- a/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
@@ -111,11 +111,12 @@ function ConfigOptionsGroup({
         </BalPopover>
       </HStack>
       <SimpleGrid columns={{ base: 1, md: 3 }} spacing="md" w="full" {...radioGroupProps}>
-        {cardOptions.map(option => {
+        {cardOptions.map((option, idx) => {
           const radio = getRadioProps({ value: option.rawValue })
+          const key = `${label.replace(/\s+/g, '-')}-${idx}`
 
           return (
-            <RadioCard key={option.rawValue} {...radio} containerProps={cardContainerProps}>
+            <RadioCard key={key} {...radio} containerProps={cardContainerProps}>
               <VStack align="center" h="full" justify="center" spacing="1" textAlign="center">
                 {option.svg && <option.svg height="100%" width="100%" />}
                 <Text color="inherit" fontSize="sm">

--- a/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
@@ -130,7 +130,9 @@ function ConfigOptionsGroup({
       </SimpleGrid>
       {customOption ? (
         <Radio {...getRadioProps({ value: customOption.rawValue })} mt="2">
-          <Text>{customOption.label}</Text>
+          <Text color="font.secondary" fontSize="sm">
+            {customOption.label}
+          </Text>
         </Radio>
       ) : null}
       {isCustomPriceRange ? (

--- a/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
@@ -49,6 +49,7 @@ function ConfigOptionsGroup({
   const normalizedFormValue = formValue?.toString?.() ?? ''
   const matchedOption = options.find(option => {
     if (option.rawValue === normalizedFormValue) return true
+    if (option.rawValue === '' || normalizedFormValue === '') return false
 
     const optionNumber = Number(option.rawValue)
     const formValueNumber = Number(normalizedFormValue)

--- a/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
@@ -205,5 +205,11 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
     }
   }, [isInitialReClammConfig])
 
+  useEffect(() => {
+    if (!initialTargetPrice || !priceRangePercentage) return
+
+    updatePriceBounds(initialTargetPrice, priceRangePercentage)
+  }, [initialTargetPrice, priceRangePercentage])
+
   return [targetPrice, priceRangeBoundaries, marginBuffer, dailyPriceReadjustmentRate]
 }

--- a/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
@@ -1,7 +1,7 @@
 import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { bn } from '@repo/lib/shared/utils/numbers'
 import { ReClammConfig } from '../../types'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { formatNumber } from '../../helpers'
 import { useReClammCurrentPrice } from './useReClammCurrentPrice'
 import { SVGProps } from 'react'
@@ -36,6 +36,8 @@ export type ReClammConfigOptionsGroup = {
 
 export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
   const { poolCreationForm, reClammConfigForm } = usePoolCreationForm()
+  const lastCalculatedPriceBoundsRef = useRef({ minPrice: '', maxPrice: '' })
+
   const { poolTokens } = poolCreationForm.watch()
   const reClammConfig = reClammConfigForm.watch()
   const { initialTargetPrice, priceRangePercentage } = reClammConfig
@@ -211,21 +213,17 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
       priceRangePercentage
     )
 
-    // prevent unnecessary re-renders
     if (
-      reClammConfig.initialMinPrice === initialMinPrice &&
-      reClammConfig.initialMaxPrice === initialMaxPrice
+      lastCalculatedPriceBoundsRef.current.minPrice === initialMinPrice &&
+      lastCalculatedPriceBoundsRef.current.maxPrice === initialMaxPrice
     ) {
       return
     }
 
+    lastCalculatedPriceBoundsRef.current = { minPrice: initialMinPrice, maxPrice: initialMaxPrice }
+
     updatePriceBounds(initialTargetPrice, priceRangePercentage)
-  }, [
-    initialTargetPrice,
-    priceRangePercentage,
-    reClammConfig.initialMinPrice,
-    reClammConfig.initialMaxPrice,
-  ])
+  }, [initialTargetPrice, priceRangePercentage])
 
   return [targetPrice, priceRangeBoundaries, marginBuffer, dailyPriceReadjustmentRate]
 }

--- a/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
@@ -206,8 +206,26 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
   useEffect(() => {
     if (!initialTargetPrice || !priceRangePercentage) return
 
+    const { initialMinPrice, initialMaxPrice } = calculatePriceBounds(
+      initialTargetPrice,
+      priceRangePercentage
+    )
+
+    // prevent unnecessary re-renders
+    if (
+      reClammConfig.initialMinPrice === initialMinPrice &&
+      reClammConfig.initialMaxPrice === initialMaxPrice
+    ) {
+      return
+    }
+
     updatePriceBounds(initialTargetPrice, priceRangePercentage)
-  }, [initialTargetPrice, priceRangePercentage])
+  }, [
+    initialTargetPrice,
+    priceRangePercentage,
+    reClammConfig.initialMinPrice,
+    reClammConfig.initialMaxPrice,
+  ])
 
   return [targetPrice, priceRangeBoundaries, marginBuffer, dailyPriceReadjustmentRate]
 }

--- a/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
@@ -26,7 +26,7 @@ export type ReClammConfigOptionsGroup = {
     label: string
     displayValue: string
     rawValue: string
-    svg: React.ComponentType<SVGProps<SVGSVGElement>>
+    svg?: React.ComponentType<SVGProps<SVGSVGElement>>
   }[]
   updateFn: (rawValue: string) => void
   validateFn: (value: string) => string | boolean
@@ -86,7 +86,12 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
         rawValue: currentPricePlus5,
         svg: CurrentPricePlusFivePercentSVG,
       },
-      { label: 'Custom', displayValue: '??', rawValue: '', svg: CurrentPricePlusFivePercentSVG },
+      {
+        label: 'Or choose custom',
+        displayValue: '',
+        rawValue: '',
+        svg: CurrentPricePlusFivePercentSVG,
+      },
     ],
     updateFn: (rawValue: string) => {
       reClammConfigForm.setValue('initialTargetPrice', rawValue)
@@ -108,7 +113,7 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
       { label: 'Narrow', displayValue: '± 25.00%', rawValue: '25', svg: TargetRangeNarrowSVG },
       { label: 'Standard', displayValue: '± 50.00%', rawValue: '50', svg: TargetRangeStandardSVG },
       { label: 'Wide', displayValue: '± 75.00%', rawValue: '75', svg: TargetRangeWideSVG },
-      { label: 'Custom', displayValue: '??%', rawValue: '', svg: TargetRangeWideSVG },
+      { label: 'Or choose custom', displayValue: '', rawValue: '', svg: TargetRangeWideSVG },
     ],
     updateFn: (rawValue: string) => {
       reClammConfigForm.setValue('priceRangePercentage', rawValue)
@@ -133,7 +138,7 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
       { label: 'Narrow', displayValue: '10%', rawValue: '10', svg: MarginBufferNarrowSVG },
       { label: 'Standard', displayValue: '25%', rawValue: '25', svg: MarginBufferStandardSVG },
       { label: 'Wide', displayValue: '50%', rawValue: '50', svg: MarginBufferWideSVG },
-      { label: 'Custom', displayValue: '??%', rawValue: '', svg: MarginBufferWideSVG },
+      { label: 'Or choose custom', displayValue: '', rawValue: '', svg: MarginBufferWideSVG },
     ],
     updateFn: (rawValue: string) => {
       reClammConfigForm.setValue('centerednessMargin', rawValue)
@@ -164,7 +169,12 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
         rawValue: '75',
         svg: PriceAdjustmentRateFastSVG,
       },
-      { label: 'Custom', displayValue: '??%', rawValue: '', svg: PriceAdjustmentRateFastSVG },
+      {
+        label: 'Or choose custom',
+        displayValue: '',
+        rawValue: '',
+        svg: PriceAdjustmentRateFastSVG,
+      },
     ],
     updateFn: (rawValue: string) => {
       reClammConfigForm.setValue('priceShiftDailyRate', rawValue)

--- a/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
@@ -90,7 +90,6 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
         label: 'Or choose custom',
         displayValue: '',
         rawValue: '',
-        svg: CurrentPricePlusFivePercentSVG,
       },
     ],
     updateFn: (rawValue: string) => {
@@ -113,7 +112,7 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
       { label: 'Narrow', displayValue: '± 25.00%', rawValue: '25', svg: TargetRangeNarrowSVG },
       { label: 'Standard', displayValue: '± 50.00%', rawValue: '50', svg: TargetRangeStandardSVG },
       { label: 'Wide', displayValue: '± 75.00%', rawValue: '75', svg: TargetRangeWideSVG },
-      { label: 'Or choose custom', displayValue: '', rawValue: '', svg: TargetRangeWideSVG },
+      { label: 'Or choose custom', displayValue: '', rawValue: '' },
     ],
     updateFn: (rawValue: string) => {
       reClammConfigForm.setValue('priceRangePercentage', rawValue)
@@ -138,7 +137,7 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
       { label: 'Narrow', displayValue: '10%', rawValue: '10', svg: MarginBufferNarrowSVG },
       { label: 'Standard', displayValue: '25%', rawValue: '25', svg: MarginBufferStandardSVG },
       { label: 'Wide', displayValue: '50%', rawValue: '50', svg: MarginBufferWideSVG },
-      { label: 'Or choose custom', displayValue: '', rawValue: '', svg: MarginBufferWideSVG },
+      { label: 'Or choose custom', displayValue: '', rawValue: '' },
     ],
     updateFn: (rawValue: string) => {
       reClammConfigForm.setValue('centerednessMargin', rawValue)
@@ -173,7 +172,6 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
         label: 'Or choose custom',
         displayValue: '',
         rawValue: '',
-        svg: PriceAdjustmentRateFastSVG,
       },
     ],
     updateFn: (rawValue: string) => {


### PR DESCRIPTION
make `custom` option a regular radio instead of a checkbox

before:
<img width="549" height="395" alt="image" src="https://github.com/user-attachments/assets/4b975b90-7c81-4cdd-a3d8-c932fc790a0c" />


after:
<img width="550" height="392" alt="image" src="https://github.com/user-attachments/assets/a19f82ae-951b-41f4-82ff-3d47054ae441" />
