### PR TITLE
fix: codegen schema gzip compression

### DIFF
--- a/packages/lib/shared/services/api/codegen.ts
+++ b/packages/lib/shared/services/api/codegen.ts
@@ -1,15 +1,13 @@
 import { CodegenConfig } from '@graphql-codegen/cli'
 
-const schemaWithHeaders = {
-  [process.env.NEXT_PUBLIC_BALANCER_API_URL as string]: {
-    headers: {
-      'Accept-Encoding': 'identity', // Prevent gzip-compressed responses that the schema loader can't decompress
+const config: CodegenConfig = {
+  schema: {
+    [process.env.NEXT_PUBLIC_BALANCER_API_URL as string]: {
+      headers: {
+        'Accept-Encoding': 'identity', // Prevent gzip-compressed responses that the schema loader can't decompress
+      },
     },
   },
-}
-
-const config: CodegenConfig = {
-  schema: schemaWithHeaders,
   generates: {
     ['./shared/services/api/generated/schema.graphql']: {
       plugins: ['schema-ast'],


### PR DESCRIPTION
the unexpected response of  `\u001f\xc2\x8b` is compressed binary data

think we can force server to respond with uncompressed data via headers

`'Accept-Encoding': 'identity'`