### PR TITLE
Improve MultiSelect Filter UX 

### DIFF
--- a/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -230,9 +230,11 @@ export function PoolNetworkFilters({
       </Box>
     ),
     selectedLabel: (
-      <Box rounded="full" shadow="md">
-        <Image alt={network} height="20" src={`/images/chains/${network}.svg`} width="20" />
-      </Box>
+      <HStack spacing="6px">
+        <Box h="20px" rounded="full" shadow="md" w="20px">
+          <Image alt={network} height="20" src={`/images/chains/${network}.svg`} width="20" />
+        </Box>
+      </HStack>
     ),
   }))
 
@@ -242,9 +244,12 @@ export function PoolNetworkFilters({
 
   return (
     <MultiSelect<GqlChain>
+      bg="background.level4"
       isChecked={isCheckedNetwork}
       label="All networks"
+      mb="xs"
       options={networkOptions}
+      rounded="md"
       toggleAll={() => setNetworks(null)}
       toggleOption={toggleNetwork}
     />

--- a/packages/lib/shared/components/inputs/MultiSelect.tsx
+++ b/packages/lib/shared/components/inputs/MultiSelect.tsx
@@ -55,14 +55,29 @@ export function MultiSelect<Value = string>({
         <Button h="auto" py="sm" ref={ref} variant="tertiary" w="full" {...buttonProps}>
           <HStack justify="space-between" w="full">
             {hasSelectedOptions ? (
-              <HStack spacing="xs" wrap="wrap">
-                {selectedOptions.map(option =>
-                  option.selectedLabel ? (
-                    <Box key={`selected-option-label-${option.value}`}>{option.selectedLabel}</Box>
-                  ) : (
-                    <Tag key={`selected-label-${option.value}`}>{option.label}</Tag>
-                  )
-                )}
+              <HStack overflow="hidden" spacing="6px" w="full">
+                <HStack spacing="xs">
+                  {selectedOptions.map(option =>
+                    option.selectedLabel ? (
+                      <Box key={`selected-option-label-${option.value}`}>
+                        {option.selectedLabel}
+                      </Box>
+                    ) : (
+                      <Tag key={`selected-label-${option.value}`}>{option.label}</Tag>
+                    )
+                  )}
+                </HStack>
+                <Text
+                  fontSize="sm"
+                  fontWeight="medium"
+                  isTruncated
+                  noOfLines={1}
+                  overflow="hidden"
+                  textOverflow="ellipsis"
+                  whiteSpace="nowrap"
+                >
+                  {selectedOptions.map(option => option.label).join(', ')}
+                </Text>
               </HStack>
             ) : (
               <Box fontWeight="medium">{label}</Box>


### PR DESCRIPTION
Improvements when selecting networks in the Pool List filters:
- When a network is now selected, the network name is now also displayed
- This is helpful for the user, and also makes the UI not look broken. 
- Also applies labels when multiple networks are selected.

<img width="1920" height="1506" alt="cs 2025-10-06 at 11 24 09@2x" src="https://github.com/user-attachments/assets/e90e90c9-77d2-4d35-8410-4c5a84d41ab3" />
