### PR TITLE
Use well constructed weighted pool for integration tests

### DIFF
--- a/packages/lib/debug-helpers.ts
+++ b/packages/lib/debug-helpers.ts
@@ -24,6 +24,7 @@ export const auraBalAddress = '0x616e8bfa43f920657b3497dbf40d6b1a02d4608d' as co
 export const bal80Weth20Address = '0x5c6ee304399dbdb9c8ef030ab642b10820db8f56' as const
 
 export const wstEthAddress = '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0' as const
+export const aaveEthAddress = '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9' as const
 export const rstEthAddress = '0x7a4effd87c2f3c55ca251080b1343b605f327e3a' as const
 
 export const ethAddress = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as const
@@ -47,6 +48,7 @@ export const vaultV2Address = mainnetNetworkConfig.contracts.balancer.vaultV2 as
 export const vaultV3Address = sepoliaNetworkConfig.contracts.balancer.vaultV3 as Address
 
 export const poolId = '0x68e3266c9c8bbd44ad9dca5afbfe629022aee9fe000200000000000000000512' as const // Balancer Weighted wjAura and WETH
+export const poolId2 = '0x3de27efa2f1aa663ae5d458857e731c129069f29000200000000000000000588' as const // Balancer Weighted 20wstETH-80AAVE
 
 export const sepoliaRouter = sepoliaNetworkConfig.contracts.balancer.router
 export const mainnetRouter = mainnetNetworkConfig.contracts.balancer.router

--- a/packages/lib/modules/pool/__mocks__/fetchPoolMock.ts
+++ b/packages/lib/modules/pool/__mocks__/fetchPoolMock.ts
@@ -43,7 +43,10 @@ export async function fetchPoolMock({
     },
     body: JSON.stringify({ query: queryString, variables }),
   })
