### PR TITLE
fix: allow proportional add for weighted v1 on protocol v3

### DIFF
--- a/packages/lib/modules/pool/actions/LiquidityActionHelpers.ts
+++ b/packages/lib/modules/pool/actions/LiquidityActionHelpers.ts
@@ -270,8 +270,8 @@ export function supportsProportionalAddLiquidityKind(pool: Pool): boolean {
   // WeightedPool2Tokens pool types do not support AddLiquidityKind.Proportional in the SDK
   if (isWeightedPool2Tokens(pool)) return false
 
-  // WeightedV1 pool types do not support AddLiquidityKind.Proportional in the SDK
-  if (isWeightedV1(pool)) return false
+  // WeightedV1 pool types do not support AddLiquidityKind.Proportional in the SDK except for protocolVersion 3
+  if (!isV3Pool(pool) && isWeightedV1(pool)) return false
 
   return true
 }


### PR DESCRIPTION
pool type versions got reset back to 1 for protocol version 3