### PR TITLE
fix: only enable Sentry `reactComponentAnnotation` in prod

### DIFF
--- a/apps/frontend-v3/sentry.config.ts
+++ b/apps/frontend-v3/sentry.config.ts
@@ -30,13 +30,9 @@ export const sentryOptions: SentryBuildOptions = {
   // https://vercel.com/docs/cron-jobs
   automaticVercelMonitors: true,
 
-  sourcemaps: {
-    disable: !shouldEnableSourceMaps,
-  },
+  sourcemaps: { disable: !shouldEnableSourceMaps },
   telemetry: shouldEnableSourceMaps,
-  reactComponentAnnotation: {
-    enabled: true,
-  },
+  reactComponentAnnotation: { enabled: shouldEnableSourceMaps },
 }
 
 const productionSentryDSN =


### PR DESCRIPTION
i think this causing my turbopack crashes 

also seems like there is no benefit to having `reactComponentAnnotation` enabled for local dev