### PR TITLE
fix: rate provider yield fee default config

### DIFF
--- a/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ChoosePoolTokens.tsx
@@ -28,6 +28,7 @@ import { validatePoolTokens } from '../../validatePoolCreationForm'
 import {
   isConstantRateProvider,
   isDynamicRateProvider,
+  isMarketRateProvider,
 } from '@repo/lib/modules/tokens/token.helpers'
 import { PoolCreationToken, SupportedPoolTypes } from '../../types'
 import { useEffect } from 'react'
@@ -79,8 +80,8 @@ export function ChoosePoolTokens() {
     return !isTokenAlreadyInPool
   })
 
-  function getVerifiedRateProviderAddress(token: ApiToken) {
-    if (!token.priceRateProviderData) return undefined
+  function getVerifiedRateProviderAddress(token: ApiOrCustomToken) {
+    if (!('priceRateProviderData' in token) || !token.priceRateProviderData) return undefined
 
     const isRateProviderConstant = isConstantRateProvider(token)
     const isRateProviderDynamic = isDynamicRateProvider(token)
@@ -93,17 +94,14 @@ export function ChoosePoolTokens() {
   function handleTokenSelect(tokenMetadata: ApiOrCustomToken) {
     if (!tokenMetadata || selectedTokenIndex === null) return
 
-    let rateProvider: Address = zeroAddress
-
-    if ('priceRateProviderData' in tokenMetadata) {
-      rateProvider = getVerifiedRateProviderAddress(tokenMetadata) ?? zeroAddress
-    }
+    const rateProvider = getVerifiedRateProviderAddress(tokenMetadata) ?? zeroAddress
+    const paysYieldFees = rateProvider !== zeroAddress && !isMarketRateProvider(tokenMetadata)
 
     updatePoolToken(selectedTokenIndex, {
       address: tokenMetadata.address as Address,
       rateProvider,
       data: tokenMetadata,
-      paysYieldFees: rateProvider !== zeroAddress,
+      paysYieldFees,
       usdPrice: '',
     })
 

--- a/packages/lib/modules/pool/actions/create/steps/tokens/ConfigureTokenRateProvider.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ConfigureTokenRateProvider.tsx
@@ -117,7 +117,11 @@ export function ConfigureTokenRateProvider({
         />
       )}
       {showYieldFeesToggle && (
-        <ShareYieldFeesCheckbox paysYieldFees={paysYieldFees} tokenIndex={tokenIndex} />
+        <ShareYieldFeesCheckbox
+          isMarketRateProvider={isMarketRateProvider(poolTokens[tokenIndex].data)}
+          paysYieldFees={paysYieldFees}
+          tokenIndex={tokenIndex}
+        />
       )}
     </FormSubsection>
   )

--- a/packages/lib/modules/pool/actions/create/steps/tokens/ConfigureTokenRateProvider.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ConfigureTokenRateProvider.tsx
@@ -16,6 +16,7 @@ import { getChainId } from '@repo/lib/config/app.config'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { ArrowUpRight } from 'react-feather'
+import { isMarketRateProvider } from '@repo/lib/modules/tokens/token.helpers'
 
 interface ConfigureTokenRateProviderProps {
   tokenIndex: number
@@ -48,14 +49,14 @@ export function ConfigureTokenRateProvider({
 
   const handleRateProviderOptionChange = (value: RateProviderOption) => {
     let rateProvider: Address | '' = zeroAddress
+    let paysYieldFees = false
 
     if (value === RateProviderOption.Verified) {
       rateProvider = verifiedRateProviderAddress as Address
+      paysYieldFees = !isMarketRateProvider(poolTokens[tokenIndex].data)
     } else if (value === RateProviderOption.Custom) {
       rateProvider = '' // to be updated by user input
     }
-
-    const paysYieldFees = value !== RateProviderOption.Null
 
     updatePoolToken(tokenIndex, { rateProvider, paysYieldFees })
     // must trigger validation for text input since radio not kept in form state (instead we infer value for radio above)

--- a/packages/lib/modules/pool/actions/create/steps/tokens/ShareYieldFeesCheckbox.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ShareYieldFeesCheckbox.tsx
@@ -33,7 +33,7 @@ export function ShareYieldFeesCheckbox({
       </Checkbox>
       {isMarketRateProvider && (
         <BalAlert
-          content='Yield fees should remain disabled since the verified rate provider for this token reports the "market rate"'
+          content='Yield fees should remain disabled since the verified rate provider for this token reports a "market rate" instead of yield bearing rate (e.g. FX rates)'
           status="warning"
         />
       )}

--- a/packages/lib/modules/pool/actions/create/steps/tokens/ShareYieldFeesCheckbox.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ShareYieldFeesCheckbox.tsx
@@ -7,9 +7,11 @@ import { isBalancer, PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 export function ShareYieldFeesCheckbox({
   tokenIndex,
   paysYieldFees,
+  isMarketRateProvider,
 }: {
   tokenIndex: number
   paysYieldFees: boolean
+  isMarketRateProvider: boolean
 }) {
   const { updatePoolToken } = usePoolCreationForm()
 
@@ -29,7 +31,13 @@ export function ShareYieldFeesCheckbox({
       >
         <Text>Share yield with {PROJECT_CONFIG.projectName} protocol</Text>
       </Checkbox>
-      {!paysYieldFees ? (
+      {isMarketRateProvider && (
+        <BalAlert
+          content='Yield fees should remain disabled since the verified rate provider for this token reports the "market rate"'
+          status="warning"
+        />
+      )}
+      {!paysYieldFees && !isMarketRateProvider ? (
         isBalancer ? (
           <BalAlert
             content="Pools that don’t share yield fees with Balancer are unlikely to receive approval for a BAL liquidity mining gauge due to misalignment with the Balancer ecosystem."

--- a/packages/lib/modules/tokens/token.helpers.ts
+++ b/packages/lib/modules/tokens/token.helpers.ts
@@ -173,8 +173,9 @@ export const isConstantRateProvider = (token: ApiToken) =>
 export const isDynamicRateProvider = (token: ApiToken) =>
   token.priceRateProviderData && token.priceRateProviderData.name?.toLowerCase().includes('dynamic')
 
-export const isMarketRateProvider = (token: ApiOrCustomToken | undefined) =>
-  token &&
-  'priceRateProviderData' in token &&
-  token.priceRateProviderData &&
-  token.priceRateProviderData.warnings?.includes('market-rate')
+export const isMarketRateProvider = (token: ApiOrCustomToken | undefined): boolean =>
+  Boolean(
+    token &&
+    'priceRateProviderData' in token &&
+    token.priceRateProviderData?.warnings?.includes('market-rate')
+  )

--- a/packages/lib/modules/tokens/token.helpers.ts
+++ b/packages/lib/modules/tokens/token.helpers.ts
@@ -12,7 +12,7 @@ import { InputAmount } from '@balancer/sdk'
 import { Pool } from '../pool/pool.types'
 import { getVaultConfig, isCowAmmPool, isV3Pool } from '../pool/pool.helpers'
 import { PoolToken } from '../pool/pool.types'
-import { ApiToken } from './token.types'
+import { ApiToken, ApiOrCustomToken } from './token.types'
 import mainnetNetworkConfig from '@repo/lib/config/networks/mainnet'
 
 export function isNativeAsset(token: TokenBase | string, chain: GqlChain | SupportedChainId) {
@@ -172,3 +172,9 @@ export const isConstantRateProvider = (token: ApiToken) =>
 
 export const isDynamicRateProvider = (token: ApiToken) =>
   token.priceRateProviderData && token.priceRateProviderData.name?.toLowerCase().includes('dynamic')
+
+export const isMarketRateProvider = (token: ApiOrCustomToken | undefined) =>
+  token &&
+  'priceRateProviderData' in token &&
+  token.priceRateProviderData &&
+  token.priceRateProviderData.warnings?.includes('market-rate')

--- a/packages/lib/shared/services/api/global.graphql
+++ b/packages/lib/shared/services/api/global.graphql
@@ -29,6 +29,7 @@ query GetTokens($chains: [GqlChain!]!) {
       address
       reviewed
       name
+      warnings
     }
   }
 }


### PR DESCRIPTION
closes #2328 

- custom rate providers default to NOT share yield fees
- verified rate providers only default to share yield fees if `!isMarketRateProvider`
- special warning message for tokens with `"market-rate"` rate providers

<img width="1414" height="578" alt="image" src="https://github.com/user-attachments/assets/87a33b4c-c7e1-4fb6-9063-9eb344bd552d" />

<img width="1339" height="326" alt="image" src="https://github.com/user-attachments/assets/cab39fe3-be4e-4e11-9401-ded81eba94b0" />

https://github.com/balancer/code-review/blob/96e7ff8015d381c3a24f65aea15471b88fd0d528/rate-providers/registry.json#L4162-L4169

<img width="1365" height="420" alt="image" src="https://github.com/user-attachments/assets/12312884-17f9-438e-ace5-96c91b208e19" />

