### PR TITLE
feat: option to boost underlying token during pool creation

### DIFF
--- a/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.tsx
+++ b/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.tsx
@@ -161,6 +161,7 @@ export function usePoolFormLogic() {
     isLoadingTokenList,
     poolAddress,
     setPoolAddress,
+    isBoostingUnderlying: poolTokens.some(token => token.isBoostingUnderlying),
   }
 }
 

--- a/packages/lib/modules/pool/actions/create/constants.ts
+++ b/packages/lib/modules/pool/actions/create/constants.ts
@@ -139,6 +139,7 @@ export const RATE_PROVIDER_RADIO_OPTIONS = [
 
 export const INITIAL_TOKEN_CONFIG: PoolCreationToken = {
   address: undefined,
+  isBoostingUnderlying: false,
   rateProvider: zeroAddress,
   paysYieldFees: false,
   data: undefined,

--- a/packages/lib/modules/pool/actions/create/helpers.ts
+++ b/packages/lib/modules/pool/actions/create/helpers.ts
@@ -2,6 +2,7 @@ import { PoolType } from '@balancer/sdk'
 import { bn } from '@repo/lib/shared/utils/numbers'
 import { GqlPoolType } from '@repo/lib/shared/services/api/generated/graphql'
 import { fNumCustom } from '@repo/lib/shared/utils/numbers'
+import { ApiOrCustomToken, ApiToken } from '@repo/lib/modules/tokens/token.types'
 import {
   WeightedPoolStructure,
   COW_AMM_RAW_WEIGHT_50,
@@ -121,4 +122,8 @@ export function isBalancerProtocol(protocol: string): boolean {
 export function isPoolCreatorEnabled(poolType: PoolType): boolean {
   // reclamm and eclp factories still require zero address
   return poolType === PoolType.Stable || poolType === PoolType.Weighted
+}
+
+export function isApiToken(token: ApiOrCustomToken): token is ApiToken {
+  return 'underlyingTokenAddress' in token
 }

--- a/packages/lib/modules/pool/actions/create/modal/PoolCreationModal.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/PoolCreationModal.tsx
@@ -24,6 +24,7 @@ import { useInitializePoolInput } from './useInitializePoolInput'
 import { RestartPoolCreationModal } from './RestartPoolCreationModal'
 import { useWatch } from 'react-hook-form'
 import { usePoolCreationTransactions } from './usePoolCreationTransactions'
+import { useBoostUnderlyingSteps } from './useBoostUnderlyingSteps'
 
 type PoolCreationModalProps = {
   isOpen: boolean
@@ -40,17 +41,22 @@ export function PoolCreationModal({
 }: PoolCreationModalProps & Omit<ModalProps, 'children'>) {
   const { poolCreationForm, resetPoolCreationForm, poolAddress, setPoolAddress } =
     usePoolCreationForm()
-  const [network, poolType] = useWatch({
+  const [network, poolType, poolTokens] = useWatch({
     control: poolCreationForm.control,
-    name: ['network', 'poolType'],
+    name: ['network', 'poolType', 'poolTokens'],
   })
   const chainId = getChainId(network)
 
   const createPoolInput = useCreatePoolInput(chainId)
   const protocolVersion = createPoolInput.protocolVersion
+  const boostUnderlying = useBoostUnderlyingSteps({
+    poolTokens,
+    chain: network,
+  })
   const initPoolInput = useInitializePoolInput(chainId)
 
   const { transactionSteps, initPoolTxHash, urlTxHash } = usePoolCreationTransactions({
+    boostUnderlying,
     poolAddress,
     setPoolAddress,
     createPoolInput,

--- a/packages/lib/modules/pool/actions/create/modal/PoolCreationModal.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/PoolCreationModal.tsx
@@ -46,12 +46,14 @@ export function PoolCreationModal({
     name: ['network', 'poolType', 'poolTokens'],
   })
   const chainId = getChainId(network)
+  const { isPoolInitialized } = useIsPoolInitialized({ chainId, poolAddress, poolType })
 
   const createPoolInput = useCreatePoolInput(chainId)
   const protocolVersion = createPoolInput.protocolVersion
   const boostUnderlying = useBoostUnderlyingSteps({
     poolTokens,
-    chain: network,
+    network,
+    isPoolInitialized,
   })
   const initPoolInput = useInitializePoolInput(chainId)
 
@@ -62,8 +64,6 @@ export function PoolCreationModal({
     createPoolInput,
     initPoolInput,
   })
-
-  const { isPoolInitialized } = useIsPoolInitialized({ chainId, poolAddress, poolType })
 
   const handleReset = () => {
     transactionSteps.resetTransactionSteps()

--- a/packages/lib/modules/pool/actions/create/modal/useBoostUnderlyingSteps.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/useBoostUnderlyingSteps.tsx
@@ -5,13 +5,22 @@ import { isApiToken } from '../helpers'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { useTokenApprovalSteps } from '@repo/lib/modules/tokens/approvals/useTokenApprovalSteps'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
+import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
+import { ManagedSendTransactionButton } from '@repo/lib/modules/transactions/transaction-steps/TransactionButton'
+import { useStepsTransactionState } from '@repo/lib/modules/transactions/transaction-steps/useStepsTransactionState'
+import { getChainId } from '@repo/lib/config/app.config'
+import { encodeFunctionData } from 'viem'
+import { sentryMetaForWagmiSimulation } from '@repo/lib/shared/utils/query-errors'
+import { useTenderly } from '@repo/lib/modules/web3/useTenderly'
+import { isTransactionSuccess } from '@repo/lib/modules/transactions/transaction-steps/transaction.helper'
 
 type Params = {
   poolTokens: PoolCreationToken[]
-  chain: GqlChain
+  network: GqlChain
+  isPoolInitialized: boolean
 }
 
-export function useBoostUnderlyingSteps({ poolTokens, chain }: Params) {
+export function useBoostUnderlyingSteps({ poolTokens, network, isPoolInitialized }: Params) {
   const { getToken } = useTokens()
 
   const poolTokensToBoost = poolTokens
@@ -21,58 +30,152 @@ export function useBoostUnderlyingSteps({ poolTokens, chain }: Params) {
         !token.data ||
         !isApiToken(token.data) ||
         !token.data.underlyingTokenAddress ||
-        !token.amount ||
         !token.address
       ) {
         throw new Error('missing requiried data for boosting underlying tokens')
       }
 
       return {
-        wrappedTokenAddress: token.address,
-        wrappedTokenAmountRaw: parseUnits(token.amount, token.data.decimals),
-        underlyingTokenAddress: token.data.underlyingTokenAddress as Address,
+        wrappedAddress: token.address,
+        wrappedAmountRaw: parseUnits(token.amount, token.data.decimals),
+        underlyingAddress: token.data.underlyingTokenAddress as Address,
       }
     })
 
-  const underlyingAmountReads = poolTokensToBoost.map(
-    ({ wrappedTokenAddress, wrappedTokenAmountRaw }) => ({
-      address: wrappedTokenAddress,
+  const { data: underlyingAmounts, isLoading: isLoadingUnderlyingAmounts } = useReadContracts({
+    contracts: poolTokensToBoost.map(({ wrappedAddress, wrappedAmountRaw }) => ({
+      address: wrappedAddress,
       abi: erc4626Abi,
       functionName: 'previewMint' as const,
-      args: [wrappedTokenAmountRaw],
-    })
-  )
-
-  const { data: underlyingAmounts, isLoading: isLoadingUnderlyingAmounts } = useReadContracts({
-    contracts: underlyingAmountReads,
+      args: [wrappedAmountRaw],
+    })),
     query: { enabled: poolTokensToBoost.length > 0 },
   })
 
   const tokenToSpender = Object.fromEntries(
-    poolTokensToBoost.map(({ underlyingTokenAddress, wrappedTokenAddress }) => [
-      underlyingTokenAddress,
-      wrappedTokenAddress,
-    ])
+    poolTokensToBoost.map(t => [t.underlyingAddress, t.wrappedAddress])
   ) as Record<Address, Address>
 
-  const approvalAmounts = poolTokensToBoost.map(({ underlyingTokenAddress }, index) => ({
-    address: underlyingTokenAddress,
-    rawAmount: underlyingAmounts?.[index]?.result ?? 0n,
-    symbol: getToken(underlyingTokenAddress, chain)?.symbol,
-  }))
+  const amounts = poolTokensToBoost.map((t, index) => {
+    const symbol = getToken(t.underlyingAddress, network)?.symbol
+    const underlyingAmountRaw = underlyingAmounts?.[index]?.result ?? 0n
+
+    return { ...t, underlyingAmountRaw, symbol }
+  })
 
   const { steps: approvalSteps, isLoading: isLoadingApprovalSteps } = useTokenApprovalSteps({
     spenderAddress: (tokenAddress: Address) => tokenToSpender[tokenAddress],
-    chain,
-    approvalAmounts,
+    chain: network,
+    approvalAmounts: amounts.map(a => ({
+      ...a,
+      address: a.underlyingAddress,
+      rawAmount: a.underlyingAmountRaw,
+    })),
     actionType: 'Wrapping',
     enabled: poolTokensToBoost.length > 0 && !isLoadingUnderlyingAmounts,
   })
 
-  // TODO: deposit into erc4626 steps
-
-  const isLoading = isLoadingUnderlyingAmounts || isLoadingApprovalSteps
-  const steps = [...approvalSteps]
+  const { depositSteps, isLoadingDepositSteps } = useDepositSteps(
+    amounts,
+    network,
+    isPoolInitialized
+  )
+  const isLoading = isLoadingUnderlyingAmounts || isLoadingApprovalSteps || isLoadingDepositSteps
+  const steps = [...approvalSteps, ...depositSteps]
 
   return { steps, isLoading }
+}
+
+type BoostAmounts = {
+  underlyingAmountRaw: bigint
+  symbol: string | undefined
+  wrappedAddress: `0x${string}`
+  wrappedAmountRaw: bigint
+  underlyingAddress: `0x${string}`
+}[]
+
+function useDepositSteps(amounts: BoostAmounts, network: GqlChain, isPoolInitialized: boolean) {
+  const { userAddress } = useUserAccount()
+  const chainId = getChainId(network)
+
+  const { getTransaction, setTransactionFn } = useStepsTransactionState()
+  const { buildTenderlyUrl } = useTenderly({ chainId })
+
+  const {
+    data: userWrappedBalances,
+    isLoading: isLoadingWrappedBalances,
+    refetch: refetchWrappedUserBalances,
+  } = useReadContracts({
+    contracts: amounts.map(a => ({
+      chainId,
+      address: a.wrappedAddress,
+      abi: erc4626Abi,
+      functionName: 'balanceOf' as const,
+      args: [userAddress],
+    })),
+  })
+
+  const depositSteps = amounts.map(
+    ({ wrappedAddress, underlyingAmountRaw, symbol, wrappedAmountRaw }, idx) => {
+      const id = `deposit-${wrappedAddress}`
+
+      const labels = {
+        init: `Deposit ${symbol}`,
+        title: `Deposit ${symbol}`,
+        tooltip: `Deposit ${symbol}`,
+        confirming: `Confirming deposit ${symbol}`,
+        confirmed: `Deposit ${symbol} confirmed`,
+      }
+
+      const txConfig = {
+        account: userAddress,
+        chainId,
+        to: wrappedAddress,
+        data: encodeFunctionData({
+          abi: erc4626Abi,
+          functionName: 'deposit',
+          args: [underlyingAmountRaw, userAddress],
+        }),
+      }
+
+      const gasEstimationMeta = sentryMetaForWagmiSimulation(
+        'Error in finalize pool gas estimation',
+        {
+          buildCallQueryData: txConfig,
+          tenderlyUrl: buildTenderlyUrl(txConfig),
+        }
+      )
+
+      // TODO: parse receipt logs for amount minted to replace init amount?
+      const transaction = getTransaction(id)
+
+      // get user balance for wrapped token
+      const wrappedBalance = userWrappedBalances?.[idx]?.result ?? 0n
+      const hasSufficientWrappedBalance = wrappedBalance >= wrappedAmountRaw
+      const isComplete = () =>
+        isTransactionSuccess(transaction) || hasSufficientWrappedBalance || isPoolInitialized
+
+      return {
+        id,
+        stepType: 'depositUnderlying' as const,
+        labels,
+        transaction,
+        renderAction: () => (
+          <ManagedSendTransactionButton
+            gasEstimationMeta={gasEstimationMeta}
+            id={id}
+            key={id}
+            labels={labels}
+            onTransactionChange={setTransactionFn(id)}
+            txConfig={txConfig}
+          />
+        ),
+        onTransactionChange: setTransactionFn(id),
+        isComplete,
+        onSuccess: () => refetchWrappedUserBalances(),
+      }
+    }
+  )
+
+  return { depositSteps, isLoadingDepositSteps: isLoadingWrappedBalances }
 }

--- a/packages/lib/modules/pool/actions/create/modal/useBoostUnderlyingSteps.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/useBoostUnderlyingSteps.tsx
@@ -1,5 +1,5 @@
 import { PoolCreationToken } from '../types'
-import { useReadContracts } from 'wagmi'
+import { usePublicClient, useReadContracts } from 'wagmi'
 import { erc4626Abi, parseUnits, Address } from 'viem'
 import { isApiToken } from '../helpers'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
@@ -12,7 +12,9 @@ import { getChainId } from '@repo/lib/config/app.config'
 import { encodeFunctionData } from 'viem'
 import { sentryMetaForWagmiSimulation } from '@repo/lib/shared/utils/query-errors'
 import { useTenderly } from '@repo/lib/modules/web3/useTenderly'
-import { isTransactionSuccess } from '@repo/lib/modules/transactions/transaction-steps/transaction.helper'
+import { parseDepositUnderlyingReceipt } from '@repo/lib/modules/transactions/transaction-steps/receipts/receipt-parsers'
+import { usePoolCreationForm } from '../PoolCreationFormProvider'
+import { isSameAddress } from '@repo/lib/shared/utils/addresses'
 
 type Params = {
   poolTokens: PoolCreationToken[]
@@ -36,31 +38,34 @@ export function useBoostUnderlyingSteps({ poolTokens, network, isPoolInitialized
       }
 
       return {
-        wrappedAddress: token.address,
-        wrappedAmountRaw: parseUnits(token.amount, token.data.decimals),
-        underlyingAddress: token.data.underlyingTokenAddress as Address,
+        wrapped: {
+          address: token.address,
+          amountRaw: parseUnits(token.amount, token.data.decimals),
+          symbol: token.data.symbol,
+        },
+        underlying: { address: token.data.underlyingTokenAddress as Address },
       }
     })
 
   const { data: underlyingAmounts, isLoading: isLoadingUnderlyingAmounts } = useReadContracts({
-    contracts: poolTokensToBoost.map(({ wrappedAddress, wrappedAmountRaw }) => ({
-      address: wrappedAddress,
+    contracts: poolTokensToBoost.map(({ wrapped }) => ({
+      address: wrapped.address,
       abi: erc4626Abi,
       functionName: 'previewMint' as const,
-      args: [wrappedAmountRaw],
+      args: [wrapped.amountRaw],
     })),
     query: { enabled: poolTokensToBoost.length > 0 },
   })
 
   const tokenToSpender = Object.fromEntries(
-    poolTokensToBoost.map(t => [t.underlyingAddress, t.wrappedAddress])
+    poolTokensToBoost.map(t => [t.underlying.address, t.wrapped.address])
   ) as Record<Address, Address>
 
   const amounts = poolTokensToBoost.map((t, index) => {
-    const symbol = getToken(t.underlyingAddress, network)?.symbol
-    const underlyingAmountRaw = underlyingAmounts?.[index]?.result ?? 0n
+    const symbol = getToken(t.underlying.address, network)?.symbol
+    const amountRaw = underlyingAmounts?.[index]?.result ?? 0n
 
-    return { ...t, underlyingAmountRaw, symbol }
+    return { ...t, underlying: { ...t.underlying, amountRaw, symbol } }
   })
 
   const { steps: approvalSteps, isLoading: isLoadingApprovalSteps } = useTokenApprovalSteps({
@@ -68,18 +73,15 @@ export function useBoostUnderlyingSteps({ poolTokens, network, isPoolInitialized
     chain: network,
     approvalAmounts: amounts.map(a => ({
       ...a,
-      address: a.underlyingAddress,
-      rawAmount: a.underlyingAmountRaw,
+      address: a.underlying.address,
+      rawAmount: a.underlying.amountRaw,
     })),
     actionType: 'Wrapping',
     enabled: poolTokensToBoost.length > 0 && !isLoadingUnderlyingAmounts,
   })
 
-  const { depositSteps, isLoadingDepositSteps } = useDepositSteps(
-    amounts,
-    network,
-    isPoolInitialized
-  )
+  const depositStepsParams = { poolTokens, amounts, network, isPoolInitialized }
+  const { depositSteps, isLoadingDepositSteps } = useDepositSteps(depositStepsParams)
   const isLoading = isLoadingUnderlyingAmounts || isLoadingApprovalSteps || isLoadingDepositSteps
   const steps = [...approvalSteps, ...depositSteps]
 
@@ -87,16 +89,31 @@ export function useBoostUnderlyingSteps({ poolTokens, network, isPoolInitialized
 }
 
 type BoostAmounts = {
-  underlyingAmountRaw: bigint
-  symbol: string | undefined
-  wrappedAddress: `0x${string}`
-  wrappedAmountRaw: bigint
-  underlyingAddress: `0x${string}`
+  underlying: {
+    amountRaw: bigint
+    symbol: string | undefined
+    address: `0x${string}`
+  }
+  wrapped: {
+    address: `0x${string}`
+    amountRaw: bigint
+    symbol: string | undefined
+  }
 }[]
 
-function useDepositSteps(amounts: BoostAmounts, network: GqlChain, isPoolInitialized: boolean) {
+type DepositStepsParams = {
+  poolTokens: PoolCreationToken[]
+  amounts: BoostAmounts
+  network: GqlChain
+  isPoolInitialized: boolean
+}
+
+function useDepositSteps({ poolTokens, amounts, network, isPoolInitialized }: DepositStepsParams) {
+  const { getToken } = useTokens()
   const { userAddress } = useUserAccount()
   const chainId = getChainId(network)
+  const { updatePoolToken } = usePoolCreationForm()
+  const publicClient = usePublicClient({ chainId })
 
   const { getTransaction, setTransactionFn } = useStepsTransactionState()
   const { buildTenderlyUrl } = useTenderly({ chainId })
@@ -108,74 +125,92 @@ function useDepositSteps(amounts: BoostAmounts, network: GqlChain, isPoolInitial
   } = useReadContracts({
     contracts: amounts.map(a => ({
       chainId,
-      address: a.wrappedAddress,
+      address: a.wrapped.address,
       abi: erc4626Abi,
       functionName: 'balanceOf' as const,
       args: [userAddress],
     })),
   })
 
-  const depositSteps = amounts.map(
-    ({ wrappedAddress, underlyingAmountRaw, symbol, wrappedAmountRaw }, idx) => {
-      const id = `deposit-${wrappedAddress}`
+  const depositSteps = amounts.map(({ underlying, wrapped }, idx) => {
+    const id = `deposit-${wrapped.address}`
 
-      const labels = {
-        init: `Deposit ${symbol}`,
-        title: `Deposit ${symbol}`,
-        tooltip: `Deposit ${symbol}`,
-        confirming: `Confirming deposit ${symbol}`,
-        confirmed: `Deposit ${symbol} confirmed`,
-      }
-
-      const txConfig = {
-        account: userAddress,
-        chainId,
-        to: wrappedAddress,
-        data: encodeFunctionData({
-          abi: erc4626Abi,
-          functionName: 'deposit',
-          args: [underlyingAmountRaw, userAddress],
-        }),
-      }
-
-      const gasEstimationMeta = sentryMetaForWagmiSimulation(
-        'Error in finalize pool gas estimation',
-        {
-          buildCallQueryData: txConfig,
-          tenderlyUrl: buildTenderlyUrl(txConfig),
-        }
-      )
-
-      // TODO: parse receipt logs for amount minted to replace init amount?
-      const transaction = getTransaction(id)
-
-      // get user balance for wrapped token
-      const wrappedBalance = userWrappedBalances?.[idx]?.result ?? 0n
-      const hasSufficientWrappedBalance = wrappedBalance >= wrappedAmountRaw
-      const isComplete = () =>
-        isTransactionSuccess(transaction) || hasSufficientWrappedBalance || isPoolInitialized
-
-      return {
-        id,
-        stepType: 'depositUnderlying' as const,
-        labels,
-        transaction,
-        renderAction: () => (
-          <ManagedSendTransactionButton
-            gasEstimationMeta={gasEstimationMeta}
-            id={id}
-            key={id}
-            labels={labels}
-            onTransactionChange={setTransactionFn(id)}
-            txConfig={txConfig}
-          />
-        ),
-        onTransactionChange: setTransactionFn(id),
-        isComplete,
-        onSuccess: () => refetchWrappedUserBalances(),
-      }
+    const labels = {
+      init: `Deposit ${underlying.symbol} to ${wrapped.symbol}`,
+      title: `Deposit ${underlying.symbol} to ${wrapped.symbol}`,
+      tooltip: `Deposit ${underlying.symbol} into ${wrapped.symbol} vault`,
+      confirming: `Confirming deposit ${underlying.symbol}`,
+      confirmed: `Deposit ${underlying.symbol} confirmed`,
     }
-  )
+
+    const txConfig = {
+      account: userAddress,
+      chainId,
+      to: wrapped.address,
+      data: encodeFunctionData({
+        abi: erc4626Abi,
+        functionName: 'deposit',
+        args: [underlying.amountRaw, userAddress],
+      }),
+    }
+
+    const gasEstimationMeta = sentryMetaForWagmiSimulation(
+      'Error in finalize pool gas estimation',
+      {
+        buildCallQueryData: txConfig,
+        tenderlyUrl: buildTenderlyUrl(txConfig),
+      }
+    )
+
+    const transaction = getTransaction(id)
+
+    const wrappedBalanceRaw = userWrappedBalances?.[idx]?.result ?? 0n
+    const hasSufficientWrappedBalance = wrappedBalanceRaw >= wrapped.amountRaw
+    const isComplete = () => hasSufficientWrappedBalance || isPoolInitialized
+
+    return {
+      id,
+      stepType: 'depositUnderlying' as const,
+      labels,
+      transaction,
+      renderAction: () => (
+        <ManagedSendTransactionButton
+          gasEstimationMeta={gasEstimationMeta}
+          id={id}
+          key={id}
+          labels={labels}
+          onTransactionChange={setTransactionFn(id)}
+          txConfig={txConfig}
+        />
+      ),
+      onTransactionChange: setTransactionFn(id),
+      isComplete,
+      onSuccess: async () => {
+        if (!transaction?.execution?.data) return
+        if (!publicClient) throw new Error('missing public client')
+
+        const receipt = await publicClient.getTransactionReceipt({
+          hash: transaction?.execution?.data,
+        })
+
+        const { mintedShares } = parseDepositUnderlyingReceipt({
+          receiptLogs: receipt.logs,
+          chain: network,
+          getToken,
+          userAddress,
+          txValue: 0n,
+          protocolVersion: 3,
+        })
+
+        if (mintedShares) {
+          const idx = poolTokens.findIndex(t => isSameAddress(t.address, wrapped.address))
+          updatePoolToken(idx, { amount: mintedShares.humanAmount })
+        }
+
+        refetchWrappedUserBalances()
+      },
+    }
+  })
 
   return { depositSteps, isLoadingDepositSteps: isLoadingWrappedBalances }
 }

--- a/packages/lib/modules/pool/actions/create/modal/useBoostUnderlyingSteps.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/useBoostUnderlyingSteps.tsx
@@ -1,6 +1,6 @@
 import { PoolCreationToken } from '../types'
 import { usePublicClient, useReadContracts } from 'wagmi'
-import { erc4626Abi, parseUnits, Address } from 'viem'
+import { erc4626Abi, parseUnits, Address, encodeFunctionData, formatUnits } from 'viem'
 import { isApiToken } from '../helpers'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { useTokenApprovalSteps } from '@repo/lib/modules/tokens/approvals/useTokenApprovalSteps'
@@ -9,7 +9,6 @@ import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { ManagedSendTransactionButton } from '@repo/lib/modules/transactions/transaction-steps/TransactionButton'
 import { useStepsTransactionState } from '@repo/lib/modules/transactions/transaction-steps/useStepsTransactionState'
 import { getChainId } from '@repo/lib/config/app.config'
-import { encodeFunctionData } from 'viem'
 import { sentryMetaForWagmiSimulation } from '@repo/lib/shared/utils/query-errors'
 import { useTenderly } from '@repo/lib/modules/web3/useTenderly'
 import { parseDepositUnderlyingReceipt } from '@repo/lib/modules/transactions/transaction-steps/receipts/receipt-parsers'
@@ -23,6 +22,45 @@ type Params = {
 }
 
 export function useBoostUnderlyingSteps({ poolTokens, network, isPoolInitialized }: Params) {
+  const { poolTokenBoostAmounts, isLoadingUnderlyingAmounts } = usePoolTokenBoostAmounts({
+    poolTokens,
+    network,
+  })
+
+  const tokenToSpender = Object.fromEntries(
+    poolTokenBoostAmounts.map(t => [t.underlying.address, t.wrapped.address])
+  ) as Record<Address, Address>
+
+  const { steps: approvalSteps, isLoading: isLoadingApprovalSteps } = useTokenApprovalSteps({
+    spenderAddress: (tokenAddress: Address) => tokenToSpender[tokenAddress],
+    chain: network,
+    approvalAmounts: poolTokenBoostAmounts.map(a => ({
+      symbol: a.underlying.symbol,
+      address: a.underlying.address,
+      rawAmount: a.underlying.amountRaw,
+    })),
+    actionType: 'Wrapping',
+    enabled: poolTokenBoostAmounts.length > 0 && !isLoadingUnderlyingAmounts,
+  })
+
+  const depositStepsParams = {
+    poolTokens,
+    amounts: poolTokenBoostAmounts,
+    network,
+    isPoolInitialized,
+  }
+  const { depositSteps, isLoadingDepositSteps } = useDepositSteps(depositStepsParams)
+  const isLoading = isLoadingUnderlyingAmounts || isLoadingApprovalSteps || isLoadingDepositSteps
+  const steps = [...approvalSteps, ...depositSteps]
+
+  return { steps, isLoading }
+}
+
+type UsePoolTokenBoostAmountsParams = {
+  poolTokens: PoolCreationToken[]
+  network: GqlChain
+}
+export function usePoolTokenBoostAmounts({ poolTokens, network }: UsePoolTokenBoostAmountsParams) {
   const { getToken } = useTokens()
 
   const poolTokensToBoost = poolTokens
@@ -38,6 +76,7 @@ export function useBoostUnderlyingSteps({ poolTokens, network, isPoolInitialized
       }
 
       return {
+        poolTokensIndex: poolTokens.findIndex(t => isSameAddress(t.address, token.address)),
         wrapped: {
           address: token.address,
           amountRaw: parseUnits(token.amount, token.data.decimals),
@@ -57,38 +96,22 @@ export function useBoostUnderlyingSteps({ poolTokens, network, isPoolInitialized
     query: { enabled: poolTokensToBoost.length > 0 },
   })
 
-  const tokenToSpender = Object.fromEntries(
-    poolTokensToBoost.map(t => [t.underlying.address, t.wrapped.address])
-  ) as Record<Address, Address>
-
-  const amounts = poolTokensToBoost.map((t, index) => {
-    const symbol = getToken(t.underlying.address, network)?.symbol
+  const poolTokenBoostAmounts = poolTokensToBoost.map((t, index) => {
+    const underlyingToken = getToken(t.underlying.address, network)
     const amountRaw = underlyingAmounts?.[index]?.result ?? 0n
+    const amountHuman = formatUnits(amountRaw, underlyingToken?.decimals || 0)
 
-    return { ...t, underlying: { ...t.underlying, amountRaw, symbol } }
+    return {
+      ...t,
+      underlying: { ...t.underlying, amountRaw, amountHuman, symbol: underlyingToken?.symbol },
+    }
   })
 
-  const { steps: approvalSteps, isLoading: isLoadingApprovalSteps } = useTokenApprovalSteps({
-    spenderAddress: (tokenAddress: Address) => tokenToSpender[tokenAddress],
-    chain: network,
-    approvalAmounts: amounts.map(a => ({
-      ...a,
-      address: a.underlying.address,
-      rawAmount: a.underlying.amountRaw,
-    })),
-    actionType: 'Wrapping',
-    enabled: poolTokensToBoost.length > 0 && !isLoadingUnderlyingAmounts,
-  })
-
-  const depositStepsParams = { poolTokens, amounts, network, isPoolInitialized }
-  const { depositSteps, isLoadingDepositSteps } = useDepositSteps(depositStepsParams)
-  const isLoading = isLoadingUnderlyingAmounts || isLoadingApprovalSteps || isLoadingDepositSteps
-  const steps = [...approvalSteps, ...depositSteps]
-
-  return { steps, isLoading }
+  return { poolTokenBoostAmounts, isLoadingUnderlyingAmounts }
 }
 
 type BoostAmounts = {
+  poolTokensIndex: number
   underlying: {
     amountRaw: bigint
     symbol: string | undefined
@@ -102,13 +125,12 @@ type BoostAmounts = {
 }[]
 
 type DepositStepsParams = {
-  poolTokens: PoolCreationToken[]
   amounts: BoostAmounts
   network: GqlChain
   isPoolInitialized: boolean
 }
 
-function useDepositSteps({ poolTokens, amounts, network, isPoolInitialized }: DepositStepsParams) {
+function useDepositSteps({ amounts, network, isPoolInitialized }: DepositStepsParams) {
   const { getToken } = useTokens()
   const { userAddress } = useUserAccount()
   const chainId = getChainId(network)
@@ -132,7 +154,7 @@ function useDepositSteps({ poolTokens, amounts, network, isPoolInitialized }: De
     })),
   })
 
-  const depositSteps = amounts.map(({ underlying, wrapped }, idx) => {
+  const depositSteps = amounts.map(({ underlying, wrapped, poolTokensIndex }, idx) => {
     const id = `deposit-${wrapped.address}`
 
     const labels = {
@@ -203,8 +225,7 @@ function useDepositSteps({ poolTokens, amounts, network, isPoolInitialized }: De
         })
 
         if (mintedShares) {
-          const idx = poolTokens.findIndex(t => isSameAddress(t.address, wrapped.address))
-          updatePoolToken(idx, { amount: mintedShares.humanAmount })
+          updatePoolToken(poolTokensIndex, { amount: mintedShares.humanAmount })
         }
 
         refetchWrappedUserBalances()

--- a/packages/lib/modules/pool/actions/create/modal/useBoostUnderlyingSteps.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/useBoostUnderlyingSteps.tsx
@@ -1,0 +1,78 @@
+import { PoolCreationToken } from '../types'
+import { useReadContracts } from 'wagmi'
+import { erc4626Abi, parseUnits, Address } from 'viem'
+import { isApiToken } from '../helpers'
+import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
+import { useTokenApprovalSteps } from '@repo/lib/modules/tokens/approvals/useTokenApprovalSteps'
+import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
+
+type Params = {
+  poolTokens: PoolCreationToken[]
+  chain: GqlChain
+}
+
+export function useBoostUnderlyingSteps({ poolTokens, chain }: Params) {
+  const { getToken } = useTokens()
+
+  const poolTokensToBoost = poolTokens
+    .filter(token => token.isBoostingUnderlying)
+    .map(token => {
+      if (
+        !token.data ||
+        !isApiToken(token.data) ||
+        !token.data.underlyingTokenAddress ||
+        !token.amount ||
+        !token.address
+      ) {
+        throw new Error('missing requiried data for boosting underlying tokens')
+      }
+
+      return {
+        wrappedTokenAddress: token.address,
+        wrappedTokenAmountRaw: parseUnits(token.amount, token.data.decimals),
+        underlyingTokenAddress: token.data.underlyingTokenAddress as Address,
+      }
+    })
+
+  const underlyingAmountReads = poolTokensToBoost.map(
+    ({ wrappedTokenAddress, wrappedTokenAmountRaw }) => ({
+      address: wrappedTokenAddress,
+      abi: erc4626Abi,
+      functionName: 'previewMint' as const,
+      args: [wrappedTokenAmountRaw],
+    })
+  )
+
+  const { data: underlyingAmounts, isLoading: isLoadingUnderlyingAmounts } = useReadContracts({
+    contracts: underlyingAmountReads,
+    query: { enabled: poolTokensToBoost.length > 0 },
+  })
+
+  const tokenToSpender = Object.fromEntries(
+    poolTokensToBoost.map(({ underlyingTokenAddress, wrappedTokenAddress }) => [
+      underlyingTokenAddress,
+      wrappedTokenAddress,
+    ])
+  ) as Record<Address, Address>
+
+  const approvalAmounts = poolTokensToBoost.map(({ underlyingTokenAddress }, index) => ({
+    address: underlyingTokenAddress,
+    rawAmount: underlyingAmounts?.[index]?.result ?? 0n,
+    symbol: getToken(underlyingTokenAddress, chain)?.symbol,
+  }))
+
+  const { steps: approvalSteps, isLoading: isLoadingApprovalSteps } = useTokenApprovalSteps({
+    spenderAddress: (tokenAddress: Address) => tokenToSpender[tokenAddress],
+    chain,
+    approvalAmounts,
+    actionType: 'Wrapping',
+    enabled: poolTokensToBoost.length > 0 && !isLoadingUnderlyingAmounts,
+  })
+
+  // TODO: deposit into erc4626 steps
+
+  const isLoading = isLoadingUnderlyingAmounts || isLoadingApprovalSteps
+  const steps = [...approvalSteps]
+
+  return { steps, isLoading }
+}

--- a/packages/lib/modules/pool/actions/create/modal/usePoolCreationTransactions.ts
+++ b/packages/lib/modules/pool/actions/create/modal/usePoolCreationTransactions.ts
@@ -16,12 +16,14 @@ import { useInitializePoolStep } from './useInitializePoolStep'
 import { CreatePoolInput } from '../types'
 import { isCowPool } from '../helpers'
 import { useCreateCowSteps } from './cow-amm-steps/useCreateCowSteps'
+import { TransactionStep } from '@repo/lib/modules/transactions/transaction-steps/lib'
 
 type Props = {
   createPoolInput: CreatePoolInput
   initPoolInput: ExtendedInitPoolInput
   poolAddress: Address | undefined
   setPoolAddress: (poolAddress: Address) => void
+  boostUnderlying?: { steps: TransactionStep[]; isLoading: boolean }
 }
 
 export function usePoolCreationTransactions({
@@ -29,6 +31,7 @@ export function usePoolCreationTransactions({
   initPoolInput,
   poolAddress,
   setPoolAddress,
+  boostUnderlying,
 }: Props) {
   const { poolType, protocolVersion } = createPoolInput
   const { amountsIn, wethIsEth, chainId } = initPoolInput
@@ -84,14 +87,18 @@ export function usePoolCreationTransactions({
   })
   const cowSteps = [...tokenApprovalSteps, ...finishCowSteps]
 
-  const steps = [createPoolStep, ...(isCowPool(poolType) ? cowSteps : v3Steps)]
+  const steps = [
+    createPoolStep,
+    ...(isCowPool(poolType) ? cowSteps : [...(boostUnderlying?.steps || []), ...v3Steps]),
+  ]
 
   const isLoadingSteps =
     isLoadingTokenApprovalSteps ||
     !signPermit2Step ||
     isLoadingTokenApprovalSteps ||
     isLoadingPermit2ApprovalSteps ||
-    isLoadingFinishCowSteps
+    isLoadingFinishCowSteps ||
+    boostUnderlying?.isLoading
 
   const transactionSteps = useTransactionSteps(steps, isLoadingSteps)
   const initPoolTxHash = transactionSteps.lastTransaction?.result?.data?.transactionHash

--- a/packages/lib/modules/pool/actions/create/steps/fund/PoolFundStep.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/fund/PoolFundStep.tsx
@@ -10,7 +10,7 @@ import { SeedPoolAlert } from './SeedPoolAlert'
 import { SeedAmountInput } from './SeedAmountInput'
 
 export function PoolFundStep() {
-  const { poolAddress, poolCreationForm } = usePoolCreationForm()
+  const { poolAddress, poolCreationForm, isBoostingUnderlying } = usePoolCreationForm()
   const [poolType, poolTokens, hasAcceptedTokenWeightsRisk, hasAcceptedPoolCreationRisk] = useWatch(
     {
       control: poolCreationForm.control,
@@ -24,7 +24,8 @@ export function PoolFundStep() {
   )
   const { hasValidationErrors } = useTokenInputsValidation()
 
-  const isTokenAmountsValid = !hasValidationErrors || (isReClammPool(poolType) && !poolAddress)
+  const isTokenAmountsValid =
+    !hasValidationErrors || (isReClammPool(poolType) && !poolAddress) || isBoostingUnderlying
 
   const isWeightRiskRequired = isWeightedPool(poolType) || isCowPool(poolType)
 

--- a/packages/lib/modules/pool/actions/create/steps/fund/SeedAmountInput.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/fund/SeedAmountInput.tsx
@@ -10,7 +10,9 @@ import { useWatch } from 'react-hook-form'
 import { VStack, Text } from '@chakra-ui/react'
 import { useTokenInputsValidation } from '@repo/lib/modules/tokens/TokenInputsValidationProvider'
 import { validatePoolTokens } from '../../validatePoolCreationForm'
-
+import { usePoolTokenBoostAmounts } from '../../modal/useBoostUnderlyingSteps'
+import { isSameAddress } from '@repo/lib/shared/utils/addresses'
+import { BalAlert } from '@repo/lib/shared/components/alerts/BalAlert'
 interface TokenAmountInputProps {
   token: PoolCreationToken
   idx: number
@@ -30,6 +32,11 @@ export function SeedAmountInput({ token, idx, poolType, poolTokens }: TokenAmoun
 
   const otherTokenInputIdx = idx === 0 ? 1 : 0
   const otherToken = poolTokens[otherTokenInputIdx]
+
+  const { poolTokenBoostAmounts } = usePoolTokenBoostAmounts({ network, poolTokens })
+  const boostToken = poolTokenBoostAmounts.find(amount =>
+    isSameAddress(amount.wrapped.address, token.address)
+  )
 
   useEffect(() => {
     if (!token.address) return
@@ -89,6 +96,7 @@ export function SeedAmountInput({ token, idx, poolType, poolTokens }: TokenAmoun
   return (
     <VStack align="start" key={idx} spacing="sm" w="full">
       <Text fontWeight="bold">Token {idx + 1}</Text>
+
       <TokenInput
         apiToken={token.data}
         aria-label={`Token ${idx + 1}`}
@@ -97,6 +105,13 @@ export function SeedAmountInput({ token, idx, poolType, poolTokens }: TokenAmoun
         onChange={e => handleAmountChange(idx, e.currentTarget.value)}
         value={token.amount}
       />
+
+      {boostToken && (
+        <BalAlert
+          content={`You will be required to deposit ${boostToken?.underlying?.amountHuman} ${boostToken?.underlying?.symbol}`}
+          status="warning"
+        />
+      )}
     </VStack>
   )
 }

--- a/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
@@ -47,7 +47,7 @@ import { useFormState, useWatch } from 'react-hook-form'
 import { TooltipWithTouch } from '@repo/lib/shared/components/tooltips/TooltipWithTouch'
 import { BalAlert } from '@repo/lib/shared/components/alerts/BalAlert'
 import { BalAlertButton } from '@repo/lib/shared/components/alerts/BalAlertButton'
-import { useBoostWhitelist } from '../../useBoostWhitelist'
+import { useBoostedTokenOptions } from '../../useBoostedTokenOptions'
 import { getChainShortName } from '@repo/lib/config/app.config'
 
 export function ChoosePoolTokens() {
@@ -94,8 +94,10 @@ export function ChoosePoolTokens() {
       : undefined
   }
 
-  function handleTokenSelect(tokenMetadata: ApiOrCustomToken) {
-    if (!tokenMetadata || selectedTokenIndex === null) return
+  function handleTokenSelect(tokenMetadata: ApiOrCustomToken, selectedBoostIndex?: number) {
+    const tokenIndex = selectedTokenIndex ?? selectedBoostIndex ?? null
+
+    if (!tokenMetadata || tokenIndex === null) return
 
     let rateProvider: Address = zeroAddress
 
@@ -103,12 +105,15 @@ export function ChoosePoolTokens() {
       rateProvider = getVerifiedRateProviderAddress(tokenMetadata) ?? zeroAddress
     }
 
-    updatePoolToken(selectedTokenIndex, {
+    const isBoostingUnderlying = selectedBoostIndex !== undefined
+
+    updatePoolToken(tokenIndex, {
       address: tokenMetadata.address as Address,
       rateProvider,
       data: tokenMetadata,
       paysYieldFees: rateProvider !== zeroAddress,
       usdPrice: '',
+      isBoostingUnderlying,
     })
 
     setSelectedTokenIndex(null)
@@ -135,12 +140,8 @@ export function ChoosePoolTokens() {
         <VStack align="start" spacing="0" w="full">
           <AnimatePresence initial={false}>
             {poolTokens.map((token, index) => {
-              const tokenData = listedTokens.find(
-                t => t.address.toLowerCase() === token.address?.toLowerCase()
-              ) as ApiToken
-
-              const verifiedRateProviderAddress = tokenData
-                ? getVerifiedRateProviderAddress(tokenData)
+              const verifiedRateProviderAddress = token.data
+                ? getVerifiedRateProviderAddress(token.data as ApiToken)
                 : undefined
 
               return (
@@ -154,6 +155,7 @@ export function ChoosePoolTokens() {
                 >
                   <Box pb="xl">
                     <ConfigureToken
+                      handleTokenSelect={handleTokenSelect}
                       index={index}
                       network={network}
                       onToggleTokenClicked={() => {
@@ -163,6 +165,7 @@ export function ChoosePoolTokens() {
                       poolTokens={poolTokens}
                       poolType={poolType}
                       rateProviderAddress={verifiedRateProviderAddress}
+                      setSelectedTokenIndex={setSelectedTokenIndex}
                       token={token}
                       weightedPoolStructure={weightedPoolStructure}
                     />
@@ -216,23 +219,31 @@ interface ConfigureTokenProps {
   poolTokens: PoolCreationToken[]
   network: GqlChain
   poolType: SupportedPoolTypes
+  handleTokenSelect: (tokenMetadata: ApiOrCustomToken, selectedBoostIndex?: number) => void
+  setSelectedTokenIndex: (index: number) => void
 }
 
 function ConfigureToken({
   token,
   index,
+  handleTokenSelect,
   rateProviderAddress,
   onToggleTokenClicked,
   weightedPoolStructure,
   poolTokens,
   network,
   poolType,
+  setSelectedTokenIndex,
 }: ConfigureTokenProps) {
-  const boostTokenOptions = useBoostWhitelist(token.address)
+  const underlyingToken = token.isBoostingUnderlying
+    ? ((token.data as ApiToken | undefined)?.underlyingTokenAddress ?? undefined)
+    : token.address
+  const boostedTokenOptions = useBoostedTokenOptions(underlyingToken)
+  console.log('boostedTokenOptions', boostedTokenOptions)
   const { poolCreationForm, removePoolToken, updatePoolToken } = usePoolCreationForm()
   const formState = useFormState({ control: poolCreationForm.control })
 
-  const { priceFor } = useTokens()
+  const { priceFor, getToken } = useTokens()
 
   const apiPriceForToken = priceFor(token?.address || '', network)
   const { cgPriceForToken } = useCoingeckoTokenPrice({ token: token?.address, network })
@@ -254,8 +265,6 @@ function ConfigureToken({
 
   const showWeightInputs = isWeightedPool(poolType) || isCowPool(poolType)
   const showRateProvider = !isCowPool(poolType)
-
-  console.log('boostTokenOptions', boostTokenOptions)
 
   return (
     <VStack align="start" key={index} spacing="sm" w="full">
@@ -301,18 +310,31 @@ function ConfigureToken({
 
       {isWeightedPool(poolType) && <InvalidWeightInputAlert message={tokenWeightErrorMsg} />}
 
-      {boostTokenOptions && (
+      {boostedTokenOptions && (
         <BalAlert
           content={
             <VStack align="start" mb="sm" spacing="md">
-              <Text color="black">{`It’s recommended to use a Boosted version of ${token.data?.symbol} on the ${getChainShortName(network)} network. Balancer v3 is optimized for Boosted tokens. LPs will get additional yield, while still being able to interact with this pool using ${token.data?.symbol}.`}</Text>
-              {boostTokenOptions.map((option, index) => (
-                <BalAlertButton key={index}>Use {option.protocol} token</BalAlertButton>
+              <Text color="black">
+                {!token.isBoostingUnderlying
+                  ? `It’s recommended to use a Boosted version of ${token.data?.symbol} on the ${getChainShortName(network)} network. Balancer v3 is optimized for Boosted tokens. LPs will get additional yield, while still being able to interact with this pool using ${token.data?.symbol}.`
+                  : `You will wrap your ${getToken(underlyingToken || '', network)?.symbol} into ${token.data?.symbol} during the pool creation process.`}
+              </Text>
+              {boostedTokenOptions.map(option => (
+                <BalAlertButton
+                  isSelected={token.address === option.token.address}
+                  key={option.token.address}
+                  onClick={() => {
+                    setSelectedTokenIndex(index)
+                    handleTokenSelect(option.token, index)
+                  }}
+                >
+                  Use {option.protocol} token
+                </BalAlertButton>
               ))}
             </VStack>
           }
-          status="warning"
-          title="Use a Boosted token for better LP returns"
+          status={token.isBoostingUnderlying ? 'success' : 'warning'}
+          title={`${token.isBoostingUnderlying ? 'Using' : 'Use'} a Boosted token for better LP returns`}
         />
       )}
 

--- a/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
@@ -45,6 +45,10 @@ import { PoolType } from '@balancer/sdk'
 import { ChoosePoolTokensAlert } from './ChoosePoolTokensAlert'
 import { useFormState, useWatch } from 'react-hook-form'
 import { TooltipWithTouch } from '@repo/lib/shared/components/tooltips/TooltipWithTouch'
+import { BalAlert } from '@repo/lib/shared/components/alerts/BalAlert'
+import { BalAlertButton } from '@repo/lib/shared/components/alerts/BalAlertButton'
+import { useBoostWhitelist } from '../../useBoostWhitelist'
+import { getChainShortName } from '@repo/lib/config/app.config'
 
 export function ChoosePoolTokens() {
   const [selectedTokenIndex, setSelectedTokenIndex] = useState<number | null>(null)
@@ -224,6 +228,7 @@ function ConfigureToken({
   network,
   poolType,
 }: ConfigureTokenProps) {
+  const boostTokenOptions = useBoostWhitelist(token.address)
   const { poolCreationForm, removePoolToken, updatePoolToken } = usePoolCreationForm()
   const formState = useFormState({ control: poolCreationForm.control })
 
@@ -249,6 +254,8 @@ function ConfigureToken({
 
   const showWeightInputs = isWeightedPool(poolType) || isCowPool(poolType)
   const showRateProvider = !isCowPool(poolType)
+
+  console.log('boostTokenOptions', boostTokenOptions)
 
   return (
     <VStack align="start" key={index} spacing="sm" w="full">
@@ -293,6 +300,21 @@ function ConfigureToken({
       </HStack>
 
       {isWeightedPool(poolType) && <InvalidWeightInputAlert message={tokenWeightErrorMsg} />}
+
+      {boostTokenOptions && (
+        <BalAlert
+          content={
+            <VStack align="start" mb="sm" spacing="md">
+              <Text color="black">{`It’s recommended to use a Boosted version of ${token.data?.symbol} on the ${getChainShortName(network)} network. Balancer v3 is optimized for Boosted tokens. LPs will get additional yield, while still being able to interact with this pool using ${token.data?.symbol}.`}</Text>
+              {boostTokenOptions.map((option, index) => (
+                <BalAlertButton key={index}>Use {option.protocol} token</BalAlertButton>
+              ))}
+            </VStack>
+          }
+          status="warning"
+          title="Use a Boosted token for better LP returns"
+        />
+      )}
 
       {token.address && !apiPriceForToken && (
         <VStack align="start" spacing="sm" w="full">

--- a/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
@@ -314,9 +314,9 @@ function ConfigureToken({
           content={
             <VStack align="start" mb="sm" spacing="md">
               <Text color="black">
-                {!token.isBoostingUnderlying
-                  ? `It’s recommended to use a Boosted version of ${token.data?.symbol} on the ${getChainShortName(network)} network. Balancer v3 is optimized for Boosted tokens. LPs will get additional yield, while still being able to interact with this pool using ${token.data?.symbol}.`
-                  : `You will wrap your ${getToken(underlyingToken || '', network)?.symbol} into ${token.data?.symbol} during the pool creation process.`}
+                {token.isBoostingUnderlying
+                  ? `You will wrap your ${getToken(underlyingToken || '', network)?.symbol} into ${token.data?.symbol} during the pool creation process.`
+                  : `It’s recommended to use a Boosted version of ${token.data?.symbol} on the ${getChainShortName(network)} network. Balancer v3 is optimized for Boosted tokens. LPs will get additional yield, while still being able to interact with this pool using ${token.data?.symbol}.`}
               </Text>
               {boostedTokenOptions.map(option => (
                 <BalAlertButton

--- a/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
@@ -239,7 +239,6 @@ function ConfigureToken({
     ? ((token.data as ApiToken | undefined)?.underlyingTokenAddress ?? undefined)
     : token.address
   const boostedTokenOptions = useBoostedTokenOptions(underlyingToken)
-  console.log('boostedTokenOptions', boostedTokenOptions)
   const { poolCreationForm, removePoolToken, updatePoolToken } = usePoolCreationForm()
   const formState = useFormState({ control: poolCreationForm.control })
 

--- a/packages/lib/modules/pool/actions/create/types.ts
+++ b/packages/lib/modules/pool/actions/create/types.ts
@@ -42,6 +42,7 @@ export type PoolCreationToken = {
   paysYieldFees: boolean
   weight: string
   amount: string
+  isBoostingUnderlying: boolean
   data?: ApiOrCustomToken
   usdPrice?: string
 }

--- a/packages/lib/modules/pool/actions/create/useBoostWhitelist.ts
+++ b/packages/lib/modules/pool/actions/create/useBoostWhitelist.ts
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query'
+import { Address } from 'viem'
+import { useWatch } from 'react-hook-form'
+import { usePoolCreationForm } from './PoolCreationFormProvider'
+import { getChainId } from '@repo/lib/config/app.config'
+import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
+import { isSameAddress } from '@repo/lib/shared/utils/addresses'
+
+type BoostWhitelistResponse = {
+  id: string
+  name: string
+  description: string
+  icon: string
+  addresses: {
+    [key: string]: Address[]
+  }
+}[]
+
+const WHITELIST_URL = 'https://raw.githubusercontent.com/balancer/metadata/main/erc4626/index.json'
+const BOOSTED_FILTER = ['boosted_aave', 'boosted_morpho']
+
+export const useBoostWhitelist = (tokenAddress: Address | undefined) => {
+  const { getToken } = useTokens()
+  const { poolCreationForm } = usePoolCreationForm()
+  const [network] = useWatch({ control: poolCreationForm.control, name: ['network'] })
+  const chainId = getChainId(network)
+
+  const { data: boostWhitelist } = useQuery<BoostWhitelistResponse>({
+    queryKey: ['boostWhitelist'],
+    queryFn: async () => {
+      const response = await fetch(WHITELIST_URL)
+      return response.json()
+    },
+  })
+
+  const filteredBoostWhitelist = boostWhitelist
+    ?.filter(list => BOOSTED_FILTER.includes(list.id))
+    .map(list => {
+      return {
+        ...list,
+        addresses: list.addresses[chainId] || [],
+      }
+    })
+
+  const boostWhitelistMetadta = filteredBoostWhitelist?.map(protocol => {
+    return {
+      name: protocol.name,
+      tokens: protocol.addresses.map(address => getToken(address, network)),
+    }
+  })
+
+  const boostTokenOptions =
+    boostWhitelistMetadta
+      ?.map(protocol => {
+        return {
+          protocol: protocol.name,
+          token: protocol.tokens.find(boostedToken =>
+            isSameAddress(boostedToken?.underlyingTokenAddress || '', tokenAddress)
+          ),
+        }
+      })
+      .filter(({ token }) => !!token) || []
+
+  return boostTokenOptions.length > 0 ? boostTokenOptions : undefined
+}

--- a/packages/lib/modules/pool/actions/create/useBoostedTokenOptions.ts
+++ b/packages/lib/modules/pool/actions/create/useBoostedTokenOptions.ts
@@ -17,9 +17,9 @@ type BoostWhitelistResponse = {
 }[]
 
 const WHITELIST_URL = 'https://raw.githubusercontent.com/balancer/metadata/main/erc4626/index.json'
-const BOOSTED_FILTER = ['boosted_aave', 'boosted_morpho']
+const PROTOCOL_FILTER = ['boosted_aave', 'boosted_morpho', 'boosted_fluid']
 
-export const useBoostWhitelist = (tokenAddress: Address | undefined) => {
+export const useBoostedTokenOptions = (tokenAddress: string | undefined) => {
   const { getToken } = useTokens()
   const { poolCreationForm } = usePoolCreationForm()
   const [network] = useWatch({ control: poolCreationForm.control, name: ['network'] })
@@ -33,33 +33,23 @@ export const useBoostWhitelist = (tokenAddress: Address | undefined) => {
     },
   })
 
-  const filteredBoostWhitelist = boostWhitelist
-    ?.filter(list => BOOSTED_FILTER.includes(list.id))
-    .map(list => {
+  if (!boostWhitelist) return undefined
+
+  const filteredWhitelist = boostWhitelist
+    .filter(protocol => PROTOCOL_FILTER.includes(protocol.id))
+    .map(protocol => {
       return {
-        ...list,
-        addresses: list.addresses[chainId] || [],
+        name: protocol.name,
+        tokens: protocol.addresses[chainId].map(address => getToken(address, network)),
       }
     })
 
-  const boostWhitelistMetadta = filteredBoostWhitelist?.map(protocol => {
-    return {
-      name: protocol.name,
-      tokens: protocol.addresses.map(address => getToken(address, network)),
-    }
+  const boostedTokenOptions = filteredWhitelist.flatMap(protocol => {
+    const token = protocol.tokens.find(boostedToken =>
+      isSameAddress(boostedToken?.underlyingTokenAddress || '', tokenAddress)
+    )
+    return token ? [{ protocol: protocol.name, token }] : []
   })
 
-  const boostTokenOptions =
-    boostWhitelistMetadta
-      ?.map(protocol => {
-        return {
-          protocol: protocol.name,
-          token: protocol.tokens.find(boostedToken =>
-            isSameAddress(boostedToken?.underlyingTokenAddress || '', tokenAddress)
-          ),
-        }
-      })
-      .filter(({ token }) => !!token) || []
-
-  return boostTokenOptions.length > 0 ? boostTokenOptions : undefined
+  return boostedTokenOptions.length > 0 ? boostedTokenOptions : undefined
 }

--- a/packages/lib/modules/pool/actions/create/useUninitializedPool.ts
+++ b/packages/lib/modules/pool/actions/create/useUninitializedPool.ts
@@ -197,6 +197,7 @@ export function useUninitializedPool() {
         amount: '',
         weight: tokenWeights ? tokenWeights[idx] : '50',
         data,
+        isBoostingUnderlying: false,
       })
     }
 

--- a/packages/lib/modules/tokens/approvals/approval-labels.ts
+++ b/packages/lib/modules/tokens/approvals/approval-labels.ts
@@ -12,6 +12,7 @@ export type ApprovalAction =
   | 'Buying'
   | 'Selling'
   | 'Withdrawing'
+  | 'Wrapping'
 
 export type TokenApprovalLabelArgs = {
   actionType: ApprovalAction

--- a/packages/lib/modules/tokens/approvals/approval-rules.ts
+++ b/packages/lib/modules/tokens/approvals/approval-rules.ts
@@ -115,3 +115,9 @@ export function isTheApprovedAmountEnough(
   const isAllowed = tokenAllowance >= requiredRawAmount
   return requiredRawAmount > 0n && isAllowed
 }
+
+export type SpenderAddress = Address | ((tokenAddress: Address) => Address)
+
+export function resolveSpender(spenderAddress: SpenderAddress, tokenAddress: Address): Address {
+  return typeof spenderAddress === 'function' ? spenderAddress(tokenAddress) : spenderAddress
+}

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -11,7 +11,7 @@ import { Address, encodeFunctionData, erc20Abi } from 'viem'
 import { ManagedErc20TransactionButton } from '../../transactions/transaction-steps/TransactionButton'
 import { Retry, TransactionStep, TxCall } from '../../transactions/transaction-steps/lib'
 import { ManagedErc20TransactionInput } from '../../web3/contracts/useManagedErc20Transaction'
-import { useTokenAllowances } from '../../web3/useTokenAllowances'
+import { SpenderAddress, useTokenAllowances } from '../../web3/useTokenAllowances'
 import { useUserAccount } from '../../web3/UserAccountProvider'
 import { useTokens } from '../TokensProvider'
 import { ApprovalAction, buildTokenApprovalLabels } from './approval-labels'
@@ -26,7 +26,7 @@ import { ErrorWithCauses } from '@repo/lib/shared/utils/errors'
 import { useStepsTransactionState } from '@repo/lib/modules/transactions/transaction-steps/useStepsTransactionState'
 
 export type Params = {
-  spenderAddress: Address
+  spenderAddress: SpenderAddress
   chain: GqlChain
   approvalAmounts: RawAmount[]
   actionType: ApprovalAction
@@ -168,14 +168,16 @@ export function useTokenApprovalSteps({
       return errors
     }
 
-    const isTxEnabled = !!spenderAddress && !tokenAllowances.isAllowancesLoading
+    const resolvedSpender =
+      typeof spenderAddress === 'function' ? spenderAddress(tokenAddress) : spenderAddress
+    const isTxEnabled = !!resolvedSpender && !tokenAllowances.isAllowancesLoading
     const props: ManagedErc20TransactionInput = {
       tokenAddress,
       functionName: isVeBalBtpAddress(tokenAddress) ? 'increaseApproval' : 'approve',
       labels,
       isComplete,
       chainId: getChainId(chain),
-      args: [spenderAddress, requestedRawAmount],
+      args: [resolvedSpender, requestedRawAmount],
       enabled: isTxEnabled,
       simulationMeta: sentryMetaForWagmiSimulation(
         'Error in wagmi tx simulation: Approving token',

--- a/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
+++ b/packages/lib/modules/tokens/approvals/useTokenApprovalSteps.tsx
@@ -11,7 +11,7 @@ import { Address, encodeFunctionData, erc20Abi } from 'viem'
 import { ManagedErc20TransactionButton } from '../../transactions/transaction-steps/TransactionButton'
 import { Retry, TransactionStep, TxCall } from '../../transactions/transaction-steps/lib'
 import { ManagedErc20TransactionInput } from '../../web3/contracts/useManagedErc20Transaction'
-import { SpenderAddress, useTokenAllowances } from '../../web3/useTokenAllowances'
+import { useTokenAllowances } from '../../web3/useTokenAllowances'
 import { useUserAccount } from '../../web3/UserAccountProvider'
 import { useTokens } from '../TokensProvider'
 import { ApprovalAction, buildTokenApprovalLabels } from './approval-labels'
@@ -20,6 +20,8 @@ import {
   areEmptyRawAmounts,
   getRequiredTokenApprovals,
   isTheApprovedAmountEnough,
+  SpenderAddress,
+  resolveSpender,
 } from './approval-rules'
 import { isVeBalBtpAddress, requiresDoubleApproval } from '../token.helpers'
 import { ErrorWithCauses } from '@repo/lib/shared/utils/errors'
@@ -168,8 +170,7 @@ export function useTokenApprovalSteps({
       return errors
     }
 
-    const resolvedSpender =
-      typeof spenderAddress === 'function' ? spenderAddress(tokenAddress) : spenderAddress
+    const resolvedSpender = resolveSpender(spenderAddress, tokenAddress)
     const isTxEnabled = !!resolvedSpender && !tokenAllowances.isAllowancesLoading
     const props: ManagedErc20TransactionInput = {
       tokenAddress,

--- a/packages/lib/modules/transactions/transaction-steps/lib.tsx
+++ b/packages/lib/modules/transactions/transaction-steps/lib.tsx
@@ -69,6 +69,7 @@ export type StepType =
   | 'setSwapFee'
   | 'finalizePool'
   | 'signature'
+  | 'depositUnderlying'
 
 export type TxActionId =
   | 'SignBatchRelayer'

--- a/packages/lib/modules/transactions/transaction-steps/receipts/receipt-parsers.ts
+++ b/packages/lib/modules/transactions/transaction-steps/receipts/receipt-parsers.ts
@@ -3,7 +3,16 @@ import { BPT_DECIMALS } from '@repo/lib/modules/pool/pool.constants'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { bn } from '@repo/lib/shared/utils/numbers'
 import { HumanAmount } from '@balancer/sdk'
-import { Address, Log, erc20Abi, formatUnits, parseAbiItem, parseAbi, parseEventLogs } from 'viem'
+import {
+  Address,
+  Log,
+  erc20Abi,
+  erc4626Abi,
+  formatUnits,
+  parseAbiItem,
+  parseAbi,
+  parseEventLogs,
+} from 'viem'
 import { HumanTokenAmount } from '../../../tokens/token.types'
 import { emptyAddress } from '../../../web3/contracts/wagmi-helpers'
 import { ProtocolVersion } from '@repo/lib/modules/pool/pool.types'
@@ -27,6 +36,7 @@ export type ParseReceipt =
   | typeof parseLstWithdrawReceipt
   | typeof parsePoolCreationReceipt
   | typeof parseRecoveryModeChangedReceipt
+  | typeof parseDepositUnderlyingReceipt
 
 export function parseAddLiquidityReceipt({
   chain,
@@ -165,6 +175,20 @@ export function parsePoolCreationReceipt({ receiptLogs }: ParseProps) {
   if (!log) return { poolAddress: undefined }
 
   return { poolAddress: log.eventName === 'PoolCreated' ? log.args.pool : log.args.bPool }
+}
+
+export function parseDepositUnderlyingReceipt({ receiptLogs, chain, getToken }: ParseProps) {
+  const logs = parseEventLogs({ abi: erc4626Abi, logs: receiptLogs, eventName: ['Deposit'] })
+
+  const log = logs[0]
+  if (!log) return { mintedShares: undefined }
+
+  const wrappedTokenAddress = log.address
+  const tokenDecimals = getToken(wrappedTokenAddress, chain)?.decimals
+
+  return {
+    mintedShares: _toHumanAmount(wrappedTokenAddress, log.args.shares, tokenDecimals),
+  }
 }
 
 export function parseRecoveryModeChangedReceipt({ receiptLogs }: ParseProps) {

--- a/packages/lib/modules/web3/useTokenAllowances.tsx
+++ b/packages/lib/modules/web3/useTokenAllowances.tsx
@@ -10,15 +10,21 @@ export type TokenAllowances = Record<Address, bigint>
 
 export type UseTokenAllowancesResponse = ReturnType<typeof useTokenAllowances>
 
+export type SpenderAddress = Address | ((tokenAddress: Address) => Address)
+
 type Props = {
   chainId: SupportedChainId
   userAddress: Address
-  spenderAddress: Address
+  spenderAddress: SpenderAddress
   tokenAddresses: Address[]
   enabled?: boolean
 }
 
 type AllowanceContracts = ReadContractParameters<Erc20Abi, 'allowance'> & { chainId: number }
+
+function resolveSpender(spenderAddress: SpenderAddress, tokenAddress: Address): Address {
+  return typeof spenderAddress === 'function' ? spenderAddress(tokenAddress) : spenderAddress
+}
 
 export function useTokenAllowances({
   chainId,
@@ -34,7 +40,7 @@ export function useTokenAllowances({
         address: tokenAddress,
         abi: erc20Abi,
         functionName: 'allowance',
-        args: [userAddress, spenderAddress],
+        args: [userAddress, resolveSpender(spenderAddress, tokenAddress)],
       }) satisfies AllowanceContracts
   )
 

--- a/packages/lib/modules/web3/useTokenAllowances.tsx
+++ b/packages/lib/modules/web3/useTokenAllowances.tsx
@@ -5,12 +5,11 @@ import { Erc20Abi } from './contracts/contract.types'
 import { SupportedChainId } from '@repo/lib/config/config.types'
 import { useCallback, useMemo } from 'react'
 import { onlyExplicitRefetch } from '@repo/lib/shared/utils/queries'
+import { SpenderAddress, resolveSpender } from '../tokens/approvals/approval-rules'
 
 export type TokenAllowances = Record<Address, bigint>
 
 export type UseTokenAllowancesResponse = ReturnType<typeof useTokenAllowances>
-
-export type SpenderAddress = Address | ((tokenAddress: Address) => Address)
 
 type Props = {
   chainId: SupportedChainId
@@ -21,10 +20,6 @@ type Props = {
 }
 
 type AllowanceContracts = ReadContractParameters<Erc20Abi, 'allowance'> & { chainId: number }
-
-function resolveSpender(spenderAddress: SpenderAddress, tokenAddress: Address): Address {
-  return typeof spenderAddress === 'function' ? spenderAddress(tokenAddress) : spenderAddress
-}
 
 export function useTokenAllowances({
   chainId,

--- a/packages/lib/shared/components/alerts/BalAlertButton.tsx
+++ b/packages/lib/shared/components/alerts/BalAlertButton.tsx
@@ -3,7 +3,11 @@
 import { Button, ButtonProps } from '@chakra-ui/react'
 import { PropsWithChildren } from 'react'
 
-export function BalAlertButton({ onClick, children }: PropsWithChildren<ButtonProps>) {
+export function BalAlertButton({
+  onClick,
+  children,
+  isSelected,
+}: PropsWithChildren<ButtonProps & { isSelected?: boolean }>) {
   return (
     <Button
       _focus={{
@@ -11,12 +15,13 @@ export function BalAlertButton({ onClick, children }: PropsWithChildren<ButtonPr
       }}
       _hover={{
         transform: 'scale(1.05)',
-        color: 'font.dark',
+        color: isSelected ? 'white' : 'font.dark',
         borderColor: 'font.dark',
-        backgroundColor: 'transparent',
+        backgroundColor: isSelected ? 'black' : 'transparent',
       }}
+      backgroundColor={isSelected ? 'black' : undefined}
       borderColor="font.dark"
-      color="font.dark"
+      color={isSelected ? 'white' : 'font.dark'}
       fontSize="sm"
       h="24px"
       mb="-2"

--- a/packages/lib/shared/services/api/global.graphql
+++ b/packages/lib/shared/services/api/global.graphql
@@ -25,6 +25,7 @@ query GetTokens($chains: [GqlChain!]!) {
     isErc4626
     isBufferAllowed
     coingeckoId
+    underlyingTokenAddress
     priceRateProviderData {
       address
       reviewed


### PR DESCRIPTION
closes #1510

Note that the reclamm pool factory is still disabled at the smart contract level

### Tokens Step

warning if user selects underlying that has corresponding erc4626 from our whitelist

<img width="1394" height="526" alt="image" src="https://github.com/user-attachments/assets/5b53dba6-5901-4087-82a1-1173ef7398db" />

<img width="1413" height="539" alt="image" src="https://github.com/user-attachments/assets/14e666e9-19b5-49fb-8de1-96c8d0c0b7ad" />


### Fund Step
user inputs wrapped amounts which are used to `previewMint` on the erc4626 to get underlying amount required

<img width="1434" height="758" alt="image" src="https://github.com/user-attachments/assets/8f059e4c-323c-41db-b172-abd9278a777d" />




### Transactions Steps
`onSuccess` of deposit underlying, update the init amounts to match how much wrapped user actually received

<img width="1432" height="733" alt="image" src="https://github.com/user-attachments/assets/9a0c3c0a-2e3b-4cf0-8af6-f0185cc60d9b" />
