### PR TITLE
fix: flaky integration tests

### DIFF
--- a/packages/test/anvil/anvil-setup.ts
+++ b/packages/test/anvil/anvil-setup.ts
@@ -75,8 +75,7 @@ export const ANVIL_NETWORKS: Record<ChainIdWithFork, NetworkSetup> = {
     chainId: sepolia.id,
     fallBackRpc: 'https://gateway.tenderly.co/public/sepolia',
     port: ANVIL_PORTS[sepolia.id],
-    // For now we will use the last block until v3 deployments are final
-    // forkBlockNumber: 6679621n,
+    forkBlockNumber: 10280000n,
   },
   [fantom.id]: {
     chainId: fantom.id,


### PR DESCRIPTION
i have rebased all my open PRs to include the updated unskipped integration tests

not sure why integration tests ONLY fail for this PR :point_down: 

https://github.com/balancer/frontend-monorepo/actions/runs/22158924678/job/64070296051?pr=2099

```
@repo/lib:test:integration:      → The contract function 
"queryAddLiquidityUnbalancedNestedPool" returned no data ("0x").
```

```
@repo/lib:test:integration:      → The contract function 
"queryRemoveLiquiditySingleTokenExactIn" returned no data ("0x").
```

those errors usually have to do with running fork on a block number **before** the contract existed