### PR TITLE
fix: voting incentives filter

### DIFF
--- a/packages/lib/shared/services/voting-incentives/useVotingIncentives.tsx
+++ b/packages/lib/shared/services/voting-incentives/useVotingIncentives.tsx
@@ -37,7 +37,7 @@ async function getStakeDaoIncentives(priceFor: PriceForFn): Promise<PoolVotingIn
   const stakeDaoVoteMarket = await fetchStakeDaoVoteMarket()
 
   const voteOpenCampaigns = stakeDaoVoteMarket.campaigns.filter(
-    campaign => campaign.status.voteOpen
+    campaign => campaign.status.voteOpen && !campaign.isBlacklist && campaign.addresses.length === 0
   )
 
   // Group campaigns by gauge address and sum values
@@ -79,7 +79,6 @@ async function getStakeDaoIncentives(priceFor: PriceForFn): Promise<PoolVotingIn
           incentives: [incentive],
         }
       } else {
-        // Merge with existing gauge entry
         acc[gaugeAddress].totalValue += fiatValue
         acc[gaugeAddress].valuePerVote += valuePerVote
         acc[gaugeAddress].incentives.push(incentive)


### PR DESCRIPTION
### Summary
- remove rewards that are for vlAURA only 

from the stake DAO team:

> you need to filter out the campaign with a whitelist (isBlacklist : false) and some addresses. There are only for vlAURA, or maybe some other market (maybe in the future)
> For the ones with vlAURA as blacklist, you can account everything
> 
> For the ones with no blacklist (addresses empty), there is no clear allocation between veBAL and vlAURA as said, it's who votes takes it, so i guess you can show the total amount too (that's what we are doing)


time of screenshots is ~19:00 UTC on Feb 4 

### Before
- 16 total campaigns which does not match how votemarket shows veBAL rewards

<img width="3023" height="1310" alt="image" src="https://github.com/user-attachments/assets/04f04409-de21-4311-92fb-faae54fa39cf" />


### After:
- 12 total campaigns matches votemarket 

<img width="3092" height="1264" alt="image" src="https://github.com/user-attachments/assets/dcf3dd5a-170a-4318-91dc-ba1c12ec3943" />
