### PR TITLE
Remove the "Create pools" button above the Pools List

### DIFF
--- a/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -627,18 +627,20 @@ export function PoolListFilters() {
             </PopoverContent>
           </Box>
         </Popover>
-        <Button
-          as={Link}
-          display="flex"
-          gap="2"
-          href={poolCreatorUrl}
-          isExternal
-          ml="ms"
-          variant="tertiary"
-        >
-          <Icon as={Plus} boxSize={4} />
-          {!isMobile && 'Create pool'}
-        </Button>
+        {!isBalancer && (
+          <Button
+            as={Link}
+            display="flex"
+            gap="2"
+            href={poolCreatorUrl}
+            isExternal
+            ml="ms"
+            variant="tertiary"
+          >
+            <Icon as={Plus} boxSize={4} />
+            {!isMobile && 'Create pool'}
+          </Button>
+        )}
       </HStack>
     </VStack>
   )

--- a/packages/lib/shared/pages/PoolsPage/BuildPromo.tsx
+++ b/packages/lib/shared/pages/PoolsPage/BuildPromo.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { Box, Button, Center, Flex, Heading, Link, Text, HStack, Stack } from '@chakra-ui/react'
+import FadeInOnView from '@repo/lib/shared/components/containers/FadeInOnView'
+import NextLink from 'next/link'
+import { ArrowUpRight } from 'react-feather'
+import { RadialPattern } from '../../components/zen/RadialPattern'
+
+export function BuildPromo() {
+  return (
+    <Box overflow="hidden" pb="40px" position="relative" pt={{ base: '120px', md: '94px' }}>
+      <Box zIndex="-1">
+        <RadialPattern
+          bottom="-800px"
+          circleCount={12}
+          height={1200}
+          innerHeight={150}
+          innerWidth={150}
+          left="calc(50% - 600px)"
+          position="absolute"
+          width={1200}
+        />
+      </Box>
+      <Center>
+        <FadeInOnView animateOnce={false}>
+          <Flex direction="column" gap="lg" textAlign="center">
+            <Stack alignItems="center" gap="md" px="md" width="full">
+              <Heading
+                as="h2"
+                backgroundClip="text"
+                bg="background.special"
+                display="flex"
+                justifyContent="center"
+                pb="0.5"
+                size="lg"
+                width="full"
+              >
+                Ready to build on Balancer?
+              </Heading>
+              <Text
+                color="font.secondary"
+                display="flex"
+                justifyContent="center"
+                lineHeight="1.4"
+                maxWidth="38ch"
+                sx={{ textWrap: 'pretty' }}
+                textAlign="center"
+                width="full"
+              >
+                Start by creating your own pool. Or prototype your own AMM with the most extensive
+                DeFi builder toolkit.
+              </Text>
+            </Stack>
+            <Flex
+              display="flex"
+              gap="ms"
+              justifyContent="center"
+              margin="0 auto"
+              maxWidth={356}
+              width="full"
+            >
+              <Button
+                as={NextLink}
+                flex={1}
+                href="https://pool-creator.balancer.fi/"
+                rightIcon={<ArrowUpRight size="14px" />}
+                size="lg"
+                variant="primary"
+              >
+                Create a pool
+              </Button>
+              <Button
+                as={NextLink}
+                flex={1}
+                href="https://github.com/balancer/scaffold-balancer-v3"
+                rightIcon={<ArrowUpRight size="14px" />}
+                size="lg"
+                variant="tertiary"
+              >
+                Prototype on v3
+              </Button>
+            </Flex>
+            <Link
+              alignItems="center"
+              color="font.secondary"
+              display="inline-flex"
+              href="https://docs.balancer.fi/"
+              isExternal
+              justifyContent="center"
+              mt="sm"
+            >
+              <HStack gap="xxs">
+                <Text color="font.secondary" fontSize={{ base: 'sm', md: 'md' }}>
+                  View the docs
+                </Text>
+
+                <Box color="grayText">
+                  <ArrowUpRight size={12} />
+                </Box>
+              </HStack>
+            </Link>
+          </Flex>
+        </FadeInOnView>
+      </Center>
+    </Box>
+  )
+}

--- a/packages/lib/shared/pages/PoolsPage/PoolsPage.tsx
+++ b/packages/lib/shared/pages/PoolsPage/PoolsPage.tsx
@@ -16,6 +16,7 @@ import { useQuery } from '@apollo/client'
 import { GetFeaturedPoolsDocument } from '@repo/lib/shared/services/api/generated/graphql'
 import { FeaturedPools } from '@repo/lib/modules/featured-pools/FeaturedPools'
 import { isBalancer } from '@repo/lib/config/getProjectConfig'
+import { BuildPromo } from './BuildPromo'
 
 type PoolsPageProps = PropsWithChildren & {
   rewardsClaimed24h?: string
@@ -135,7 +136,7 @@ export function PoolsPage({ children, rewardsClaimed24h }: PoolsPageProps) {
         </FadeInOnView>
       </DefaultPageContainer>
       {isBalancer && (featuredPools.length > 0 || featuredPoolsLoading) && (
-        <DefaultPageContainer py="0" rounded="2xl">
+        <DefaultPageContainer mb="lg" py="0" rounded="2xl">
           <Box>
             {!featuredPoolsLoading && featuredPools.length > 0 && (
               <FeaturedPools featuredPools={featuredPools} />
@@ -144,9 +145,14 @@ export function PoolsPage({ children, rewardsClaimed24h }: PoolsPageProps) {
           </Box>
         </DefaultPageContainer>
       )}
-      <DefaultPageContainer mb="3xl" py="0" rounded="2xl">
+      <DefaultPageContainer mb="0" py="0" rounded="2xl">
         <FeaturedPartners />
       </DefaultPageContainer>
+      {isBalancer && (
+        <DefaultPageContainer mb="0" py="0" rounded="2xl">
+          <BuildPromo />
+        </DefaultPageContainer>
+      )}
     </>
   )
 }


### PR DESCRIPTION
- Placing the "Create pool" button next to the "Filters" button above the pools list was never the right position for it.
- This PR removes it from there and creates a new builder promo section at the bottom of the page.
- This is in addition to the "Create a pool" links recently added into the "Build" primary navigation link.

<img width="1472" height="2556" alt="create-pool" src="https://github.com/user-attachments/assets/5c693eba-7260-495b-a27d-baa3c4da7cbe" />
