### PR TITLE
Fix: local dev navbar items display

### DIFF
--- a/packages/lib/shared/components/navs/NavBar.tsx
+++ b/packages/lib/shared/components/navs/NavBar.tsx
@@ -321,7 +321,7 @@ export function NavBar({
         <HStack
           animate="show"
           as={motion.div}
-          initial="hidden"
+          initial={process.env.NODE_ENV === 'development' ? false : 'hidden'}
           onClick={e => e.stopPropagation()}
           spacing="xl"
           variants={staggeredFadeIn}
@@ -342,7 +342,7 @@ export function NavBar({
         <HStack
           animate="show"
           as={motion.div}
-          initial="hidden"
+          initial={process.env.NODE_ENV === 'development' ? false : 'hidden'}
           onClick={e => e.stopPropagation()}
           order={{ md: '2' }}
           variants={staggeredFadeIn}


### PR DESCRIPTION
this should be fixed permanently now...

BEFORE
<img width="1432" height="124" alt="image" src="https://github.com/user-attachments/assets/4eee46e6-5b4f-4631-8469-4e4a84c2cd86" />


AFTER
<img width="1432" height="124" alt="image" src="https://github.com/user-attachments/assets/27a5a880-33ed-4e62-9822-c6a4e0691032" />


explanation per claude code:

```
  In local development:
  - React Strict Mode causes double-mounting
  - Hot Module Reloading can interrupt animations mid-flight
  - Components can remount before the 1s animation completes
  - Result: Elements stuck at opacity: 0 (invisible) but fully rendered and clickable
```