### PR TITLE
Fix set-state-in-effect for `RemoveLiquidityProvider`

### DIFF
--- a/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -249,7 +249,6 @@ export function useRemoveLiquidityLogic(urlTxHash?: Hash) {
     singleTokenOutAddress,
     humanBptIn,
     humanBptInPercent,
-    quoteBptIn: humanBptIn,
     quotePriceImpact,
     totalUsdFromBprPrice,
     isSingleToken,

--- a/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -82,7 +82,7 @@ export function RemoveLiquidityForm() {
     isDisabled,
     disabledReason,
     simulationQuery,
-    quoteBptIn,
+    humanBptIn,
     removeLiquidityTxHash,
     isSingleTokenBalanceMoreThat25Percent,
     isSingleToken,
@@ -260,7 +260,7 @@ export function RemoveLiquidityForm() {
                   }
                   accordionPanelComponent={
                     <PoolActionsPriceImpactDetails
-                      bptAmount={BigInt(parseUnits(quoteBptIn, 18))}
+                      bptAmount={BigInt(parseUnits(humanBptIn, 18))}
                       isLoading={isFetching}
                       slippage={slippage}
                       totalUSDValue={totalUSDValue}

--- a/packages/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquiditySummary.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquiditySummary.tsx
@@ -28,7 +28,7 @@ export function RemoveLiquiditySummary({
 }: RemoveLiquidityReceiptResult) {
   const {
     transactionSteps,
-    quoteBptIn,
+    humanBptIn,
     totalUSDValue,
     amountsOut,
     hasQuoteContext,
@@ -83,7 +83,7 @@ export function RemoveLiquiditySummary({
 
       <Card variant="modalSubSection">
         <BptRow
-          bptAmount={shouldShowReceipt ? sentBptUnits : quoteBptIn}
+          bptAmount={shouldShowReceipt ? sentBptUnits : humanBptIn}
           isLoading={shouldShowReceipt ? isLoadingReceipt : false}
           label={shouldShowReceipt ? 'You removed' : "You're removing"}
           pool={pool}
@@ -110,7 +110,7 @@ export function RemoveLiquiditySummary({
           <Card variant="modalSubSection">
             <VStack align="start" spacing="sm">
               <PoolActionsPriceImpactDetails
-                bptAmount={BigInt(parseUnits(quoteBptIn, 18))}
+                bptAmount={BigInt(parseUnits(humanBptIn, 18))}
                 slippage={slippage}
                 totalUSDValue={totalUSDValue}
               />


### PR DESCRIPTION
closes  #1901

I don't think we need to worry about the reason the provider was using `set-state-in-effect`

see https://github.com/balancer/frontend-monorepo/pull/1906#discussion_r2600255850