### PR TITLE
fix: lst tab state sync

### DIFF
--- a/apps/beets-frontend-v3/lib/modules/lst/Lst.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/Lst.tsx
@@ -107,11 +107,11 @@ function LstForm() {
 
     setActiveTab(tab)
 
-    // need to use tab here because activeTab is not synced yet (0 is stake, 1 is unstake)
-    if (tab.value === '0') {
+    // need to use tab here because activeTab is not synced yet
+    if (tab.label === 'Stake') {
       setDisclosure(stakeModalDisclosure)
       setAmountAssets('')
-    } else if (tab.value === '1') {
+    } else if (tab.label === 'Unstake') {
       setDisclosure(unstakeModalDisclosure)
       setAmountShares('')
     }


### PR DESCRIPTION
in the `handleTabChange` function the active tab is set
and in the same function the value for it is checked (through `isStakeTab` and `isUnstake`) but these have then not yet synced
so this causes the wrong modal to be shown when the `Next` button is clicked

fix is to check the local value which is then also used to set the active tab