### PR TITLE
fix mobile LBP chart display

### DIFF
--- a/packages/lib/modules/pool/LbpDetail/LbpDetail.tsx
+++ b/packages/lib/modules/pool/LbpDetail/LbpDetail.tsx
@@ -16,6 +16,8 @@ import { MyTransactions } from './MyTransactions'
 import { GetFundsWarning } from './GetFundsWarning'
 import { Top10Trades } from './Top10Trades'
 
+const MIN_GRID_ITEM_HEIGHT = '400px'
+
 export function LbpDetail() {
   const { userPoolEvents, isLoadingUserPoolEvents, hasPoolEvents } = useUserPoolEvents()
   const { pool } = usePool()
@@ -32,10 +34,10 @@ export function LbpDetail() {
           {isSaleFinished && fundsAvailable && <GetFundsWarning />}
 
           <Grid gap="4" templateColumns={{ base: '1fr', md: '2fr 1fr' }} w="full">
-            <GridItem>
+            <GridItem minH={MIN_GRID_ITEM_HEIGHT}>
               <LbpPoolChartsContainer />
             </GridItem>
-            <GridItem minH="400px">
+            <GridItem minH={MIN_GRID_ITEM_HEIGHT}>
               {isSaleFinished ? <Top10Trades chain={pool.chain} pool={lbpPool} /> : <LbpSwap />}
             </GridItem>
           </Grid>


### PR DESCRIPTION
closes #2267 

not best looking for `Volume` and `Fees` but same issue on desktop with the empty top space

can't really go smaller for mobile cus `Price` needs the line type labels

<img width="2055" height="1091" alt="image" src="https://github.com/user-attachments/assets/ab2cb1e3-1fa5-4acf-92e2-8a21da929a43" />

<img width="3124" height="901" alt="image" src="https://github.com/user-attachments/assets/c919d4cf-873c-45ef-8cf2-1eb56b36a4d6" />


