### PR TITLE
[#1670] show warning tooltip on token prices and market cap

### DIFF
--- a/packages/lib/modules/tokens/TokenMissingPriceWarning.tsx
+++ b/packages/lib/modules/tokens/TokenMissingPriceWarning.tsx
@@ -1,4 +1,4 @@
-import { HStack, Text, Tooltip } from '@chakra-ui/react'
+import { Box, HStack, Text, Tooltip } from '@chakra-ui/react'
 import { AlertTriangle } from 'react-feather'
 
 export function TokenMissingPriceWarning({ message }: { message: string }) {
@@ -6,7 +6,9 @@ export function TokenMissingPriceWarning({ message }: { message: string }) {
     <HStack color="font.warning" spacing="xs">
       <Text color="font.warning">—</Text>
       <Tooltip label={message} placement="top">
-        <AlertTriangle size={16} />
+        <Box zIndex="tooltip">
+          <AlertTriangle size={16} />
+        </Box>
       </Tooltip>
     </HStack>
   )


### PR DESCRIPTION
Closes #1670 

There is a hovering effect in the container that was consuming the events (the golden glitter of the card.