### PR TITLE
chore: ignore @nktkas/hyperliquid updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "prConcurrentLimit": 5,
   "automerge": false,
 
-  "ignoreDeps": ["viem", "@balancer/sdk"],
+  "ignoreDeps": ["viem", "@balancer/sdk", "@nktkas/hyperliquid"],
 
   "packageRules": [
     {


### PR DESCRIPTION
related to #2348

## Summary
- Add `@nktkas/hyperliquid` to `ignoreDeps` in `renovate.json` to prevent Renovate from opening update PRs for this package

## Test plan
- [ ] Verify Renovate no longer opens PRs for `@nktkas/hyperliquid` on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)