### PR TITLE
fix: block some renovate upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -107,6 +107,24 @@
       "matchPackageNames": ["chakra-react-select"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Block Vitest v4 until we are ready to migrate the test tooling.",
+      "matchPackageNames": ["vitest", "@vitest/**"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Block Stylelint major upgrades until we are ready to migrate the style linting stack.",
+      "matchPackageNames": ["stylelint", "stylelint-**"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Block zod v4 until we are ready for that migration.",
+      "matchPackageNames": ["zod"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
for now block these proposed changes by renovatebot

- fix(deps): replace dependency framer-motion with motion (chakra v2 does not support it)
- fix(deps): update dependency chakra-react-select to v6 (chakra v2 only support v5 (current))
- fix(deps): update chakra ui to v3 (major) (@chakra-ui/cli, @chakra-ui/react) (chakra v2 is still used)
- chore(deps): update eslint ecosystem to v10 (major) (@eslint/js, eslint) (next does not support it yet)
- fix(deps): update dependency zod to v4 (needs investigation)
- chore(deps): update vitest monorepo to v4 (major) (@vitest/coverage-v8, vitest) (needs investigation)
- chore(deps): update dependency stylelint to v17 (needs investigation)
- chore(deps): update dependency stylelint-config-standard to v40 (needs investigation)