### PR TITLE
fix: decouple pi from token input

### DIFF
--- a/apps/beets-frontend-v3/lib/modules/lst/LstProvidersLayout.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/LstProvidersLayout.tsx
@@ -5,7 +5,6 @@ import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { PropsWithChildren } from 'react'
 import sonicNetworkConfig from '@repo/lib/config/networks/sonic'
 import { TokenInputsValidationProvider } from '@repo/lib/modules/tokens/TokenInputsValidationProvider'
-import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { LstProvider } from './LstProvider'
 import { TransactionStateProvider } from '@repo/lib/modules/transactions/transaction-steps/TransactionStateProvider'
 
@@ -26,9 +25,7 @@ export default function LstProvidersLayout({ children }: PropsWithChildren) {
       {stakingTokens.length > 0 && (
         <TokenBalancesProvider initTokens={stakingTokens}>
           <TokenInputsValidationProvider>
-            <LstProvider>
-              <PriceImpactProvider>{children}</PriceImpactProvider>
-            </LstProvider>
+            <LstProvider>{children}</LstProvider>
           </TokenInputsValidationProvider>
         </TokenBalancesProvider>
       )}

--- a/apps/beets-frontend-v3/lib/modules/reliquary/ReliquaryProvidersLayout.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/ReliquaryProvidersLayout.tsx
@@ -5,7 +5,6 @@ import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { PropsWithChildren } from 'react'
 import sonicNetworkConfig from '@repo/lib/config/networks/sonic'
 import { TokenInputsValidationProvider } from '@repo/lib/modules/tokens/TokenInputsValidationProvider'
-import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { TransactionStateProvider } from '@repo/lib/modules/transactions/transaction-steps/TransactionStateProvider'
 import { ReliquaryProvider } from './ReliquaryProvider'
 import { RelayerSignatureProvider } from '@repo/lib/modules/relayer/RelayerSignatureProvider'
@@ -28,9 +27,7 @@ export default function ReliquaryProvidersLayout({ children }: PropsWithChildren
         <Permit2SignatureProvider>
           <TokenBalancesProvider initTokens={poolTokens}>
             <TokenInputsValidationProvider>
-              <ReliquaryProvider>
-                <PriceImpactProvider>{children}</PriceImpactProvider>
-              </ReliquaryProvider>
+              <ReliquaryProvider>{children}</ReliquaryProvider>
             </TokenInputsValidationProvider>
           </TokenBalancesProvider>
         </Permit2SignatureProvider>

--- a/apps/frontend-v3/app/(app)/debug/token-input/page.tsx
+++ b/apps/frontend-v3/app/(app)/debug/token-input/page.tsx
@@ -10,7 +10,6 @@ import { TokenBalancesProvider } from '@repo/lib/modules/tokens/TokenBalancesPro
 import { ConnectWallet } from '@repo/lib/modules/web3/ConnectWallet'
 import { daiAddress } from '@repo/lib/debug-helpers'
 import { TokenInputsValidationProvider } from '@repo/lib/modules/tokens/TokenInputsValidationProvider'
-import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { ApiToken } from '@repo/lib/modules/tokens/token.types'
 
 export default function TokenInputPage() {
@@ -27,40 +26,38 @@ export default function TokenInputPage() {
 
   return (
     <TokenInputsValidationProvider>
-      <PriceImpactProvider>
-        <TokenBalancesProvider extTokens={tokens}>
-          <VStack align="start" p="md" width="sm">
-            <Heading>Token Input</Heading>
-            <Text>Current value: {currentValue}</Text>
-            <ConnectWallet />
-            <Card p="md" shadow="2xl" variant="level3">
-              <VStack spacing="md" w="full">
-                <TokenInput
-                  address={token?.address}
-                  chain={token?.chain}
-                  onChange={e => setCurrentValue(e.currentTarget.value)}
-                  toggleTokenSelect={() => {
-                    tokenSelectDisclosure.onOpen()
-                  }}
-                  value={currentValue}
-                />
-                <Button variant="primary" w="full">
-                  Submit
-                </Button>
-              </VStack>
-            </Card>
+      <TokenBalancesProvider extTokens={tokens}>
+        <VStack align="start" p="md" width="sm">
+          <Heading>Token Input</Heading>
+          <Text>Current value: {currentValue}</Text>
+          <ConnectWallet />
+          <Card p="md" shadow="2xl" variant="level3">
+            <VStack spacing="md" w="full">
+              <TokenInput
+                address={token?.address}
+                chain={token?.chain}
+                onChange={e => setCurrentValue(e.currentTarget.value)}
+                toggleTokenSelect={() => {
+                  tokenSelectDisclosure.onOpen()
+                }}
+                value={currentValue}
+              />
+              <Button variant="primary" w="full">
+                Submit
+              </Button>
+            </VStack>
+          </Card>
 
-            <TokenSelectModal
-              chain={GqlChain.Mainnet}
-              isOpen={tokenSelectDisclosure.isOpen}
-              onClose={tokenSelectDisclosure.onClose}
-              onOpen={tokenSelectDisclosure.onOpen}
-              onTokenSelect={handleTokenSelect}
-              tokens={tokens}
-            />
-          </VStack>
-        </TokenBalancesProvider>
-      </PriceImpactProvider>
+          <TokenSelectModal
+            chain={GqlChain.Mainnet}
+            isOpen={tokenSelectDisclosure.isOpen}
+            onClose={tokenSelectDisclosure.onClose}
+            onOpen={tokenSelectDisclosure.onOpen}
+            onTokenSelect={handleTokenSelect}
+            tokens={tokens}
+          />
+        </VStack>
+      </TokenBalancesProvider>
     </TokenInputsValidationProvider>
   )
 }

--- a/apps/frontend-v3/lib/vebal/lock/VebalLockActionsLayout.tsx
+++ b/apps/frontend-v3/lib/vebal/lock/VebalLockActionsLayout.tsx
@@ -7,7 +7,6 @@ import { PropsWithChildren } from 'react'
 import { VebalLockProvider } from './VebalLockProvider'
 import { useVeBalRedirectPath } from '../vebal-navigation'
 import { TokenInputsValidationProvider } from '@repo/lib/modules/tokens/TokenInputsValidationProvider'
-import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 
 type Props = PropsWithChildren
 
@@ -27,9 +26,7 @@ export function VebalLockActionsLayout({ children }: Props) {
       redirectPath={redirectPath}
     >
       <TokenInputsValidationProvider>
-        <PriceImpactProvider>
-          <VebalLockProvider>{children}</VebalLockProvider>
-        </PriceImpactProvider>
+        <VebalLockProvider>{children}</VebalLockProvider>
       </TokenInputsValidationProvider>
     </FocussedActionLayout>
   )

--- a/packages/lib/modules/lbp/steps/SaleStructureStep.tsx
+++ b/packages/lib/modules/lbp/steps/SaleStructureStep.tsx
@@ -52,7 +52,6 @@ import {
 import { TokenBalancesProvider, useTokenBalances } from '../../tokens/TokenBalancesProvider'
 import { WeightAdjustmentTypeInput } from './WeightAdjustmentTypeInput'
 import { TokenInputsValidationProvider } from '../../tokens/TokenInputsValidationProvider'
-import { PriceImpactProvider } from '../../price-impact/PriceImpactProvider'
 import { LbpFormAction } from '../LbpFormAction'
 import { CustomToken } from '../../tokens/token.types'
 import { useUserBalance } from '@repo/lib/shared/hooks/useUserBalance'
@@ -193,26 +192,23 @@ export function SaleStructureStep() {
             </VStack>
 
             <TokenInputsValidationProvider>
-              {/* TODO: Decouple PriceImpactProvider from Token input, it shouldn't be a dependency. */}
-              <PriceImpactProvider>
-                {collateralToken && (
-                  <TokenBalancesProvider extTokens={[collateralToken]}>
-                    <SaleTokenAmountInput
-                      control={control}
-                      errors={errors}
-                      launchToken={launchToken}
-                      selectedChain={selectedChain}
-                    />
-                    <CollateralTokenAmountInput
-                      collateralTokenAddress={collateralTokenAddress}
-                      collateralTokenSymbol={collateralToken?.symbol || ''}
-                      control={control}
-                      errors={errors}
-                      selectedChain={selectedChain}
-                    />
-                  </TokenBalancesProvider>
-                )}
-              </PriceImpactProvider>
+              {collateralToken && (
+                <TokenBalancesProvider extTokens={[collateralToken]}>
+                  <SaleTokenAmountInput
+                    control={control}
+                    errors={errors}
+                    launchToken={launchToken}
+                    selectedChain={selectedChain}
+                  />
+                  <CollateralTokenAmountInput
+                    collateralTokenAddress={collateralTokenAddress}
+                    collateralTokenSymbol={collateralToken?.symbol || ''}
+                    control={control}
+                    errors={errors}
+                    selectedChain={selectedChain}
+                  />
+                </TokenBalancesProvider>
+              )}
             </TokenInputsValidationProvider>
           </>
         )}

--- a/packages/lib/modules/swap/SwapForm.tsx
+++ b/packages/lib/modules/swap/SwapForm.tsx
@@ -49,6 +49,7 @@ import { useContractWallet } from '../web3/wallets/useContractWallet'
 import { useIsSafeAccount } from '../web3/safe.hooks'
 import { buildCowSwapUrl } from '../cow/cow.utils'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
+import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 
 type Props = {
   redirectToPoolPage?: () => void // Only used for pool swaps
@@ -103,6 +104,7 @@ export function SwapForm({
   const isMounted = useIsMounted()
   const { isConnected } = useUserAccount()
   const { startTokenPricePolling } = useTokens()
+  const { priceImpact, priceImpactColor, priceImpactLevel } = usePriceImpact()
 
   const isLoadingSwaps = simulationQuery.isLoading
   const isLoading = isLoadingSwaps || !isMounted
@@ -309,6 +311,12 @@ export function SwapForm({
                     simulationQuery.isLoading || !simulationQuery.data || !tokenIn.amount
                   }
                   onChange={e => setTokenOutAmount(e.currentTarget.value as HumanAmount)}
+                  // pi is only used for token out
+                  priceImpactProps={{
+                    priceImpact,
+                    priceImpactColor,
+                    priceImpactLevel,
+                  }}
                   ref={finalRefTokenOut}
                   value={tokenOut.amount}
                   {...(!isLbpSwap && {

--- a/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
+++ b/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
@@ -25,7 +25,7 @@ import { TokenIcon } from '../TokenIcon'
 import { useTokenInputsValidation } from '../TokenInputsValidationProvider'
 import { ChevronDown } from 'react-feather'
 import { WalletIcon } from '@repo/lib/shared/components/icons/WalletIcon'
-import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvider'
+import { PriceImpactLevel } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { useEffect, useState } from 'react'
 import { useIsMounted } from '@repo/lib/shared/hooks/useIsMounted'
 import { isNativeAsset } from '@repo/lib/shared/utils/addresses'
@@ -103,6 +103,12 @@ export function TokenInputSelector({
   )
 }
 
+type PriceImpactProps = {
+  priceImpact: string | number | null | undefined
+  priceImpactColor: string
+  priceImpactLevel: PriceImpactLevel
+}
+
 type TokenInputFooterProps = {
   token: ApiToken | CustomToken | undefined
   value?: string
@@ -113,6 +119,7 @@ type TokenInputFooterProps = {
   customUserBalance?: string
   isDisabled?: boolean
   customUsdPrice?: number
+  priceImpactProps: PriceImpactProps | undefined
 }
 
 function TokenInputFooter({
@@ -125,12 +132,13 @@ function TokenInputFooter({
   customUserBalance,
   isDisabled,
   customUsdPrice,
+  priceImpactProps,
 }: TokenInputFooterProps) {
   const { balanceFor, isBalancesLoading } = useTokenBalances()
   const { usdValueForToken } = useTokens()
   const { toCurrency } = useCurrency()
   const { hasValidationError, getValidationError } = useTokenInputsValidation()
-  const { priceImpact, priceImpactColor, priceImpactLevel } = usePriceImpact()
+
   const isMounted = useIsMounted()
 
   const hasError = hasValidationError(token)
@@ -148,7 +156,7 @@ function TokenInputFooter({
   const noBalance = !token || bn(userBalance).isZero()
   const _isNativeAsset = token && isNativeAsset(token.chain, token.address)
 
-  const showPriceImpact = !isLoadingPriceImpact && hasPriceImpact && priceImpact
+  const showPriceImpact = !isLoadingPriceImpact && hasPriceImpact && priceImpactProps?.priceImpact
   const hasDisabledInteraction = noBalance || _isNativeAsset || isDisabled
 
   function handleBalanceClick() {
@@ -169,13 +177,15 @@ function TokenInputFooter({
         <Skeleton h="full" w="12" />
       ) : (
         <Text
-          color={showPriceImpact ? priceImpactColor : 'font.secondary'}
+          color={showPriceImpact ? priceImpactProps?.priceImpactColor : 'font.secondary'}
           fontSize="sm"
           opacity={!priceMessage && usdValue === '0' ? 0.5 : 1}
           variant="secondary"
         >
           {priceMessage ? priceMessage : toCurrency(usdValue, { abbreviated: false })}
-          {showPriceImpact && priceImpactLevel !== 'unknown' && getPriceImpactLabel(priceImpact)}
+          {showPriceImpact &&
+            priceImpactProps?.priceImpactLevel !== 'unknown' &&
+            getPriceImpactLabel(priceImpactProps?.priceImpact)}
         </Text>
       )}
       {isBalancesLoading || !isMounted ? (
@@ -221,6 +231,7 @@ type Props = {
   disableBalanceValidation?: boolean
   customUserBalance?: string
   customUsdPrice?: number
+  priceImpactProps?: PriceImpactProps
 }
 
 export const TokenInput = forwardRef(
@@ -240,6 +251,7 @@ export const TokenInput = forwardRef(
       disableBalanceValidation = false,
       customUserBalance,
       customUsdPrice,
+      priceImpactProps,
       ...inputProps
     }: InputProps & Props,
     ref
@@ -350,6 +362,7 @@ export const TokenInput = forwardRef(
             hasPriceImpact={hasPriceImpact}
             isDisabled={inputProps.isDisabled}
             isLoadingPriceImpact={isLoadingPriceImpact}
+            priceImpactProps={priceImpactProps}
             priceMessage={priceMessage}
             token={token}
             updateValue={updateValue}

--- a/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
+++ b/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
@@ -138,7 +138,6 @@ function TokenInputFooter({
   const { usdValueForToken } = useTokens()
   const { toCurrency } = useCurrency()
   const { hasValidationError, getValidationError } = useTokenInputsValidation()
-
   const isMounted = useIsMounted()
 
   const hasError = hasValidationError(token)

--- a/packages/lib/shared/pages/PoolCreationPage.tsx
+++ b/packages/lib/shared/pages/PoolCreationPage.tsx
@@ -12,7 +12,6 @@ import { TokenBalancesProvider } from '@repo/lib/modules/tokens/TokenBalancesPro
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { TokenInputsValidationProvider } from '@repo/lib/modules/tokens/TokenInputsValidationProvider'
-import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 
 export default function PoolCreationPage() {
   return (
@@ -34,11 +33,9 @@ function PoolCreationPageContent() {
         {!isLoadingTokens && (
           <TokenInputsValidationProvider>
             <TokenBalancesProvider initTokens={initTokens}>
-              <PriceImpactProvider>
-                <Permit2SignatureProvider>
-                  <PoolCreationForm />
-                </Permit2SignatureProvider>
-              </PriceImpactProvider>
+              <Permit2SignatureProvider>
+                <PoolCreationForm />
+              </Permit2SignatureProvider>
             </TokenBalancesProvider>
           </TokenInputsValidationProvider>
         )}


### PR DESCRIPTION
price impact is only shown in the token input on the swap form
this change decouples them so that in all other places where token input is used, the price impact provider is no longer required