### PR TITLE
Only check for V3 vault on chains that support Balancer V3 for getting token rates

### DIFF
--- a/packages/lib/modules/eclp/hooks/useGetTokenRates.tsx
+++ b/packages/lib/modules/eclp/hooks/useGetTokenRates.tsx
@@ -12,8 +12,7 @@ export function useGetTokenRates(pool: Pool) {
   const chainId = getChainId(pool.chain)
   const isV3 = isV3Pool(pool)
 
-  const v3Vault: Address = AddressProvider.Vault(chainId)
-  const contractAddress: Address = isV3 ? v3Vault : (pool.address as Address)
+  const contractAddress: Address = isV3 ? AddressProvider.Vault(chainId) : (pool.address as Address)
 
   const query = useReadContract({
     chainId,


### PR DESCRIPTION
<img width="459" height="306" alt="Screenshot 2025-10-31 at 16 30 49" src="https://github.com/user-attachments/assets/6d2b20e5-1fbf-4fa9-95bb-cecf16d94919" />

Affected pool: https://balancer.fi/pools/zkevm/v2/0xe26e205ced7ec44de3dded7e63ff01a7cf158c1b000200000000000000000067