### PR TITLE
fix: pool creation form custom radio input

### DIFF
--- a/packages/lib/modules/pool/actions/create/steps/details/PoolSettingsRadioGroup.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/PoolSettingsRadioGroup.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { VStack, HStack, Text, RadioGroup, Radio, Stack } from '@chakra-ui/react'
 import { InfoIconPopover } from '../../InfoIconPopover'
 import { Controller } from 'react-hook-form'
@@ -39,6 +40,8 @@ export function PoolSettingsRadioGroup({
   isPercentage,
   isDisabled,
 }: PoolSettingsRadioGroupProps) {
+  const [isCustomMode, setIsCustomMode] = useState(false)
+
   const {
     poolCreationForm: { control, setValue, trigger, resetField, formState },
   } = usePoolCreationForm()
@@ -67,25 +70,26 @@ export function PoolSettingsRadioGroup({
         name={name}
         render={({ field }) => {
           const recommendedOptions = options.map(option => option.value)
-          const isCustomOptionSelected = !recommendedOptions.includes(field.value)
-          const selectedRadioGroupValue = isCustomOptionSelected ? '' : field.value
+          const isCustomOptionSelected = isCustomMode || !recommendedOptions.includes(field.value)
 
           return (
             <RadioGroup
               aria-label={title}
               onChange={value => {
                 if (value === '') {
+                  setIsCustomMode(true)
                   resetField(name, { defaultValue: '' })
                 } else {
+                  setIsCustomMode(false)
                   field.onChange(value)
                 }
               }}
-              value={selectedRadioGroupValue}
+              value={isCustomOptionSelected ? '' : field.value}
               w="full"
             >
               <Stack spacing={4}>
                 {optionsPlusCustom.map((option, idx) => {
-                  const isCustomOption = option.value === ''
+                  const showCustomInput = option.value === '' && isCustomOptionSelected
 
                   return (
                     <VStack align="start" key={idx} w="full">
@@ -95,8 +99,7 @@ export function PoolSettingsRadioGroup({
                           {option.detail && option.detail}
                         </HStack>
                       </Radio>
-                      {isCustomOption &&
-                        isCustomOptionSelected &&
+                      {showCustomInput &&
                         (customInputType === 'address' ? (
                           <FormSubsection>
                             <Controller


### PR DESCRIPTION
user reported being unable to enter `10000` as amp for stable pool

problem was as user entered `100` the logic auto selected the default option of matching value


![Recording 2026-03-11 at 14 21 29](https://github.com/user-attachments/assets/0283a2e1-370d-4661-a511-ee3c74f913ff)

added state to track if custom option has been selected

<img width="665" height="262" alt="image" src="https://github.com/user-attachments/assets/7e1f1822-9815-43d0-95c1-82da5b0529bb" />


