### PR TITLE
Improved UX for Inputs with suggested items

### DIFF
--- a/packages/lib/modules/pool/actions/create/steps/details/InputWithSuggestion.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/InputWithSuggestion.tsx
@@ -34,44 +34,48 @@ export function InputWithSuggestion({
       <Controller
         control={control}
         name={name}
-        render={({ field, fieldState: { error } }) => (
-          <InputWithError
-            error={error?.message}
-            isFiatPrice={isFiatPrice}
-            label={label}
-            onChange={e => field.onChange(e.target.value)}
-            placeholder={placeholder}
-            tooltip={tooltip}
-            value={field.value}
-          />
-        )}
+        render={({ field, fieldState: { error } }) => {
+          const isSuggestionApplied = field.value === suggestedValue
+
+          return (
+            <>
+              <InputWithError
+                error={error?.message}
+                isFiatPrice={isFiatPrice}
+                label={label}
+                onChange={e => field.onChange(e.target.value)}
+                placeholder={placeholder}
+                tooltip={tooltip}
+                value={field.value}
+              />
+              {suggestedValue && (
+                <HStack justify="space-between" w="full">
+                  <HStack spacing="xs">
+                    <Text color="font.secondary" fontSize="sm">
+                      {suggestionLabel}:
+                    </Text>
+                    <Text
+                      color={isSuggestionApplied ? 'font.secondary' : 'font.link'}
+                      cursor={isSuggestionApplied ? 'default' : 'pointer'}
+                      fontSize="sm"
+                      onClick={isSuggestionApplied ? undefined : onClickSuggestion}
+                      textDecoration={isSuggestionApplied ? 'none' : 'underline dotted 1px'}
+                      textUnderlineOffset="3px"
+                    >
+                      {suggestedValue}
+                    </Text>
+                  </HStack>
+                  {attribution && attribution}
+                </HStack>
+              )}
+            </>
+          )
+        }}
         rules={{
           required: `${label} is required`,
           validate,
         }}
       />
-      {suggestedValue && (
-        <HStack justify="space-between" w="full">
-          <HStack spacing="xs">
-            <Text color="font.secondary" fontSize="sm">
-              {suggestionLabel}:
-            </Text>
-            <Text
-              color="font.link"
-              cursor="pointer"
-              fontSize="sm"
-              onClick={onClickSuggestion}
-              textDecoration="underline"
-              textDecorationStyle="dotted"
-              textDecorationThickness="1px"
-              textUnderlineOffset="3px"
-            >
-              {suggestedValue}
-            </Text>
-          </HStack>
-          {attribution && attribution}
-        </HStack>
-      )}
     </VStack>
   )
 }

--- a/packages/lib/modules/pool/actions/create/steps/details/PoolDetails.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/PoolDetails.tsx
@@ -3,6 +3,7 @@ import { InputWithSuggestion } from './InputWithSuggestion'
 import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { validatePoolDetails } from '../../validatePoolCreationForm'
 import { useWatch } from 'react-hook-form'
+import { useEffect, useRef } from 'react'
 
 export function PoolDetails() {
   const { poolCreationForm } = usePoolCreationForm()
@@ -17,6 +18,27 @@ export function PoolDetails() {
 
   const suggestedPoolName = tokenSymbols.join(' / ')
   const suggestedPoolSymbol = tokenSymbols.join('-').replace(/% /g, '-')
+
+  const hasInitialized = useRef(false)
+
+  useEffect(() => {
+    if (hasInitialized.current) return
+    if (!suggestedPoolName || suggestedPoolName === ' / ') return
+
+    const currentName = poolCreationForm.getValues('name')
+    const currentSymbol = poolCreationForm.getValues('symbol')
+
+    if (!currentName) {
+      poolCreationForm.setValue('name', suggestedPoolName)
+      poolCreationForm.trigger('name')
+    }
+    if (!currentSymbol) {
+      poolCreationForm.setValue('symbol', suggestedPoolSymbol)
+      poolCreationForm.trigger('symbol')
+    }
+
+    hasInitialized.current = true
+  }, [suggestedPoolName, suggestedPoolSymbol, poolCreationForm])
 
   return (
     <VStack align="start" spacing="xl" w="full">


### PR DESCRIPTION
I think its best to include the suggested text items in the input field (as per Matt's current version). In addition, let's keep the suggestion as hint text, so that if someone edits the text, they can easily see the suggestion, and click on it to return it to the suggested value. 

<img width="2732" height="1718" alt="cs 2025-12-11 at 12 52 34@2x" src="https://github.com/user-attachments/assets/132b653d-4706-4644-b6de-0365ad2a5658" />
