### PR TITLE
fix: validation errors update

### DIFF
--- a/packages/lib/modules/tokens/TokenInputsValidationProvider.tsx
+++ b/packages/lib/modules/tokens/TokenInputsValidationProvider.tsx
@@ -10,7 +10,10 @@ export function useTokenInputsValidationLogic() {
   const [validationErrors, setValidationErrors] = useState<ValidationErrorsByToken>({})
 
   function setValidationError(tokenAddress: Address, value: string) {
-    setValidationErrors({ ...validationErrors, [tokenAddress]: value })
+    setValidationErrors(prev => {
+      if (prev[tokenAddress] === value) return prev
+      return { ...prev, [tokenAddress]: value }
+    })
   }
 
   function hasValidationError(token: ApiOrCustomToken | undefined) {


### PR DESCRIPTION
get most recent state of validation errors by using `prev`

before:

<img width="536" height="749" alt="image" src="https://github.com/user-attachments/assets/56d695f8-2af5-41eb-87ca-68c8c9d15664" />

after:

<img width="543" height="728" alt="image" src="https://github.com/user-attachments/assets/8a8c7130-d48d-466a-a3eb-12b8115e44b0" />