### PR TITLE
Do not sort route hop tokens when input or output token not available

### DIFF
--- a/packages/lib/config/networks/gnosis.ts
+++ b/packages/lib/config/networks/gnosis.ts
@@ -34,7 +34,7 @@ const networkConfig: NetworkConfig = {
       '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee': 'xDAI',
       '0xe91d153e0b41518a2ce8dd3d7944fa863463a97d': 'WXDAI',
       '0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1': 'WETH',
-      '0x6c76971f98945ae98dd7d4dfca8711ebea946ea6': 'wsETH',
+      '0x6c76971f98945ae98dd7d4dfca8711ebea946ea6': 'wstETH',
       '0x9c58bacc331c9aa871afd802db6379a98e80cedb': 'GNO',
       '0xddafbb505ad214d7b80b1f830fccc89b60fb7a83': 'USDC',
       '0x7ef541e2a22058048904fe5744f9c7e4c57af717': 'BAL',

--- a/packages/lib/modules/swap/RoutesCard.tsx
+++ b/packages/lib/modules/swap/RoutesCard.tsx
@@ -150,7 +150,6 @@ type PathRouteProps = {
 }
 
 function PathRoute({ chain, path, totalAmount, colors }: PathRouteProps) {
-  console.log(path)
   const amountShare = bn(path.inputAmountRaw)
     .shiftedBy(-path.tokens[0].decimals)
     .div(totalAmount)


### PR DESCRIPTION
<img width="551" height="752" alt="Screenshot 2026-03-05 at 16 24 48" src="https://github.com/user-attachments/assets/07ce4a24-78b7-4048-bd3f-75e2365e1256" />

Some strange paths where one of the hops does not contain either the input or output token make it impossible for the hop tokens to be sorted (BAL token on the image).