-    .then(response => response.json())
+    .then(response => {
+      if (!response.ok) console.log(response.body)
+      return response.json()
+    })
     .then(result => result.data)) as GetPoolQuery
 
   if (!getPoolQuery?.pool) {

--- a/packages/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidityV2.handler.integration.spec.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/handlers/UnbalancedAddLiquidityV2.handler.integration.spec.ts
@@ -1,8 +1,17 @@
 import networkConfig from '@repo/lib/config/networks/mainnet'
-import { balAddress, wETHAddress, wjAuraAddress } from '@repo/lib/debug-helpers'
+import {
+  aaveEthAddress,
+  balAddress,
+  wETHAddress,
+  wjAuraAddress,
+  wstEthAddress,
+} from '@repo/lib/debug-helpers'
 import { HumanTokenAmountWithAddress } from '@repo/lib/modules/tokens/token.types'
 import { defaultTestUserAccount } from '@repo/test/anvil/anvil-setup'
-import { aWjAuraWethPoolElementMock } from '@repo/lib/test/msw/builders/gqlPoolElement.builders'
+import {
+  aWeightedV2PoolMock,
+  aWjAuraWethPoolElementMock,
+} from '@repo/lib/test/msw/builders/gqlPoolElement.builders'
 import { UnbalancedAddLiquidityV2Handler } from './UnbalancedAddLiquidityV2.handler'
 import { selectAddLiquidityHandler } from './selectAddLiquidityHandler'
 
@@ -12,11 +21,11 @@ function selectUnbalancedHandler() {
 
 describe('When adding unbalanced liquidity for a weighted V2 pool', () => {
   test('calculates price impact', async () => {
-    const handler = selectUnbalancedHandler()
+    const handler = selectAddLiquidityHandler(aWeightedV2PoolMock())
 
     const humanAmountsIn: HumanTokenAmountWithAddress[] = [
-      { humanAmount: '1', tokenAddress: wETHAddress, symbol: 'ETH' },
-      { humanAmount: '1', tokenAddress: wjAuraAddress, symbol: 'wjAura' },
+      { tokenAddress: wstEthAddress, humanAmount: '1', symbol: 'wstETH' },
+      { tokenAddress: aaveEthAddress, humanAmount: '1', symbol: 'AAVE' },
     ]
 
     const priceImpact = await handler.getPriceImpact(humanAmountsIn)

--- a/packages/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.integration.spec.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/queries/useAddLiquidityPriceImpactQuery.integration.spec.tsx
@@ -1,15 +1,15 @@
-import { wETHAddress, wjAuraAddress } from '@repo/lib/debug-helpers'
+import { aaveEthAddress, wstEthAddress } from '@repo/lib/debug-helpers'
 import { DefaultPoolTestProvider, testHook } from '@repo/lib/test/utils/custom-renderers'
 import { waitFor } from '@testing-library/react'
 
-import { aWjAuraWethPoolElementMock } from '@repo/lib/test/msw/builders/gqlPoolElement.builders'
+import { aWeightedV2PoolMock } from '@repo/lib/test/msw/builders/gqlPoolElement.builders'
 import { selectAddLiquidityHandler } from '../handlers/selectAddLiquidityHandler'
 import { useAddLiquidityPriceImpactQuery } from './useAddLiquidityPriceImpactQuery'
 import { connectWithDefaultUser } from '@repo/test/utils/wagmi/wagmi-connections'
 import { HumanTokenAmountWithAddress } from '@repo/lib/modules/tokens/token.types'
 
 async function testQuery(humanAmountsIn: HumanTokenAmountWithAddress[]) {
-  const handler = selectAddLiquidityHandler(aWjAuraWethPoolElementMock())
+  const handler = selectAddLiquidityHandler(aWeightedV2PoolMock())
   const { result } = testHook(
     () => useAddLiquidityPriceImpactQuery({ handler, humanAmountsIn, enabled: true }),
     {
@@ -22,8 +22,8 @@ async function testQuery(humanAmountsIn: HumanTokenAmountWithAddress[]) {
 test('queries price impact for add liquidity', async () => {
   await connectWithDefaultUser()
   const humanAmountsIn: HumanTokenAmountWithAddress[] = [
-    { tokenAddress: wETHAddress, humanAmount: '1', symbol: 'WETH' },
-    { tokenAddress: wjAuraAddress, humanAmount: '1', symbol: 'wjAura' },
+    { tokenAddress: wstEthAddress, humanAmount: '1', symbol: 'wstETH' },
+    { tokenAddress: aaveEthAddress, humanAmount: '1', symbol: 'AAVE' },
   ]
 
   const result = await testQuery(humanAmountsIn)

--- a/packages/lib/test/msw/builders/gqlPoolElement.builders.ts
+++ b/packages/lib/test/msw/builders/gqlPoolElement.builders.ts
@@ -4,6 +4,9 @@ import {
   poolId,
   wETHAddress,
   wjAuraAddress,
+  aaveEthAddress,
+  wstEthAddress,
+  poolId2,
 } from '@repo/lib/debug-helpers'
 import {
   aTokenExpandedMock,
@@ -47,6 +50,23 @@ export function aWjAuraWethPoolElementMock(...options: Partial<GqlPoolElement>[]
   const options2 = {
     id: poolId,
     address: getPoolAddress(poolId),
+    poolTokens: tokens as unknown as GqlPoolTokenDetail[],
+    protocolVersion: 2,
+    ...options,
+  }
+
+  return aGqlPoolElementMock(options2)
+}
+
+export function aWeightedV2PoolMock(...options: Partial<GqlPoolElement>[]): GqlPoolElement {
+  const tokens = [
+    aTokenExpandedMock({ address: wstEthAddress }),
+    aTokenExpandedMock({ address: aaveEthAddress }),
+  ]
+
+  const options2 = {
+    id: poolId2,
+    address: getPoolAddress(poolId2),
     poolTokens: tokens as unknown as GqlPoolTokenDetail[],
     protocolVersion: 2,
     ...options,


### PR DESCRIPTION
Some of the tests had a dependency on pools that lowered their TVL after the exploit.

<img width="646" height="104" alt="Screenshot 2025-11-06 at 13 50 08" src="https://github.com/user-attachments/assets/52b1b8c5-01ad-4c78-881d-67cfd2759405" />
