### PR TITLE
chore: disable create reclamm e2e test

### DIFF
--- a/packages/e2e-tests/helpers/create-pool.helpers.ts
+++ b/packages/e2e-tests/helpers/create-pool.helpers.ts
@@ -47,13 +47,14 @@ export const POOL_CREATION_CONFIGS: PoolCreationConfig[] = [
       { symbol: 'GHO', amount: undefined },
     ],
   },
-  {
-    type: PoolType.ReClamm,
-    tokens: [
-      { symbol: 'WETH', amount: '1' },
-      { symbol: 'USDC', amount: undefined },
-    ],
-  },
+  // reclamm pool creation has been temporarily disabled for audit investigations
+  // {
+  //   type: PoolType.ReClamm,
+  //   tokens: [
+  //     { symbol: 'WETH', amount: '1' },
+  //     { symbol: 'USDC', amount: undefined },
+  //   ],
+  // },
   {
     type: PoolType.CowAmm,
     tokens: [


### PR DESCRIPTION
test fails because the pool factory was disabled as part of SC investigations

https://x.com/Balancer/status/2024526585702039851?s=20

the option to create reclamm is only available at https://test.balancer.fi/ so i think okay to leave enabled?