### PR TITLE
fix: functions cannot be passed error in next v16

### DIFF
--- a/packages/lib/shared/pages/NotFoundPage.tsx
+++ b/packages/lib/shared/pages/NotFoundPage.tsx
@@ -1,7 +1,5 @@
-import { DefaultPageContainer } from '@repo/lib/shared/components/containers/DefaultPageContainer'
-import { Button, Heading, VStack, Text } from '@chakra-ui/react'
+import { NotFoundPageClient } from './NotFoundPageClient'
 import { headers } from 'next/headers'
-import Link from 'next/link'
 
 export async function NotFoundPage() {
   const headersList = await headers()
@@ -20,16 +18,11 @@ export async function NotFoundPage() {
   const redirectText = isPoolPageNotFound ? 'View All Pools' : 'Return Home'
 
   return (
-    <DefaultPageContainer minH="80vh">
-      <VStack align="start" spacing="md">
-        <Heading size="md">{title}</Heading>
-        <VStack align="start" spacing="xs">
-          <Text>{description}</Text>
-        </VStack>
-        <Button as={Link} href={redirectUrl} size="sm">
-          {redirectText}
-        </Button>
-      </VStack>
-    </DefaultPageContainer>
+    <NotFoundPageClient
+      description={description}
+      redirectText={redirectText}
+      redirectUrl={redirectUrl}
+      title={title}
+    />
   )
 }

--- a/packages/lib/shared/pages/NotFoundPageClient.tsx
+++ b/packages/lib/shared/pages/NotFoundPageClient.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { DefaultPageContainer } from '@repo/lib/shared/components/containers/DefaultPageContainer'
+import { Button, Heading, VStack, Text } from '@chakra-ui/react'
+import NextLink from 'next/link'
+
+interface NotFoundPageClientProps {
+  title: string
+  description: string
+  redirectUrl: string
+  redirectText: string
+}
+
+export function NotFoundPageClient({
+  title,
+  description,
+  redirectUrl,
+  redirectText,
+}: NotFoundPageClientProps) {
+  return (
+    <DefaultPageContainer minH="80vh">
+      <VStack align="start" spacing="md">
+        <Heading size="md">{title}</Heading>
+        <VStack align="start" spacing="xs">
+          <Text>{description}</Text>
+        </VStack>
+        <Button as={NextLink} href={redirectUrl} size="sm">
+          {redirectText}
+        </Button>
+      </VStack>
+    </DefaultPageContainer>
+  )
+}


### PR DESCRIPTION
fixes #1877 

next 16 is more strict on passing functions/components as props which gives an error for the not-found page

```
Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
```

splitting the `NotFoundPage` component into a server (current component) and client (`NotFoundPageClient`) component solves the error

