### PR TITLE
Reduce unstake amount for beets e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ fork-base:
 
 fork-gnosis:
 	anvil --fork-url "${GNOSIS_RPC_URL}" --port 8545
+
+fork-sonic:
+	anvil --fork-url "${SONIC_RPC_URL}" --port 8545

--- a/packages/e2e-tests/tests/dev/beets/unstake.spec.ts
+++ b/packages/e2e-tests/tests/dev/beets/unstake.spec.ts
@@ -24,7 +24,7 @@ test('Unstake stS on /stake', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'stS', exact: true })).toBeVisible()
 
   // Fill in the amount to unstake
-  await page.getByPlaceholder('0.00').nth(0).fill('1')
+  await page.getByPlaceholder('0.00').nth(0).fill('0.5')
 
   // Click Next to open unstake modal
   await clickButton(page, 'Next')


### PR DESCRIPTION
the amount received from staking test is less than 1

<img width="1282" height="584" alt="image" src="https://github.com/user-attachments/assets/58d8904a-90db-4b18-840e-1f488c495cba" />

<br>
<br>

so unstake fails because next button stays disabled

<img width="1796" height="746" alt="image" src="https://github.com/user-attachments/assets/7b7c66d9-fd16-40d9-bf4a-df6e2760c09b" />
