### PR TITLE
[#234] use user locale decimal separator on token input

### DIFF
--- a/packages/e2e-tests/tests/dev/balancer/swap.spec.ts
+++ b/packages/e2e-tests/tests/dev/balancer/swap.spec.ts
@@ -8,7 +8,7 @@ test('Swap 1 ETH to GHO)', async ({ page }) => {
 
   await impersonate(page, defaultAnvilAccount)
 
-  await page.getByRole('spinbutton', { name: 'TokenIn' }).fill('0.1')
+  await page.getByRole('textbox', { name: 'TokenIn' }).fill('0.1')
   await selectPopularToken(page, 'GHO')
   await clickButton(page, 'Next')
 

--- a/packages/e2e-tests/tests/dev/beets/swap.spec.ts
+++ b/packages/e2e-tests/tests/dev/beets/swap.spec.ts
@@ -10,7 +10,7 @@ test('Wrap 1 S to wS', async ({ page }) => {
   await impersonate(page, defaultAnvilAccount)
 
   await selectPopularToken(page, 'wS')
-  await page.getByRole('spinbutton', { name: 'TokenIn' }).fill('1')
+  await page.getByRole('textbox', { name: 'TokenIn' }).fill('1')
 
   await clickButton(page, 'Next')
 

--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -336,7 +336,9 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
         ...newState,
         swapType: GqlSorSwapType.ExactIn,
       })
-      setTokenOutAmount('', { userTriggered: false })
+      if (state.tokenIn.amount !== newState.tokenIn.amount) {
+        setTokenOutAmount('', { userTriggered: false })
+      }
     } else {
       // Sometimes we want to set the amount without triggering a fetch or
       // swapType change, like when we populate the amount after a change from the other input.
@@ -386,7 +388,9 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
         ...newState,
         swapType: GqlSorSwapType.ExactOut,
       })
-      setTokenInAmount('', { userTriggered: false })
+      if (state.tokenOut.amount !== newState.tokenOut.amount) {
+        setTokenInAmount('', { userTriggered: false })
+      }
     } else {
       // Sometimes we want to set the amount without triggering a fetch or
       // swapType change, like when we populate the amount after a change from

--- a/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
+++ b/packages/lib/modules/tokens/TokenInput/TokenInput.tsx
@@ -337,6 +337,7 @@ export const TokenInput = forwardRef(
                 boxShadow="none"
                 fontSize="3xl"
                 fontWeight="medium"
+                inputMode="decimal"
                 isDisabled={!token}
                 min={0}
                 onChange={handleOnChange}
@@ -352,7 +353,6 @@ export const TokenInput = forwardRef(
                 shadow="none"
                 step="any"
                 title={value || ''}
-                type="number"
                 value={value}
                 {...inputProps}
               />

--- a/packages/lib/modules/tokens/TokenInput/useTokenInput.ts
+++ b/packages/lib/modules/tokens/TokenInput/useTokenInput.ts
@@ -53,7 +53,13 @@ export function useTokenInput({
 
   const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newValue = event.currentTarget.value
-    updateValue(newValue)
+
+    let cleanValue = newValue.replace(',', '.')
+    cleanValue = cleanValue.replace(/[^\d.]/g, '')
+    let separators = 0 // Remove all non decimal chars except the first decimal separator
+    cleanValue = cleanValue.replace('.', () => (separators++ === 0 ? '.' : ''))
+
+    updateValue(cleanValue)
   }
 
   return {


### PR DESCRIPTION
Closes #234 

- Both comma and period keys can be used to input the decimal separator
- On input if not the separator defined by the user locale it is replaced by the right one