### PR TITLE
fix: split minimumReleaseAge and group sentry packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,11 @@
       ]
     },
     {
+      "description": "Keep Sentry packages in sync.",
+      "groupName": "Sentry",
+      "matchPackageNames": ["@sentry/**"]
+    },
+    {
       "description": "Low-risk, high-frequency — consolidate to reduce noise.",
       "groupName": "@types packages",
       "matchPackageNames": ["@types/**"]
@@ -99,7 +104,8 @@
         "!@vitest/**",
         "!stylelint",
         "!stylelint-**",
-        "!zod"
+        "!zod",
+        "!@sentry/**"
       ]
     },
     {


### PR DESCRIPTION
set `minimumReleaseAge` for:

- `patch`: 3 days (default)
- `minor`: 7 days
- `major`: 14 days

and group `@sentry` packages