### PR TITLE
Fix bribe market name

### DIFF
--- a/apps/frontend-v3/lib/vebal/vote/VoteList/VoteListTable/VoteListTableRow.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/VoteList/VoteListTable/VoteListTableRow.tsx
@@ -52,7 +52,7 @@ export function VoteListTableRow({ vote, keyValue, ...rest }: Props) {
     : 'Connect your wallet to select and vote on pool gauges.'
 
   const missingDataReason =
-    'Bribe data is temporarily unavailable during the transition from Hidden Hand to Stake DAO'
+    'Bribe data is temporarily unavailable during the transition from Hidden Hand to Votemarket'
 
   return (
     <FadeInOnView>

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotes.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotes.tsx
@@ -60,7 +60,8 @@ export function MyVotes() {
           >
             <AlertTitle>Hidden Hand incentives sunset on December 31, 2025</AlertTitle>
             <AlertDescription>
-              Bribe market data will be available again after the migration to Stake DAO is complete
+              Bribe market data will be available again after the migration to Votemarket is
+              complete
             </AlertDescription>
           </Stack>
         </Alert>

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesHintModal.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesHintModal.tsx
@@ -56,7 +56,7 @@ export function MyVotesHintModal({ isOpen = false, onClose = () => {} }: UseDisc
                 <Text>
                   There are vote incentives offered by 3rd parties (also known as bribes). If you
                   vote on pools with bribes, you can claim these bribes on third party platforms
-                  like Stake DAO and Paladin.
+                  like Votemarket and Paladin.
                 </Text>
               </ListItem>
               <ListItem mb="xs">

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/MyVotesStatsAverageReward.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/MyVotesStatsAverageReward.tsx
@@ -17,7 +17,7 @@ export function MyVotesStatsAverageReward() {
     <MyVotesStatsCard
       headerText={
         <TooltipWithTouch
-          label="The amount of bribes you could earn on Stake DAO for the next period per veBAL vote. Stake DAO is an unaffiliated 3rd party vote market."
+          label="The amount of bribes you could earn on Votemarket for the next period per veBAL vote. Votemarket is an unaffiliated 3rd party vote market."
           placement="top"
         >
           <Text

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/MyVotesStatsMyIncentives.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/MyVotesStatsMyIncentives.tsx
@@ -18,7 +18,7 @@ export function MyVotesStatsMyIncentives() {
     <MyVotesStatsCard
       headerText={
         <TooltipWithTouch
-          label="The extra incentives you could earn from bribes on Stake DAO, based on your voting choices. Stake DAO is an unaffiliated 3rd party vote market. Note: This doesn't include bribes from other vote markets like Paladin"
+          label="The extra incentives you could earn from bribes on Votemarket, based on your voting choices. Votemarket is an unaffiliated 3rd party vote market. Note: This doesn't include bribes from other vote markets like Paladin"
           placement="top"
         >
           <Text

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/incentives-optimization/MyVotesStatsMyIncentivesOptimized.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/incentives-optimization/MyVotesStatsMyIncentivesOptimized.tsx
@@ -72,7 +72,7 @@ export function MyVotesStatsMyIncentivesOptimized() {
   const headerText =
     !isConnected || noVeBALBalance || !canReceiveIncentives(userAddress) ? (
       <TooltipWithTouch
-        label="The average APR veBAL holders may get from 3rd party bribes on Stake DAO for voting on eligible pool gauges. Stake DAO is an unaffiliated 3rd party vote market."
+        label="The average APR veBAL holders may get from 3rd party bribes on Votemarket for voting on eligible pool gauges. Votemarket is an unaffiliated 3rd party vote market."
         placement="top"
       >
         <Text
@@ -95,7 +95,7 @@ export function MyVotesStatsMyIncentivesOptimized() {
       </TooltipWithTouch>
     ) : (
       <TooltipWithTouch
-        label="The potential amount you can earn from 3rd party bribes on Stake DAO by tapping 'Apply' to optimize your votes for maximum returns. Stake DAO is an unaffiliated 3rd party vote market."
+        label="The potential amount you can earn from 3rd party bribes on Votemarket by tapping 'Apply' to optimize your votes for maximum returns. Votemarket is an unaffiliated 3rd party vote market."
         placement="top"
       >
         <Text
@@ -134,7 +134,7 @@ export function MyVotesStatsMyIncentivesOptimized() {
   const allVotesTimelocked = areAllVotesTimelocked(myVotes)
   const votesAlreadyOptimized = totalInfo.totalRewardValue.toNumber() === optimizedRewardValue
 
-  const disabledButton = true // TODO: enable again during migration to Stake DAO?
+  const disabledButton = true // TODO: enable again during migration to Votemarket?
   // const disabledButton = !canReceiveIncentives(userAddress) || votesAlreadyOptimized
 
   let tooltipLabelText: string
@@ -144,7 +144,7 @@ export function MyVotesStatsMyIncentivesOptimized() {
     tooltipLabelText = 'Your optimized votes have already been applied'
   } else {
     tooltipLabelText =
-      'This selects pool gauges and applies the optimal vote combinations to maximize your rewards from the Stake DAO vote market.'
+      'This selects pool gauges and applies the optimal vote combinations to maximize your rewards from the Votemarket vote market.'
   }
 
   return (

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/shared/MyIncentivesTooltip.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/MyVotesStats/shared/MyIncentivesTooltip.tsx
@@ -9,7 +9,7 @@ export function MyIncentivesTooltip() {
     <PopoverContent bg="background.base" gap="md" minWidth={['100px']} px="0" py="ms" shadow="3xl">
       <Stack px="sm" spacing="sm" w="full">
         <Text color="font.secondary" fontSize="sm">
-          {`Weekly bribes are provided by unaffiliated 3rd parties through the Stake DAO platform
+          {`Weekly bribes are provided by unaffiliated 3rd parties through the Votemarket platform
           to incentivize liquidity to certain pools. This does not include additional yield that veBAL
           holders also can earn (e.g. protocol revenue, extra boosts on liquidity mining incentives,
           and swap fees).`}

--- a/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/myVotes.helpers.ts
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/MyVotes/myVotes.helpers.ts
@@ -125,7 +125,7 @@ export const orderByHash: Record<SortingBy, { label: string; title?: string }> =
   bribes: {
     label: 'Bribes',
     title:
-      'Voting incentives (referred to as ‘Bribes’ in DeFi) are provided by unaffiliated 3rd parties through the Stake DAO platform to incentivize liquidity to certain pools.',
+      'Voting incentives (referred to as ‘Bribes’ in DeFi) are provided by unaffiliated 3rd parties through the Votemarket platform to incentivize liquidity to certain pools.',
   },
   bribesPerVebal: {
     label: 'Bribes/veBAL',

--- a/apps/frontend-v3/lib/vebal/vote/Votes/VotesIntroduction/VotesIntroduction.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/Votes/VotesIntroduction/VotesIntroduction.tsx
@@ -126,7 +126,7 @@ export function VotesIntroduction() {
                 </Box>
                 <Text color="font.secondary" sx={{ textWrap: 'balance' }}>
                   Voting on pool gauges helps to direct weekly BAL emissions and earns you
-                  additional voting incentives from third-party platforms like Stake DAO.
+                  additional voting incentives from third-party platforms like Votemarket.
                 </Text>
               </VStack>
             </VStack>

--- a/packages/lib/modules/vebal/vote/vote.helpers.ts
+++ b/packages/lib/modules/vebal/vote/vote.helpers.ts
@@ -56,7 +56,7 @@ export const orderByHash: Record<SortVotesBy, { label: string; title?: string }>
   bribes: {
     label: 'Bribes',
     title:
-      'Voting incentives (referred to as ‘Bribes’ in DeFi) are provided by unaffiliated 3rd parties through the Stake DAO platform to incentivize liquidity to certain pools.',
+      'Voting incentives (referred to as ‘Bribes’ in DeFi) are provided by unaffiliated 3rd parties through the Votemarket platform to incentivize liquidity to certain pools.',
   },
   bribesPerVebal: {
     label: 'Bribes/veBAL',

--- a/packages/lib/shared/components/modals/VebalPartnerRedirectModal.tsx
+++ b/packages/lib/shared/components/modals/VebalPartnerRedirectModal.tsx
@@ -51,11 +51,11 @@ const partnerInfo: PartnerInfo = {
     imageName: 'aura',
   },
   [VebalRedirectPartner.StakeDAO]: {
-    shortName: 'Stake DAO',
-    fullName: 'Stake DAO',
+    shortName: 'Votemarket',
+    fullName: 'Votemarket',
     category: 'DeFi liquid locker',
     description:
-      "Stake DAO is a key participant in veBAL through its 'Liquid Locker' product for BAL tokens. Stake DAO enables users and DAOs to lock BAL in the 80BAL/20WETH Balancer pool, minting sdBAL—a liquid wrapper that provides the benefits of veBAL for LPs (voting power, boosted rewards, and protocol fees) without sacrificing liquidity.",
+      "Votemarket is a key participant in veBAL through its 'Liquid Locker' product for BAL tokens. Votemarket enables users and DAOs to lock BAL in the 80BAL/20WETH Balancer pool, minting sdBAL—a liquid wrapper that provides the benefits of veBAL for LPs (voting power, boosted rewards, and protocol fees) without sacrificing liquidity.",
     url: 'https://www.stakedao.org/lockers/bal',
     imageName: 'stakedao',
   },

--- a/packages/lib/shared/hooks/useAprTooltip.ts
+++ b/packages/lib/shared/hooks/useAprTooltip.ts
@@ -26,7 +26,7 @@ export const lockingIncentivesTooltipText = `The protocol revenue share for Liqu
                                             with 1-year locked Balancer ve8020 tokens.`
 
 export const votingIncentivesTooltipText = `Vote incentives are offered to veBAL holders who
-                        participate in weekly gauge voting by third parties on platforms like Stake DAO.
+                        participate in weekly gauge voting by third parties on platforms like Votemarket.
                         Your incentives are determined by your veBAL voting power compared to other voters.
                         The listed APR represents an average rather than a guaranteed return for active participants.`
 


### PR DESCRIPTION
might be better ( or more specific ) for UI to reference `Votemarket` instead of `Stake DAO` ? 

- https://votemarket.stakedao.org/
- https://forum.balancer.fi/t/bip-xxx-transition-core-pool-incentive-program-to-stake-dao-s-votemarket-v2/6928


<img width="634" height="166" alt="image" src="https://github.com/user-attachments/assets/b88321b0-982b-4d1e-bbc8-10f2b1d1f538" />


<img width="634" height="166" alt="image" src="https://github.com/user-attachments/assets/fac19539-2205-4d94-b37a-bb96b92e24f7" />

<img width="605" height="72" alt="image" src="https://github.com/user-attachments/assets/68840c57-d2fd-41ba-b7f0-dd19aa0a0c70" />
