### PR TITLE
fix: use partialBoostedSepolia in usePoolStateWithBalancesQuery integration test

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/queries/usePoolStateWithBalancesQuery.integration.spec.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/queries/usePoolStateWithBalancesQuery.integration.spec.ts
@@ -2,7 +2,7 @@ import { GqlPoolElement } from '@repo/lib/shared/services/api/generated/graphql'
 import { buildDefaultPoolTestProvider, testHook } from '@repo/lib/test/utils/custom-renderers'
 import { waitFor } from '@testing-library/react'
 import { getApiPoolMock } from '../../../__mocks__/api-mocks/api-mocks'
-import { partialBoosted } from '../../../__mocks__/pool-examples/boosted'
+import { partialBoostedSepolia } from '../../../__mocks__/pool-examples/boosted'
 import { Pool } from '../../../pool.types'
 import { usePoolStateWithBalancesQuery } from './usePoolStateWithBalancesQuery'
 
@@ -15,7 +15,7 @@ async function testQuery(pool: Pool) {
 
 describe('usePoolStateWithBalances', () => {
   it('for a partial boosted pool', async () => {
-    const pool = getApiPoolMock(partialBoosted)
+    const pool = getApiPoolMock(partialBoostedSepolia)
 
     const result = await testQuery(pool)
 


### PR DESCRIPTION
partialBoosted (Gnosis) lacks a mock and its staking gauge contract is not available in the blockchain fork, causing balanceOf to return 0x.

partialBoostedSepolia (Sepolia) has a proper API mock and its contracts exist in the Sepolia fork.