### PR TITLE
fix: use partial to prevent failed builds

### DIFF
--- a/packages/lib/modules/pool/pool.utils.ts
+++ b/packages/lib/modules/pool/pool.utils.ts
@@ -194,7 +194,7 @@ export function getTotalAprRaw(aprItems: GqlPoolAprItem[], vebalBoost?: string):
 }
 
 // Maps GraphQL pool type enum to human readable label for UI.
-const poolTypeLabelMap: { [key in GqlPoolType]: string } = {
+const poolTypeLabelMap: Partial<Record<GqlPoolType, string>> = {
   [GqlPoolType.Weighted]: 'Weighted',
   [GqlPoolType.Element]: 'Element',
   [GqlPoolType.Gyro]: '2-CLP',


### PR DESCRIPTION
when ever new pool types get added to the api the build will break

because there usually is a lag between test and prod we end up in limbo

using `Partial` fixes this