### PR TITLE
fix: flaky e2e token select

### DIFF
--- a/packages/e2e-tests/helpers/create-pool.helpers.ts
+++ b/packages/e2e-tests/helpers/create-pool.helpers.ts
@@ -1,4 +1,10 @@
-import { clickButton, clickRadio, button, checkbox } from '@/helpers/user.helpers'
+import {
+  clickButton,
+  clickRadio,
+  button,
+  checkbox,
+  selectPopularToken,
+} from '@/helpers/user.helpers'
 import { expect, Page } from '@playwright/test'
 import { POOL_CREATION_FORM_STEPS } from '@repo/lib/modules/pool/actions/create/constants'
 import { POOL_TYPES } from '@repo/lib/modules/pool/actions/create/constants'
@@ -118,18 +124,6 @@ export class CreatePoolPage {
     await clickRadio(this.page, 'Choose a pool type', POOL_TYPES[poolType].label)
   }
 
-  async selectToken(tokenName: string) {
-    await button(this.page, 'Select token').first().click()
-    const modalHeader = this.page.getByText('Select a token: Ethereum', { exact: true })
-    await modalHeader.waitFor({ state: 'visible' })
-    const modal = this.page.getByRole('dialog').filter({ has: modalHeader })
-    await modal
-      .getByRole('group')
-      .filter({ has: this.page.getByText(tokenName, { exact: true }) })
-      .first()
-      .click()
-  }
-
   async fillTokenAmounts() {
     const shouldOnlyFillOneAmount = this.isReClamm || this.isGyroEclp
 
@@ -166,7 +160,7 @@ export class CreatePoolPage {
     await expect(this.page).toHaveURL(this.urls.tokens)
     await expect(this.page.getByText('Choose pool tokens')).toBeVisible()
     await expect(button(this.page, 'Next')).toBeDisabled()
-    for (const token of this.config.tokens) await this.selectToken(token.symbol)
+    for (const token of this.config.tokens) await selectPopularToken(this.page, token.symbol)
     await expect(button(this.page, 'Next')).toBeEnabled()
     if (goToNextStep) await clickButton(this.page, 'Next')
   }

--- a/packages/e2e-tests/helpers/user.helpers.ts
+++ b/packages/e2e-tests/helpers/user.helpers.ts
@@ -36,3 +36,16 @@ export async function clickRadio(page: Page, groupLabel: string, radioLabel: str
 export async function checkbox(page: Page, text: string) {
   return page.locator('label', { hasText: text }).locator('.chakra-checkbox__control')
 }
+
+// reliable method for selecting pill buttons at top of token select modal
+export async function selectPopularToken(page: Page, tokenSymbol: string) {
+  await button(page, 'Select token').first().click()
+  const modalHeader = page.getByText('Select a token')
+  await modalHeader.waitFor({ state: 'visible' })
+  const modal = page.getByRole('dialog').filter({ has: modalHeader })
+  await modal
+    .getByRole('group')
+    .filter({ has: page.getByText(tokenSymbol, { exact: true }) })
+    .first()
+    .click()
+}

--- a/packages/e2e-tests/tests/dev/beets/swap.spec.ts
+++ b/packages/e2e-tests/tests/dev/beets/swap.spec.ts
@@ -1,5 +1,5 @@
 import { impersonate } from '@/helpers/e2e.helpers'
-import { clickButton, clickLink } from '@/helpers/user.helpers'
+import { clickButton, clickLink, selectPopularToken } from '@/helpers/user.helpers'
 import { expect, test } from '@playwright/test'
 import { defaultAnvilAccount } from '@repo/lib/test/utils/wagmi/fork.helpers'
 
@@ -9,8 +9,7 @@ test('Wrap 1 S to wS', async ({ page }) => {
   await page.waitForURL('http://localhost:3001/swap', { waitUntil: 'commit' })
   await impersonate(page, defaultAnvilAccount)
 
-  await clickButton(page, 'Select token')
-  await page.getByText('Wrapped Sonic', { exact: true }).click()
+  await selectPopularToken(page, 'wS')
   await page.getByRole('spinbutton', { name: 'TokenIn' }).fill('1')
 
   await clickButton(page, 'Next')


### PR DESCRIPTION
beets e2e [still hanging
](https://github.com/balancer/frontend-monorepo/actions/runs/22157048971/job/64063728579?pr=2099) 
```
e2e-tests:test:e2e:dev:beets:     Retry #1 ───────────────────────────────────────────────────────────────────────────────────────
e2e-tests:test:e2e:dev:beets: 
e2e-tests:test:e2e:dev:beets:     Test timeout of 90000ms exceeded.
e2e-tests:test:e2e:dev:beets: 
e2e-tests:test:e2e:dev:beets:     Error: locator.click: Test timeout of 90000ms exceeded.
e2e-tests:test:e2e:dev:beets:     Call log:
e2e-tests:test:e2e:dev:beets:       - waiting for getByText('Wrapped Sonic', { exact: true })
e2e-tests:test:e2e:dev:beets:         - locator resolved to <p title="Wrapped Sonic" class="chakra-text css-6vvyup">Wrapped Sonic</p>
e2e-tests:test:e2e:dev:beets:       - attempting click action
e2e-tests:test:e2e:dev:beets:         - waiting for element to be visible, enabled and stable
e2e-tests:test:e2e:dev:beets:       - element was detached from the DOM, retrying
```


guessing element detatched from DOM because virtual list changes as wallet balances load

i havent seen pool creation test fail same way since i switched to using the token pills at top

<img width="1042" height="752" alt="image" src="https://github.com/user-attachments/assets/afc57fe4-676b-4575-b338-96639ee95cdb" />


