### PR TITLE
Allow unbalanced add liquidity for gyro v3

### DIFF
--- a/packages/lib/modules/pool/actions/LiquidityActionHelpers.spec.ts
+++ b/packages/lib/modules/pool/actions/LiquidityActionHelpers.spec.ts
@@ -915,8 +915,17 @@ describe('supportsProportionalAddLiquidityKind', () => {
 })
 
 describe('requiresProportionalInput', () => {
-  it('should require for gyro pools', () => {
+  it('should NOT require for gyro V3 pools', () => {
     const pool = getApiPoolMock(gyroV3)
+    pool.protocolVersion = 3
+
+    expect(requiresProportionalInput(pool)).toBe(false)
+    expect(requiresProportionalInputReason(pool)).toBeUndefined()
+  })
+
+  it('should require for gyro V2 pools', () => {
+    const pool = getApiPoolMock(gyroV3)
+    pool.protocolVersion = 2
 
     expect(requiresProportionalInput(pool)).toBe(true)
     expect(requiresProportionalInputReason(pool)).not.toBeUndefined()

--- a/packages/lib/modules/pool/actions/LiquidityActionHelpers.ts
+++ b/packages/lib/modules/pool/actions/LiquidityActionHelpers.ts
@@ -261,7 +261,7 @@ export function requiresProportionalInputReason(pool: Pool): string | undefined 
   if (isV3Pool(pool) && isUnbalancedLiquidityDisabled(pool)) {
     return 'Adding unbalanced liquidity has been disabled in this pool'
   }
-  if (isGyro(pool.type)) return requiresProportionalTemplate('Gyro (CLP)')
+  if (isGyro(pool.type) && !isV3Pool(pool)) return requiresProportionalTemplate('Gyro (CLP)')
   if (isCowAmmPool(pool.type)) return requiresProportionalTemplate('Cow AMM')
 
   return undefined


### PR DESCRIPTION
closes #1856 

tested the unbalanced add on local fork with this pool
`/pools/ethereum/v3/0x698a72bc8bc2eeb0f0f9a77cef0a2859399dc469/add-liquidity`
