### PR TITLE
fix: update renovate bot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,7 +48,9 @@
         "eslint",
         "eslint-config-**",
         "eslint-plugin-**",
-        "@eslint/**"
+        "@eslint/**",
+        "@typescript-eslint/**",
+        "typescript-eslint"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,12 @@
       "matchManagers": ["github-actions"]
     },
     {
+      "description": "Keep Next server external workaround packages pinned to the transitive versions required by the current WalletConnect/pino stack.",
+      "groupName": "Pinned Next server externals",
+      "matchPackageNames": ["thread-stream", "real-require"],
+      "enabled": false
+    },
+    {
       "description": "Group remaining npm devDependencies that are not already covered by more specific package groups.",
       "groupName": "Other devDependencies",
       "matchManagers": ["npm"],


### PR DESCRIPTION
1. Ignore 2 transitive dependencies

Added a Renovate rule to ignore thread-stream and real-require updates because these are only pinned as Next.js serverExternalPackages workaround dependencies.

They are pulled transitively by the current WalletConnect/pino stack, not used directly by app code, so upgrading them independently is unnecessary and can break the build.

2. Add packages to eslint group rule

Added `"@typescript-eslint/**"` and `"typescript-eslint"` to the eslint group.