### PR TITLE
fix: step indicator color for beets

### DIFF
--- a/apps/beets-frontend-v3/lib/services/chakra/themes/beets/colors.ts
+++ b/apps/beets-frontend-v3/lib/services/chakra/themes/beets/colors.ts
@@ -8,6 +8,10 @@ export const colors = {
     dark: '#363636',
     hslDark: '0, 0%, 17%',
   },
+  gradient: {
+    ...baseColors.gradient,
+    dawnDark: 'linear-gradient(228deg, #91E2C1 0%, #05D690 100%)',
+  },
 }
 
 export const primaryTextColor = `linear-gradient(45deg, ${colors.gray['700']} 0%, ${colors.gray['500']} 100%)`


### PR DESCRIPTION
before:
<img width="306" height="140" alt="image" src="https://github.com/user-attachments/assets/98330b7e-c4bc-4f83-bb4b-b365f1ffa1fc" />

after:
<img width="316" height="138" alt="image" src="https://github.com/user-attachments/assets/22b80aac-251b-4334-b1b4-3b7f8697134c" />