### PR TITLE
Improve UI when global alerts are present

### DIFF
--- a/apps/frontend-v3/app/(marketing)/3rd-party-services/page.tsx
+++ b/apps/frontend-v3/app/(marketing)/3rd-party-services/page.tsx
@@ -61,7 +61,7 @@ export default function Cookies() {
   ]
 
   return (
-    <Container>
+    <Container py="2xl">
       <Prose>
         <div className="pb-4">
           <FadeInOnView>

--- a/apps/frontend-v3/app/(marketing)/cookies-policy/page.tsx
+++ b/apps/frontend-v3/app/(marketing)/cookies-policy/page.tsx
@@ -7,7 +7,7 @@ import FadeInOnView from '@repo/lib/shared/components/containers/FadeInOnView'
 
 export default function Cookies() {
   return (
-    <Container>
+    <Container py="2xl">
       <Prose>
         <div className="pb-4">
           <FadeInOnView>

--- a/apps/frontend-v3/app/(marketing)/privacy-policy/page.tsx
+++ b/apps/frontend-v3/app/(marketing)/privacy-policy/page.tsx
@@ -7,7 +7,7 @@ import FadeInOnView from '@repo/lib/shared/components/containers/FadeInOnView'
 
 export default function Privacy() {
   return (
-    <Container>
+    <Container py="2xl">
       <Prose>
         <div className="pb-4">
           <FadeInOnView>

--- a/apps/frontend-v3/app/(marketing)/terms-of-use/page.tsx
+++ b/apps/frontend-v3/app/(marketing)/terms-of-use/page.tsx
@@ -7,7 +7,7 @@ import FadeInOnView from '@repo/lib/shared/components/containers/FadeInOnView'
 
 export default function Terms() {
   return (
-    <Container>
+    <Container py="2xl">
       <Prose>
         <FadeInOnView>
           <div className="subsection">

--- a/packages/lib/shared/components/alerts/ApiOutageAlert.tsx
+++ b/packages/lib/shared/components/alerts/ApiOutageAlert.tsx
@@ -5,7 +5,7 @@ export function ApiOutageAlert() {
   const { projectName } = PROJECT_CONFIG
 
   return (
-    <Alert color="font.dark" fontWeight="bold" status="warning">
+    <Alert color="font.dark" fontWeight="bold" rounded="none" status="warning">
       {`The ${projectName} API is currently down, causing most site features to be unavailable. The issue is
       being worked on to restore full service.`}
     </Alert>

--- a/packages/lib/shared/components/containers/DefaultPageContainer.tsx
+++ b/packages/lib/shared/components/containers/DefaultPageContainer.tsx
@@ -12,7 +12,7 @@ export function DefaultPageContainer({
   ...rest
 }: PropsWithChildren & ContainerProps & Props) {
   return (
-    <Box bg={bg} pt={noVerticalPadding ? '0px' : '72px'}>
+    <Box bg={bg} pt={noVerticalPadding ? '0px' : 'var(--navbar-height, 72px)'}>
       <Container
         maxW="maxContent"
         overflowX={{ base: 'hidden', md: 'visible' }}

--- a/packages/lib/shared/components/navs/NavBar.tsx
+++ b/packages/lib/shared/components/navs/NavBar.tsx
@@ -282,6 +282,15 @@ export function NavBar({
   const pathname = usePathname()
   const shouldShowV2Exploit = poolActions.every(action => !pathname.includes(action))
 
+  // Determine navbar height based on alerts
+  const hasAlerts = !apiOK || (isBalancer && shouldShowV2Exploit)
+  const navbarHeight = hasAlerts ? '120px' : '72px'
+
+  // Set CSS variable on document root
+  useEffect(() => {
+    document.documentElement.style.setProperty('--navbar-height', navbarHeight)
+  }, [navbarHeight])
+
   return (
     <Box
       _before={{
@@ -314,18 +323,21 @@ export function NavBar({
       {!apiOK && <ApiOutageAlert />}
 
       {isBalancer && shouldShowV2Exploit && (
-        <Alert gap="2" justifyContent="center" status="warning">
-          <Text color="font.dark" fontWeight="bold">
-            There has been an exploit affecting v2 Composable Stable pools (v3 pools are not
-            affected).
+        <Alert gap="1" justifyContent="center" rounded="none" status="warning">
+          <Text color="#000" fontWeight="bold">
+            There was a recent exploit on some v2 Composable Stable pools (v3 pools not affected).
           </Text>
           <Link
-            color="font.dark"
+            _hover={{
+              color: '#555',
+            }}
+            color="#000"
+            fontWeight="bold"
             href="https://x.com/Balancer/status/1990856260988670132"
             isExternal
             textDecoration="underline"
           >
-            View the official statement
+            Read the Post-Mortem
           </Link>
         </Alert>
       )}


### PR DESCRIPTION

- UI tweaks to the global alerts (e.g. remove border radius)
- Add a dynamic top padding based on whether the navbar has a global alert present or not.


Before: The title of some pages were being cut off

<img width="2232" height="932" alt="514187090-5ff04941-45b6-4b9b-af48-37e275725ed4" src="https://github.com/user-attachments/assets/07b13015-1d1c-4429-adab-9863805329ab" />

And tooltips on the /pools page are getting cut off

<img width="1898" height="560" alt="516079308-90a6fba5-edf4-4bed-bd50-4db21176801e" src="https://github.com/user-attachments/assets/6208298b-7eb7-43cc-9739-a80c62ef58bc" />

After:

<img width="2230" height="1166" alt="514187267-d681c682-3423-4d13-8fcd-60b2dccaf993" src="https://github.com/user-attachments/assets/5751b697-c8e5-4baa-94da-bb95b27fcc10" />
