### PR TITLE
fix: pool creation feedback items

### DIFF
--- a/packages/lib/modules/pool/actions/create/constants.ts
+++ b/packages/lib/modules/pool/actions/create/constants.ts
@@ -43,7 +43,6 @@ export const MAX_POOL_NAME_LENGTH = 32
 export const MAX_POOL_SYMBOL_LENGTH = 26
 export const MAX_SWAP_FEE_PERCENTAGE = 10
 export const REQUIRED_TOTAL_WEIGHT = 100
-export const AMPLIFICATION_PARAMETER_OPTIONS = ['100', '1000']
 export const MIN_AMPLIFICATION_PARAMETER = Number(STABLE_POOL_CONSTRAINTS.MIN_AMP)
 export const MAX_AMPLIFICATION_PARAMETER = Number(STABLE_POOL_CONSTRAINTS.MAX_AMP)
 export const MAX_LAMBDA = 100000000
@@ -160,7 +159,7 @@ export const INITIAL_POOL_CREATION_FORM: PoolCreationForm = {
   pauseManager: zeroAddress,
   poolCreator: zeroAddress,
   swapFeePercentage: getSwapFeePercentageOptions(PoolType.Stable)[0].value,
-  amplificationParameter: AMPLIFICATION_PARAMETER_OPTIONS[0],
+  amplificationParameter: '100',
   poolHooksContract: zeroAddress,
   enableDonation: false,
   disableUnbalancedLiquidity: false,

--- a/packages/lib/modules/pool/actions/create/steps/details/LiquidityManagement.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/LiquidityManagement.tsx
@@ -41,7 +41,7 @@ export function LiquidityManagement() {
 
   const donationsToolTip = isDonationToggleDisabled
     ? 'The selected pool type does not allow donations to be enabled'
-    : 'Allows the option to add liquidity to the pool without minting additional LP tokens. Most pools should NOT allow donations. Only recommended for advanced users.'
+    : 'Option to add liquidity to a pool without minting additional LP tokens. Most pools should NOT allow donations. Only recommended for advanced users.'
 
   return (
     <VStack align="start" spacing="md" w="full">

--- a/packages/lib/modules/pool/actions/create/steps/details/LiquidityManagement.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/LiquidityManagement.tsx
@@ -39,6 +39,10 @@ export function LiquidityManagement() {
     isStableSurgePool(poolType) || hookFlags?.enableHookAdjustedAmounts
   const isDonationToggleDisabled = isReClammPool(poolType)
 
+  const donationsToolTip = isDonationToggleDisabled
+    ? 'The selected pool type does not allow donations to be enabled'
+    : 'Allows the option to add liquidity to the pool without minting additional LP tokens. Most pools should NOT allow donations. Only recommended for advanced users.'
+
   return (
     <VStack align="start" spacing="md" w="full">
       <HStack>
@@ -59,11 +63,7 @@ export function LiquidityManagement() {
           onChange={e => poolCreationForm.setValue('disableUnbalancedLiquidity', !e.target.checked)}
         />
       </TooltipWithTouch>
-      <TooltipWithTouch
-        isHidden={!isDonationToggleDisabled}
-        label="The reClamm pool factory does not allow donations"
-        placement="right"
-      >
+      <TooltipWithTouch label={donationsToolTip} placement="right">
         <PoolCreationCheckbox
           isChecked={enableDonation}
           isDisabled={isDonationToggleDisabled}

--- a/packages/lib/modules/pool/actions/create/steps/details/PoolDetails.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/PoolDetails.tsx
@@ -4,26 +4,24 @@ import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { validatePoolDetails } from '../../validatePoolCreationForm'
 import { useWatch } from 'react-hook-form'
 import { useEffect, useRef } from 'react'
+import { PoolCreationToken, SupportedPoolTypes } from '../../types'
+import { isWeightedPool, isStableSurgePool, isReClammPool } from '../../helpers'
+import { MAX_POOL_NAME_LENGTH, MAX_POOL_SYMBOL_LENGTH } from '../../constants'
 
 export function PoolDetails() {
   const { poolCreationForm } = usePoolCreationForm()
-  const poolTokens = useWatch({ control: poolCreationForm.control, name: 'poolTokens' })
-
-  const tokenSymbols = poolTokens.map(token => {
-    const { data, weight } = token
-    if (!data) return ''
-    if (!weight) return data.symbol
-    return weight + '% ' + data.symbol
+  const [poolTokens, poolType] = useWatch({
+    control: poolCreationForm.control,
+    name: ['poolTokens', 'poolType'],
   })
 
-  const suggestedPoolName = tokenSymbols.join(' / ')
-  const suggestedPoolSymbol = tokenSymbols.join('-').replace(/% /g, '-')
+  const { suggestedPoolName, suggestedPoolSymbol } = getSuggestions(poolTokens, poolType)
 
   const hasInitialized = useRef(false)
 
   useEffect(() => {
     if (hasInitialized.current) return
-    if (!suggestedPoolName || suggestedPoolName === ' / ') return
+    if (!suggestedPoolName || suggestedPoolName === '-') return
 
     const currentName = poolCreationForm.getValues('name')
     const currentSymbol = poolCreationForm.getValues('symbol')
@@ -75,4 +73,30 @@ export function PoolDetails() {
       />
     </VStack>
   )
+}
+
+function getSuggestions(poolTokens: PoolCreationToken[], poolType: SupportedPoolTypes) {
+  const poolTypePrefix = isStableSurgePool(poolType)
+    ? 'surge'
+    : isReClammPool(poolType)
+      ? 'reCLAMM'
+      : ''
+
+  const tokenSymbols = poolTokens
+    .map(({ data, weight }) => {
+      if (!data?.symbol) return ''
+      if (!isWeightedPool(poolType) || !weight) return data.symbol
+      return weight + data.symbol
+    })
+    .join('-')
+
+  const poolSymbol = poolTypePrefix ? `${poolTypePrefix}-${tokenSymbols}` : tokenSymbols
+  const suggestedPoolSymbol =
+    poolSymbol.length <= MAX_POOL_SYMBOL_LENGTH ? poolSymbol : tokenSymbols
+
+  const poolName = poolTypePrefix ? `${poolTypePrefix} ${tokenSymbols}` : tokenSymbols
+  const suggestedPoolName =
+    `Balancer ${poolName}`.length <= MAX_POOL_NAME_LENGTH ? `Balancer ${poolName}` : poolName
+
+  return { suggestedPoolName, suggestedPoolSymbol }
 }

--- a/packages/lib/modules/pool/actions/create/steps/details/PoolDetails.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/PoolDetails.tsx
@@ -5,8 +5,10 @@ import { validatePoolDetails } from '../../validatePoolCreationForm'
 import { useWatch } from 'react-hook-form'
 import { useEffect, useRef } from 'react'
 import { PoolCreationToken, SupportedPoolTypes } from '../../types'
-import { isWeightedPool, isStableSurgePool, isReClammPool } from '../../helpers'
+import { isWeightedPool } from '../../helpers'
 import { MAX_POOL_NAME_LENGTH, MAX_POOL_SYMBOL_LENGTH } from '../../constants'
+import { PoolType } from '@balancer/sdk'
+import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
 export function PoolDetails() {
   const { poolCreationForm } = usePoolCreationForm()
@@ -76,11 +78,12 @@ export function PoolDetails() {
 }
 
 function getSuggestions(poolTokens: PoolCreationToken[], poolType: SupportedPoolTypes) {
-  const poolTypePrefix = isStableSurgePool(poolType)
-    ? 'surge'
-    : isReClammPool(poolType)
-      ? 'reCLAMM'
-      : ''
+  const poolTypePrefixMap: Partial<Record<SupportedPoolTypes, string>> = {
+    [PoolType.StableSurge]: 'surge',
+    [PoolType.ReClamm]: 'reCLAMM',
+  }
+
+  const poolTypePrefix = poolTypePrefixMap[poolType] ?? ''
 
   const tokenSymbols = poolTokens
     .map(({ data, weight }) => {
@@ -94,9 +97,12 @@ function getSuggestions(poolTokens: PoolCreationToken[], poolType: SupportedPool
   const suggestedPoolSymbol =
     poolSymbol.length <= MAX_POOL_SYMBOL_LENGTH ? poolSymbol : tokenSymbols
 
+  const { projectName } = PROJECT_CONFIG
+
   const poolName = poolTypePrefix ? `${poolTypePrefix} ${tokenSymbols}` : tokenSymbols
+  const poolNameWithProject = `${projectName} ${poolName}`
   const suggestedPoolName =
-    `Balancer ${poolName}`.length <= MAX_POOL_NAME_LENGTH ? `Balancer ${poolName}` : poolName
+    poolNameWithProject.length <= MAX_POOL_NAME_LENGTH ? poolNameWithProject : poolName
 
   return { suggestedPoolName, suggestedPoolSymbol }
 }

--- a/packages/lib/modules/pool/actions/create/steps/details/PoolSettings.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/PoolSettings.tsx
@@ -4,7 +4,6 @@ import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { PoolSettingsRadioGroup } from './PoolSettingsRadioGroup'
 import { LiquidityManagement } from './LiquidityManagement'
 import { BlockExplorerLink } from '@repo/lib/shared/components/BlockExplorerLink'
-import { AMPLIFICATION_PARAMETER_OPTIONS } from '../../constants'
 import { getSwapFeePercentageOptions } from '../../helpers'
 import { validatePoolSettings } from '../../validatePoolCreationForm'
 import { usePoolHooksWhitelist } from './usePoolHooksWhitelist'
@@ -16,6 +15,12 @@ import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { isStablePool, isStableSurgePool, isPoolCreatorEnabled } from '../../helpers'
 import { useWatch } from 'react-hook-form'
+import { ConfigOptionsGroup } from './ReClammConfiguration'
+import {
+  SteepCurve,
+  FlatCurve,
+  VeryFlatCurve,
+} from '@repo/lib/shared/components/imgs/AmplificationParameterSvgs'
 
 export type PoolSettingsOption = {
   label: string
@@ -65,10 +70,6 @@ export function PoolSettings() {
     ...(filteredPoolHooksOptions || []),
   ]
 
-  const amplificationParameterOptions: PoolSettingsOption[] = AMPLIFICATION_PARAMETER_OPTIONS.map(
-    value => ({ label: value, value })
-  )
-
   useEffect(() => {
     if (isStableSurgePool(poolType) && poolHooksWhitelist) {
       const stableSurgeHookMetadata = poolHooksWhitelist.find(hook => hook.label === 'StableSurge')
@@ -109,6 +110,45 @@ export function PoolSettings() {
 
   return (
     <VStack align="start" spacing="lg" w="full">
+      {showAmplificationParameter && (
+        <>
+          <Heading color="font.maxContrast" size="md">
+            Stable Pool Configuration
+          </Heading>
+          <ConfigOptionsGroup
+            control={poolCreationForm.control}
+            customInputLabel="Custom amplification parameter"
+            label="Amplification parameter"
+            name="amplificationParameter"
+            options={[
+              {
+                label: 'Steep curve',
+                displayValue: '100',
+                rawValue: '100',
+                svg: SteepCurve,
+              },
+              {
+                label: 'Flat curve',
+                displayValue: '1,000',
+                rawValue: '1000',
+                svg: FlatCurve,
+              },
+              {
+                label: 'Very flat curve',
+                displayValue: '10,000',
+                rawValue: '10000',
+                svg: VeryFlatCurve,
+              },
+            ]}
+            tooltip="Controls the 'flatness' of the invariant curve. Higher values = lower slippage and assumes prices are near parity. Lower values = closer to the constant product curve (e.g., more like a weighted pool). This has higher slippage and accommodates greater price volatility."
+            updateFn={(value: string) => {
+              poolCreationForm.setValue('amplificationParameter', value, { shouldValidate: true })
+            }}
+            validateFn={(value: string) => validatePoolSettings.amplificationParameter(value)}
+          />
+        </>
+      )}
+
       <Heading color="font.maxContrast" size="md">
         Pool settings
       </Heading>
@@ -155,18 +195,6 @@ export function PoolSettings() {
         tooltip="The initial static swap fee percentage of the pool"
         validate={value => validatePoolSettings.swapFeePercentage(value, poolType)}
       />
-
-      {showAmplificationParameter && (
-        <PoolSettingsRadioGroup
-          customInputLabel="Custom amplification parameter"
-          customInputType="number"
-          name="amplificationParameter"
-          options={amplificationParameterOptions}
-          title="Amplification parameter"
-          tooltip='Controls the "flatness" of the invariant curve. Higher values = lower slippage and assumes prices are near parity. Lower values = closer to the constant product curve (e.g., more like a weighted pool). This has higher slippage and accommodates greater price volatility.'
-          validate={validatePoolSettings.amplificationParameter}
-        />
-      )}
 
       {showPoolHooks && (
         <PoolSettingsRadioGroup

--- a/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/ReClammConfiguration.tsx
@@ -1,16 +1,14 @@
 import { Heading, VStack, Text, HStack, Radio, SimpleGrid, useRadioGroup } from '@chakra-ui/react'
 import { InfoIconPopover } from '../../InfoIconPopover'
-import {
-  useReClammConfigurationOptions,
-  ReClammConfigOptionsGroup,
-} from './useReClammConfigurationOptions'
+import { useReClammConfigurationOptions } from './useReClammConfigurationOptions'
 import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { NumberInput } from '@repo/lib/shared/components/inputs/NumberInput'
 import { bn } from '@repo/lib/shared/utils/numbers'
 import { getPercentFromPrice } from '../../helpers'
 import { formatNumber } from '../../helpers'
 import { RadioCard } from '@repo/lib/shared/components/inputs/RadioCardGroup'
-import { useWatch } from 'react-hook-form'
+import { useWatch, Control } from 'react-hook-form'
+import { useState, SVGProps } from 'react'
 
 export function ReClammConfiguration() {
   const reClammConfigurationOptions = useReClammConfigurationOptions()
@@ -22,6 +20,7 @@ export function ReClammConfiguration() {
       </Heading>
       {reClammConfigurationOptions.map(option => (
         <ConfigOptionsGroup
+          control={option.control}
           customInputLabel={option.customInputLabel}
           key={option.label}
           label={option.label}
@@ -36,25 +35,43 @@ export function ReClammConfiguration() {
   )
 }
 
-function ConfigOptionsGroup({
+export type ConfigOptionsGroupProps = {
+  label: string
+  options: {
+    label: string
+    displayValue: string
+    rawValue: string
+    svg?: React.ComponentType<SVGProps<SVGSVGElement>>
+  }[]
+  updateFn: (rawValue: string) => void
+  validateFn: (value: string) => string | boolean
+  name: string
+  control: Control<any>
+  customInputLabel: string
+  tooltip: string
+}
+
+export function ConfigOptionsGroup({
   label,
   options,
   updateFn,
   validateFn,
   name,
+  control,
   customInputLabel,
   tooltip,
-}: ReClammConfigOptionsGroup) {
+}: ConfigOptionsGroupProps) {
   const { reClammConfigForm } = usePoolCreationForm()
   const [initialMinPrice, initialTargetPrice, initialMaxPrice] = useWatch({
     control: reClammConfigForm.control,
     name: ['initialMinPrice', 'initialTargetPrice', 'initialMaxPrice'],
   })
-  const formValue = useWatch({ control: reClammConfigForm.control, name })
+  const [forceCustom, setForceCustom] = useState(false)
+  const formValue = useWatch({ control, name })
   const normalizedFormValue = formValue?.toString?.() ?? ''
   const matchedOption = options.find(option => {
     if (option.rawValue === normalizedFormValue) return true
-    if (option.rawValue === '' || normalizedFormValue === '') return false
+    if (normalizedFormValue === '') return false
 
     const optionNumber = Number(option.rawValue)
     const formValueNumber = Number(normalizedFormValue)
@@ -64,18 +81,20 @@ function ConfigOptionsGroup({
     return optionNumber === formValueNumber
   })
 
-  const isCustom = matchedOption ? matchedOption.rawValue === '' : normalizedFormValue !== ''
+  const isCustom = forceCustom || (!matchedOption && normalizedFormValue !== '')
   const selectedValue = isCustom ? '' : (matchedOption?.rawValue ?? '')
   const isCustomTargetPrice = isCustom && name === 'initialTargetPrice'
   const ispriceRangePercentage = name === 'priceRangePercentage'
   const isCustomPriceRange = isCustom && ispriceRangePercentage
   const isPercentage = name === 'centerednessMargin' || name === 'priceShiftDailyRate'
-  const cardOptions = options.filter(option => option.rawValue !== '')
-  const customOption = options.find(option => option.rawValue === '')
+  const cardOptions = options
   const { getRootProps, getRadioProps } = useRadioGroup({
     name,
     value: selectedValue,
-    onChange: (value: string) => updateFn(value),
+    onChange: (value: string) => {
+      setForceCustom(false)
+      updateFn(value)
+    },
   })
   const radioGroupProps = getRootProps()
   const cardContainerProps = {
@@ -109,7 +128,7 @@ function ConfigOptionsGroup({
   return (
     <VStack align="start" spacing="md" w="full">
       <HStack>
-        <Text textAlign="start" w="full">
+        <Text fontWeight="bold" textAlign="start" w="full">
           {label}
         </Text>
         <InfoIconPopover message={tooltip} />
@@ -136,19 +155,18 @@ function ConfigOptionsGroup({
           )
         })}
       </SimpleGrid>
-      {customOption ? (
-        <Radio
-          isChecked={selectedValue === customOption.rawValue}
-          mt="2"
-          name={name}
-          onChange={() => updateFn(customOption.rawValue)}
-          value={customOption.rawValue}
-        >
-          <Text color="font.secondary" fontSize="sm">
-            {customOption.label}
-          </Text>
-        </Radio>
-      ) : null}
+      <Radio
+        isChecked={isCustom}
+        mt="2"
+        name={name}
+        onChange={() => {
+          setForceCustom(true)
+          updateFn('')
+        }}
+        value=""
+      >
+        <Text color="font.secondary">Or choose custom</Text>
+      </Radio>
       {isCustomPriceRange ? (
         <VStack align="start" spacing="md" w="full">
           <NumberInput
@@ -196,7 +214,7 @@ function ConfigOptionsGroup({
         </VStack>
       ) : isCustom ? (
         <NumberInput
-          control={reClammConfigForm.control}
+          control={control}
           isPercentage={isPercentage}
           label={customInputLabel}
           name={name}

--- a/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/useReClammConfigurationOptions.tsx
@@ -1,10 +1,8 @@
 import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { bn } from '@repo/lib/shared/utils/numbers'
-import { ReClammConfig } from '../../types'
 import { useEffect, useRef } from 'react'
 import { formatNumber } from '../../helpers'
 import { usePoolSpotPriceWithoutRate } from './usePoolSpotPriceWithoutRate'
-import { SVGProps } from 'react'
 import {
   CurrentPriceMinusFivePercentSVG,
   CurrentPriceSVG,
@@ -20,29 +18,9 @@ import {
   PriceAdjustmentRateFastSVG,
 } from '@repo/lib/shared/components/imgs/ReClammConfigSvgs'
 import { useWatch } from 'react-hook-form'
+import { ConfigOptionsGroupProps } from './ReClammConfiguration'
 
-export type ReClammConfigOptionsGroup = {
-  label: string
-  options: {
-    label: string
-    displayValue: string
-    rawValue: string
-    svg?: React.ComponentType<SVGProps<SVGSVGElement>>
-  }[]
-  updateFn: (rawValue: string) => void
-  validateFn: (value: string) => string | boolean
-  name: keyof ReClammConfig
-  customInputLabel: string
-  tooltip: string
-}
-
-const CUSTOM_OPTION = {
-  label: 'Or choose custom',
-  displayValue: '',
-  rawValue: '',
-}
-
-export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
+export function useReClammConfigurationOptions(): ConfigOptionsGroupProps[] {
   const { poolCreationForm, reClammConfigForm } = usePoolCreationForm()
   const lastCalculatedPriceBoundsRef = useRef({ minPrice: '', maxPrice: '' })
 
@@ -73,7 +51,8 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
   }
 
   const targetPrice = {
-    name: 'initialTargetPrice' as const,
+    name: 'initialTargetPrice',
+    control: reClammConfigForm.control,
     label: `Target price: ${tokenSymbolsString}`,
     customInputLabel: 'Custom target price',
     customInputPlaceholder: bn(spotPriceWithoutRate.toString()).toFixed(2),
@@ -96,7 +75,6 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
         rawValue: currentPricePlus5,
         svg: CurrentPricePlusFivePercentSVG,
       },
-      CUSTOM_OPTION,
     ],
     tooltip: 'The initial target price of token A in terms of token B',
     updateFn: (rawValue: string) => {
@@ -113,13 +91,13 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
 
   const priceRangeBoundaries = {
     label: `Target concentration density of liquidity`,
-    name: 'priceRangePercentage' as const,
+    name: 'priceRangePercentage',
+    control: reClammConfigForm.control,
     customInputLabel: '???',
     options: [
       { label: 'Narrow', displayValue: '± 25.00%', rawValue: '25', svg: TargetRangeNarrowSVG },
       { label: 'Standard', displayValue: '± 50.00%', rawValue: '50', svg: TargetRangeStandardSVG },
       { label: 'Wide', displayValue: '± 75.00%', rawValue: '75', svg: TargetRangeWideSVG },
-      CUSTOM_OPTION,
     ],
     tooltip: 'The target concentration density of liquidity',
     updateFn: (rawValue: string) => {
@@ -138,14 +116,14 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
   }
 
   const marginBuffer = {
-    name: 'centerednessMargin' as const,
+    name: 'centerednessMargin',
+    control: reClammConfigForm.control,
     label: `Margin buffer`,
     customInputLabel: 'Custom margin buffer',
     options: [
       { label: 'Narrow', displayValue: '10%', rawValue: '10', svg: MarginBufferNarrowSVG },
       { label: 'Standard', displayValue: '25%', rawValue: '25', svg: MarginBufferStandardSVG },
       { label: 'Wide', displayValue: '50%', rawValue: '50', svg: MarginBufferWideSVG },
-      CUSTOM_OPTION,
     ],
     tooltip: 'How far the price can be from the center before the price range starts to move',
     updateFn: (rawValue: string) => {
@@ -160,7 +138,8 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
   }
 
   const dailyPriceReadjustmentRate = {
-    name: 'priceShiftDailyRate' as const,
+    name: 'priceShiftDailyRate',
+    control: reClammConfigForm.control,
     label: `Daily price re-adjustment rate, when out-of-range`,
     customInputLabel: 'Custom rate',
     options: [
@@ -177,7 +156,6 @@ export function useReClammConfigurationOptions(): ReClammConfigOptionsGroup[] {
         rawValue: '75',
         svg: PriceAdjustmentRateFastSVG,
       },
-      CUSTOM_OPTION,
     ],
     tooltip: 'Controls the speed of the price shift when out-of-range',
     updateFn: (rawValue: string) => {

--- a/packages/lib/shared/components/imgs/AmplificationParameterSvgs.tsx
+++ b/packages/lib/shared/components/imgs/AmplificationParameterSvgs.tsx
@@ -1,0 +1,148 @@
+import { SVGProps } from 'react'
+
+export function SteepCurve(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      fill="none"
+      height="56"
+      viewBox="0 0 70 56"
+      width="70"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M0.5 1C0.5 19.625 20.05 54.95 68.25 55.25"
+        opacity="0.5"
+        stroke="#A0AEC0"
+        strokeDasharray="2 2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M6.5 1C6.5 23.625 10.05 49.95 68.25 50.25"
+        opacity="0.5"
+        stroke="#A0AEC0"
+        strokeDasharray="2 2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M12.5 1C12.5 32.625 3.05001 43.95 68.25 45.25"
+        stroke="url(#paint0_linear_740_15111)"
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+      <defs>
+        <linearGradient
+          gradientUnits="userSpaceOnUse"
+          id="paint0_linear_740_15111"
+          x1="11.3426"
+          x2="73.4669"
+          y1="25.3176"
+          y2="25.0597"
+        >
+          <stop stopColor="#B3AEF5" />
+          <stop offset="0.260439" stopColor="#D7CBE7" />
+          <stop offset="0.458359" stopColor="#E5C8C8" />
+          <stop offset="0.905621" stopColor="#EAA879" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}
+
+export function FlatCurve(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      fill="none"
+      height="56"
+      viewBox="0 0 70 56"
+      width="70"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M12.5 1C12.5 32.625 3.05001 43.95 68.25 45.25"
+        opacity="0.5"
+        stroke="#A0AEC0"
+        strokeDasharray="2 2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M0.5 1C0.5 19.625 20.05 54.95 68.25 55.25"
+        opacity="0.5"
+        stroke="#A0AEC0"
+        strokeDasharray="2 2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M6.5 1C6.5 23.625 10.05 49.95 68.25 50.25"
+        stroke="url(#paint0_linear_740_15119)"
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+      <defs>
+        <linearGradient
+          gradientUnits="userSpaceOnUse"
+          id="paint0_linear_740_15119"
+          x1="5.75302"
+          x2="73.9793"
+          y1="28.0653"
+          y2="27.7858"
+        >
+          <stop stopColor="#B3AEF5" />
+          <stop offset="0.260439" stopColor="#D7CBE7" />
+          <stop offset="0.458359" stopColor="#E5C8C8" />
+          <stop offset="0.905621" stopColor="#EAA879" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}
+
+export function VeryFlatCurve(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      fill="none"
+      height="57"
+      viewBox="0 0 70 57"
+      width="70"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M7 1C7 23.625 10.55 49.95 68.75 50.25"
+        opacity="0.5"
+        stroke="#A0AEC0"
+        strokeDasharray="2 2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M13 1C13 32.625 3.54998 43.95 68.75 45.25"
+        opacity="0.5"
+        stroke="#A0AEC0"
+        strokeDasharray="2 2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M1 1C1 19.625 20.55 54.95 68.75 55.25"
+        stroke="url(#paint0_linear_740_15127)"
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+      <defs>
+        <linearGradient
+          gradientUnits="userSpaceOnUse"
+          id="paint0_linear_740_15127"
+          x1="0.180444"
+          x2="75.036"
+          y1="30.8131"
+          y2="30.5077"
+        >
+          <stop stopColor="#B3AEF5" />
+          <stop offset="0.260439" stopColor="#D7CBE7" />
+          <stop offset="0.458359" stopColor="#E5C8C8" />
+          <stop offset="0.905621" stopColor="#EAA879" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}


### PR DESCRIPTION
closes https://github.com/balancer/frontend-monorepo/issues/2311

## Summary
- Refactored `ConfigOptionsGroup` into a reusable, form-agnostic component by accepting a `control` prop, enabling it to work with both reClamm and pool creation forms
- Replaced the `PoolSettingsRadioGroup` for amplification parameter with `ConfigOptionsGroup`, adding SVG curve illustrations and three presets (100, 1,000, 10,000) with proper min/max validation
- Hardcoded the "Or choose custom" radio inside `ConfigOptionsGroup` and added `forceCustom` state to prevent the custom input from snapping to a preset while typing (e.g. typing "1001" no longer auto-selects "100")
- Improved suggested pool name/symbol generation with pool-type prefixes (surge, reCLAMM) and weighted pool weight formatting
- Show donation tooltip for all pool types, not just reClamm

<img width="718" height="385" alt="image" src="https://github.com/user-attachments/assets/9b465a70-dce4-4f3e-88b4-423c696431ea" />

<img width="550" height="163" alt="image" src="https://github.com/user-attachments/assets/516f395f-357a-4c6f-9906-ff5b9f796785" />
