### PR TITLE
fix: token balances integration test

### DIFF
--- a/packages/lib/modules/tokens/TokenBalancesProvider.integration.spec.ts
+++ b/packages/lib/modules/tokens/TokenBalancesProvider.integration.spec.ts
@@ -96,13 +96,11 @@ test('Should not return balances when user is not connected (account is empty) '
   })
 })
 
-test('should return balances of 20 tokens', async () => {
-  const numberOfTokens = 19
+test('returns balances for all tokens on a single chain', async () => {
+  const tokens = allFakeGqlTokens.filter(token => token.chainId === 1)
 
-  const { result } = testHook(() =>
-    useTokenBalancesLogic(allFakeGqlTokens.slice(0, numberOfTokens))
-  )
+  const { result } = testHook(() => useTokenBalancesLogic(tokens))
 
   await waitFor(() => expect(result.current.isBalancesLoading).toBeFalsy())
-  expect(result.current.balances).toHaveLength(numberOfTokens)
+  expect(result.current.balances).toHaveLength(tokens.length)
 })


### PR DESCRIPTION
`TokenBalancesProvider` assumes all requested tokens belong to the same chain, but this integration test was passing a mixed-chain slice from `allFakeGqlTokens`. 

That made the balance query flaky in CI because some token reads were executed against the wrong chain, so the test now filters to a single chain and asserts against that deterministic set.