### PR TITLE
Ux/search UI

### DIFF
--- a/packages/lib/modules/chains/ChainSelect.tsx
+++ b/packages/lib/modules/chains/ChainSelect.tsx
@@ -37,7 +37,7 @@ function DropdownIndicator({
     <chakraComponents.DropdownIndicator {...props}>
       <HStack position="relative" right="12px">
         <Center bg="background.level4" h="24px" rounded="full" w="24px">
-          <Box color={hasBalance ? 'font.secondary' : 'font.warning'}>
+          <Box color={hasBalance ? 'font.secondary' : 'font.error'}>
             <GasIcon size={14} />
           </Box>
         </Center>

--- a/packages/lib/modules/chains/ChainSelect.tsx
+++ b/packages/lib/modules/chains/ChainSelect.tsx
@@ -3,19 +3,23 @@
 import { getChainShortName } from '@repo/lib/config/app.config'
 import { NetworkIcon } from '@repo/lib/shared/components/icons/NetworkIcon'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
-import { Box, HStack, Text } from '@chakra-ui/react'
+import { Box, HStack, Text, Center } from '@chakra-ui/react'
 import {
   GroupBase,
   chakraComponents,
   DropdownIndicatorProps,
   SingleValueProps,
 } from 'chakra-react-select'
-import { ChevronDown, Globe } from 'react-feather'
+import { ChevronDown } from 'react-feather'
 import { motion } from 'framer-motion'
 import { pulseOnceWithDelay } from '@repo/lib/shared/utils/animations'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { SelectInput, SelectOption } from '@repo/lib/shared/components/inputs/SelectInput'
-import { NativeTokenBalance } from './NativeTokenBalance'
+import { NativeTokenBalance, useHasNativeBalance } from './NativeTokenBalance'
+import { useUserAccount } from '../web3/UserAccountProvider'
+import { getGqlChain } from '@repo/lib/config/app.config'
+import { GasIcon } from '@repo/lib/shared/components/icons/GasIcon'
+import { PlugIcon } from '@repo/lib/shared/components/icons/PlugIcon'
 
 type Props = {
   value: GqlChain
@@ -26,10 +30,18 @@ type Props = {
 function DropdownIndicator({
   ...props
 }: DropdownIndicatorProps<SelectOption, false, GroupBase<SelectOption>>) {
+  const chain = (props.selectProps.value as SelectOption)?.value as GqlChain
+  const hasBalance = useHasNativeBalance(chain)
+
   return (
     <chakraComponents.DropdownIndicator {...props}>
       <HStack pr="ms">
-        <Globe size={16} />
+        <Center bg="background.level4" h="24px" rounded="full" shadow="sm" w="24px">
+          <Box color={hasBalance ? 'font.secondary' : 'font.warning'}>
+            <GasIcon size={14} />
+          </Box>
+        </Center>
+
         <ChevronDown size={16} />
       </HStack>
     </chakraComponents.DropdownIndicator>
@@ -39,22 +51,39 @@ function DropdownIndicator({
 function SingleValue({ ...props }: SingleValueProps<SelectOption, false, GroupBase<SelectOption>>) {
   return (
     <chakraComponents.SingleValue {...props}>
-      <HStack align="center" spacing="xs">
+      <HStack align="center" gap="xxs">
         <NetworkIcon chain={props.data.value} size={5} />
         <Text>{getChainShortName(props.data.value)}</Text>
-        <NativeTokenBalance chain={props.data.value} color="font.secondary" fontSize="xs" pr="1" />
+        <NativeTokenBalance
+          chain={props.data.value}
+          color="font.secondary"
+          fontSize="xs"
+          pr="1.5"
+        />
       </HStack>
     </chakraComponents.SingleValue>
   )
 }
 
 export function ChainSelect({ value, onChange, chains = PROJECT_CONFIG.supportedNetworks }: Props) {
+  const { chainId } = useUserAccount()
+  const connectedChain = chainId ? getGqlChain(chainId) : undefined
   const networkOptions: SelectOption[] = chains.map(chain => ({
     label: (
       <HStack w="full">
         <NetworkIcon chain={chain} size={6} />
-        <Text>{getChainShortName(chain)}</Text>
-        <NativeTokenBalance chain={chain} />
+        <HStack gap="xxs">
+          <Text>{getChainShortName(chain)}</Text>
+          {connectedChain === chain && (
+            <Box alignItems="center" borderRadius="full" display="inline-flex" gap="xxs" px="xxs">
+              <PlugIcon size={18} />
+              <Text color="font.secondary" fontSize="11px" opacity="0.8">
+                Connected
+              </Text>
+            </Box>
+          )}
+        </HStack>
+        <NativeTokenBalance applyOpacity chain={chain} fontSize="xs" />
       </HStack>
     ),
     value: chain,

--- a/packages/lib/modules/chains/ChainSelect.tsx
+++ b/packages/lib/modules/chains/ChainSelect.tsx
@@ -35,8 +35,8 @@ function DropdownIndicator({
 
   return (
     <chakraComponents.DropdownIndicator {...props}>
-      <HStack pr="ms">
-        <Center bg="background.level4" h="24px" rounded="full" shadow="sm" w="24px">
+      <HStack position="relative" right="12px">
+        <Center bg="background.level4" h="24px" rounded="full" w="24px">
           <Box color={hasBalance ? 'font.secondary' : 'font.warning'}>
             <GasIcon size={14} />
           </Box>
@@ -51,15 +51,10 @@ function DropdownIndicator({
 function SingleValue({ ...props }: SingleValueProps<SelectOption, false, GroupBase<SelectOption>>) {
   return (
     <chakraComponents.SingleValue {...props}>
-      <HStack align="center" gap="xxs">
+      <HStack align="center" gap="sm">
         <NetworkIcon chain={props.data.value} size={5} />
         <Text>{getChainShortName(props.data.value)}</Text>
-        <NativeTokenBalance
-          chain={props.data.value}
-          color="font.secondary"
-          fontSize="xs"
-          pr="1.5"
-        />
+        <NativeTokenBalance chain={props.data.value} color="font.secondary" fontSize="xs" pr="3" />
       </HStack>
     </chakraComponents.SingleValue>
   )

--- a/packages/lib/shared/components/icons/PlugIcon.tsx
+++ b/packages/lib/shared/components/icons/PlugIcon.tsx
@@ -1,0 +1,23 @@
+import { SVGProps } from 'react'
+
+export function PlugIcon({ size = 20, ...props }: { size?: number } & SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      fill="none"
+      height={size}
+      viewBox="0 0 20 20"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="10" cy="10" fill="" r="10" />
+      <path
+        d="M4.667 15.335 7 13m5-8.333L9.667 7.001m5.666 1L13 10.335M8.523 6 14 11.478l-1.37 1.37A3.873 3.873 0 1 1 7.155 7.37L8.524 6Z"
+        stroke="#00D395"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
Improvements to the network selector in Search:
- replace globe icon with gas icon
- give the gas icon two color states (neutral color if gas is present, red color if gas is empty).
- Add a "Connected' label and icon to the network that the user's wallet is connected to.
- Add the native token with a `–` balance to any token that the user doesn't have gas for.

<img width="3098" height="2080" alt="cs 2025-10-06 at 10 55 59@2x" src="https://github.com/user-attachments/assets/b478f346-4b15-4ff6-9423-b80a925c391c" />



