### PR TITLE
fix: flaky receipt hooks integration test

### DIFF
--- a/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.integration.spec.ts
+++ b/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.integration.spec.ts
@@ -165,12 +165,6 @@ test('queries add liquidity in V3 GNOSIS pool', async () => {
       humanAmount: '0.000063840672042232',
       tokenAddress: '0xe91d153e0b41518a2ce8dd3d7944fa863463a97d',
     },
-    // the following one is excluded to avoid duplication
-    // ERC-20: Monerium EURe (EURe)
-    // {
-    //   humanAmount: '0.014361104681096343',
-    //   tokenAddress: '0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430',
-    // },
     {
       humanAmount: '0.014361104681096343',
       tokenAddress: '0xcb444e90d8198415266c6a2724b7900fb12fc56e', // Monerium EUR emoney (EURe)

--- a/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.ts
+++ b/packages/lib/modules/transactions/transaction-steps/receipts/receipt.hooks.ts
@@ -147,7 +147,7 @@ function useTxReceipt({
   protocolVersion,
   txReceipt,
 }: ReceiptProps) {
-  const { getToken, isLoadingTokenPrices } = useTokens()
+  const { getToken, isLoadingTokenPrices, isLoadingTokens } = useTokens()
   const chainId = getChainId(chain)
   // These query will be skipped if we are in the context of a transaction flow (where txReceipt is defined)
   // or will be fetched if the user is visiting an historic transaction receipt (where txReceipt is undefined)
@@ -170,7 +170,10 @@ function useTxReceipt({
   const txValue = transactionQuery.data?.value || 0n
 
   const isLoading =
-    isLoadingTokenPrices || historicReceiptQuery.isLoading || transactionQuery.isLoading
+    isLoadingTokenPrices ||
+    isLoadingTokens ||
+    historicReceiptQuery.isLoading ||
+    transactionQuery.isLoading
   const error = historicReceiptQuery.error || transactionQuery.error
 
   const data =


### PR DESCRIPTION
closes #2251

`useTxReceipt` guards parsing with `isLoading`, which includes `isLoadingTokenPrices` but not `isLoadingTokens`. Since `getToken` reads from the tokens list, if that query isn't done yet, `getToken(address, chain)` returns `undefined`, and `_toHumanAmount` falls back to 18 decimals instead of the token's actual 6. 

For USDC.e on Gnosis, this changes the output from `"0.01"` to `"0.00000000000001"`