### PR TITLE
Wrap warning messages content on forms and modals

### DIFF
--- a/apps/beets-frontend-v3/lib/modules/lst/components/LstUnstakeSummary.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/components/LstUnstakeSummary.tsx
@@ -45,6 +45,7 @@ export function LstUnstakeSummary() {
             description="After initiating the unstake, you will need to return to the UI after 14 days to claim $S on the Withdraw tab"
             forceColumnMode
             title="Please note"
+            wrapText
           />
         }
         status="info"

--- a/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityFormTabs.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityFormTabs.tsx
@@ -60,6 +60,7 @@ function PoolWeightsInfo() {
               </Box>
             }
             forceColumnMode
+            wrapText
           >
             <UnorderedList>
               <ListItem
@@ -101,6 +102,7 @@ function OutOfRangeWarning() {
         <BalAlertContent
           title="This CLP is currently out of range"
           tooltipLabel="No swap fees accrue when CLP is outside the price range. Fees resume automatically when prices return to the range."
+          wrapText
         />
       }
       status="warning"

--- a/packages/lib/modules/swap/PoolSwapCard.tsx
+++ b/packages/lib/modules/swap/PoolSwapCard.tsx
@@ -14,6 +14,7 @@ export function PoolSwapCard() {
             description="This swap routes through a single pool only. Better rates are usually available through the standard swap UI."
             forceColumnMode
             title="Direct single pool swap (expert option)"
+            wrapText
           />
         }
         status="warning"

--- a/packages/lib/shared/components/alerts/SafeAppAlert.tsx
+++ b/packages/lib/shared/components/alerts/SafeAppAlert.tsx
@@ -43,7 +43,12 @@ function Content({
 }) {
   return (
     <VStack align="start">
-      <BalAlertContent description={content.description} forceColumnMode title={content.title} />
+      <BalAlertContent
+        description={content.description}
+        forceColumnMode
+        title={content.title}
+        wrapText
+      />
       {/*
         It is not possible to link to custom pool pages within balancer.fi/pools as the Safe App will not recognize them as valid Safe Apps :(
       */}


### PR DESCRIPTION
When changing it for showing the migration warnings, some of the others ended up misaligned

<img width="760" height="221" alt="image" src="https://github.com/user-attachments/assets/eda5e027-b6ea-4570-9236-8a379a5a7726" />
