### PR TITLE
fix: gauge tooltip current period vote totals

### DIFF
--- a/apps/frontend-v3/lib/vebal/vote/VoteRateTooltip.tsx
+++ b/apps/frontend-v3/lib/vebal/vote/VoteRateTooltip.tsx
@@ -21,6 +21,8 @@ import { VotesState } from '@repo/lib/modules/vebal/vote/vote.types'
 import tinycolor from 'tinycolor2'
 import { useVeBALTotal } from './useVeBALTotal'
 import { oneWeekInMs } from '@repo/lib/shared/utils/time'
+import { useTotalVotes } from './useTotalVotes'
+import { formatUnits } from 'viem'
 
 interface TooltipItemProps extends StackProps {
   label: ReactNode
@@ -100,8 +102,10 @@ export function VoteRateTooltip({ votesState, votesShare, votesShareNextWeek }: 
   const trendIcon = !voteDiff ? undefined : voteDiff > 0 ? <TrendUpIcon /> : <TrendDownIcon />
 
   const [thisWeek] = useState(() => Math.floor(Date.now() / oneWeekInMs) * oneWeekInMs)
-  const { totalAmount: totalVeBAL } = useVeBALTotal(thisWeek)
-  const votesThisWeek = totalVeBAL && votesShare ? (votesShare * totalVeBAL).toFixed(2) : undefined
+
+  const { totalVotes: totalVotesRaw } = useTotalVotes()
+  const totalVotes = Number(formatUnits(totalVotesRaw, 18))
+  const votesThisWeek = totalVotes && votesShare ? (votesShare * totalVotes).toFixed(2) : undefined
 
   const nextWeek = thisWeek + oneWeekInMs
   const { totalAmount: totalVeBALNextWeek } = useVeBALTotal(nextWeek)


### PR DESCRIPTION
since `totalVeBal` does not represent total votes that have actually been cast , would it be more accurate to use `totalVotes`  for the tooltip current period calculations? 

```
{
    "totalVotes": 5115293.762535003,
    "totalVeBAL": 5261378.479302539
}
```

the votes provider, votes table, and incentive optimizer are all using `totalVotes`

also seems to match votemarket calculations closer

:point_left: left side uses votes cast and prod uses total vebal supply on the right :point_right: 

<img width="3441" height="805" alt="image" src="https://github.com/user-attachments/assets/bb7d5efa-3346-4ab2-97db-996e126ee1d9" />

<img width="3441" height="705" alt="image" src="https://github.com/user-attachments/assets/9422d1b0-8066-4010-8d62-0c460b194b9d" />


<img width="3430" height="707" alt="image" src="https://github.com/user-attachments/assets/1527f380-bc80-44e7-846d-4b8f6f30fe5a" />
