### PR TITLE
fix: balancer e2e test speed & reliability

### DIFF
--- a/packages/e2e-tests/helpers/create-pool.helpers.ts
+++ b/packages/e2e-tests/helpers/create-pool.helpers.ts
@@ -211,15 +211,8 @@ export class CreatePoolPage {
       await expect(this.page.getByText('Pool creation confirmed!')).toBeVisible()
     }
 
-    const signApprovalsButtonText = `Sign approvals: ${this.config.tokens.map(t => t.symbol).join(', ')}`
-    const signApprovalsButton = button(this.page, signApprovalsButtonText)
-
-    // after first pool creation test runs, some tokens may have already been approved
     for (const token of this.config.tokens) {
-      const approveButton = button(this.page, `Approve ${token.symbol}`)
-      await approveButton.or(signApprovalsButton).waitFor()
-
-      if (await approveButton.isVisible()) await approveButton.click()
+      await clickButton(this.page, `Approve ${token.symbol}`)
     }
 
     if (this.isCowAmm) {
@@ -229,7 +222,8 @@ export class CreatePoolPage {
       await clickButton(this.page, 'Set Swap Fee')
       await clickButton(this.page, 'Finalize')
     } else {
-      await signApprovalsButton.click()
+      const signApprovalsButtonText = `Sign approvals: ${this.config.tokens.map(t => t.symbol).join(', ')}`
+      await clickButton(this.page, signApprovalsButtonText)
       await clickButton(this.page, 'Seed pool liquidity')
     }
 

--- a/packages/e2e-tests/tests/dev/balancer/create-lbp.spec.ts
+++ b/packages/e2e-tests/tests/dev/balancer/create-lbp.spec.ts
@@ -7,8 +7,6 @@ import {
   doProjectInfoStep,
   doReviewStep,
   doSaleStructureStep,
-  expectInitialFormState,
-  clickResetAndConfirm,
   mockCreateLbpMetadata,
   stepUrl,
   BASE_URL,

--- a/packages/e2e-tests/tests/dev/balancer/create-lbp.spec.ts
+++ b/packages/e2e-tests/tests/dev/balancer/create-lbp.spec.ts
@@ -72,30 +72,4 @@ test.describe('LBP creation page', () => {
       await expect(page).toHaveURL(stepUrl(0))
     })
   })
-
-  test.describe('Form reset at each step', () => {
-    test('sale structure', async ({ page }) => {
-      await doSaleStructureStep(page)
-      await clickButton(page, 'Next')
-
-      await clickResetAndConfirm(page)
-      await expectInitialFormState(page)
-    })
-
-    test('project info', async ({ page }) => {
-      await doSaleStructureStep(page, { continue: true })
-      await doProjectInfoStep(page)
-
-      await clickResetAndConfirm(page)
-      await expectInitialFormState(page)
-    })
-
-    test('review', async ({ page }) => {
-      await doSaleStructureStep(page, { continue: true })
-      await doProjectInfoStep(page, { continue: true })
-
-      await clickResetAndConfirm(page)
-      await expectInitialFormState(page)
-    })
-  })
 })

--- a/packages/e2e-tests/tests/dev/balancer/create-pool.spec.ts
+++ b/packages/e2e-tests/tests/dev/balancer/create-pool.spec.ts
@@ -28,33 +28,6 @@ test.describe('Create each pool type', () => {
   }
 })
 
-test.describe('Reset form on each step', () => {
-  test('type', async ({ poolAtTypeStep }) => {
-    await poolAtTypeStep.chooseNetwork('Arbitrum')
-    await poolAtTypeStep.choosePoolType(PoolType.Weighted)
-    await poolAtTypeStep.resetAndConfirm()
-    await poolAtTypeStep.expectInitialFormState()
-  })
-
-  test('tokens', async ({ poolAtTokensStep }) => {
-    await poolAtTokensStep.tokensStep()
-    await poolAtTokensStep.resetAndConfirm()
-    await poolAtTokensStep.expectInitialFormState()
-  })
-
-  test('details', async ({ poolAtDetailsStep }) => {
-    await poolAtDetailsStep.detailsStep()
-    await poolAtDetailsStep.resetAndConfirm()
-    await poolAtDetailsStep.expectInitialFormState()
-  })
-
-  test('fund', async ({ poolAtFundStep }) => {
-    await poolAtFundStep.fundStep()
-    await poolAtFundStep.resetAndConfirm()
-    await poolAtFundStep.expectInitialFormState()
-  })
-})
-
 test.describe('Build popover', () => {
   test('protocol link sets form state for protocol', async ({ page, poolAtTypeStep }) => {
     await poolAtTypeStep.clickBuildPopoverToCowAmm()

--- a/packages/e2e-tests/tests/dev/balancer/create-pool.spec.ts
+++ b/packages/e2e-tests/tests/dev/balancer/create-pool.spec.ts
@@ -1,7 +1,6 @@
 import { clickButton } from '@/helpers/user.helpers'
 import { POOL_CREATION_CONFIGS } from '@/helpers/create-pool.helpers'
 import { test, expect } from '../../../helpers/create-pool.fixtures'
-import { PoolType } from '@balancer/sdk'
 import { forkClient } from '@repo/lib/test/utils/wagmi/fork.helpers'
 
 test.describe('Create each pool type', () => {

--- a/packages/e2e-tests/tests/dev/balancer/create-pool.spec.ts
+++ b/packages/e2e-tests/tests/dev/balancer/create-pool.spec.ts
@@ -2,8 +2,19 @@ import { clickButton } from '@/helpers/user.helpers'
 import { POOL_CREATION_CONFIGS } from '@/helpers/create-pool.helpers'
 import { test, expect } from '../../../helpers/create-pool.fixtures'
 import { PoolType } from '@balancer/sdk'
+import { forkClient } from '@repo/lib/test/utils/wagmi/fork.helpers'
 
 test.describe('Create each pool type', () => {
+  let snapshotId: `0x${string}`
+
+  test.beforeEach(async () => {
+    snapshotId = await forkClient.snapshot()
+  })
+
+  test.afterEach(async () => {
+    await forkClient.revert({ id: snapshotId })
+  })
+
   for (const config of POOL_CREATION_CONFIGS) {
     test(config.type, async ({ createPool }) => {
       const pool = await createPool(config)

--- a/packages/lib/modules/lbp/LbpFormProvider.integration.spec.tsx
+++ b/packages/lib/modules/lbp/LbpFormProvider.integration.spec.tsx
@@ -3,6 +3,7 @@ import { useLbpFormLogic } from './LbpFormProvider'
 import { clearLocalStorageMock, mockLocalStorage } from '@repo/lib/test/utils/localstorage-mock'
 import { LS_KEYS } from '@repo/lib/modules/local-storage/local-storage.constants'
 import { FiatFxRatesProvider } from '@repo/lib/shared/hooks/FxRatesProvider'
+import { INITIAL_SALE_STRUCTURE, INITIAL_PROJECT_INFO } from './constants.lbp'
 import { act, waitFor } from '@testing-library/react'
 import { PropsWithChildren } from 'react'
 
@@ -14,7 +15,6 @@ vi.mock('next/navigation', async importOriginal => {
   const actual = await importOriginal<typeof import('next/navigation')>()
   return {
     ...actual,
-    useParams: () => ({ variant: 'v2' }),
     usePathname: () => '/lbp/create',
     useSearchParams: () => new URLSearchParams(),
   }
@@ -28,15 +28,65 @@ afterAll(() => {
   clearLocalStorageMock()
 })
 
+async function renderLbpForm() {
+  const rendered = testHook(() => useLbpFormLogic(), { wrapper: LbpTestWrapper })
+  await waitFor(() => {
+    expect(rendered.result.current.saleStructureForm.isHydrated).toBe(true)
+    expect(rendered.result.current.projectInfoForm.isHydrated).toBe(true)
+  })
+  return rendered
+}
+
 describe('useLbpFormLogic', () => {
-  describe('resetLbpCreation', () => {
-    it('reverts sale structure, project info, step index, and pool address to initial values', async () => {
-      const { result } = testHook(() => useLbpFormLogic(), { wrapper: LbpTestWrapper })
+  describe('persistence', () => {
+    it('rehydrates form values and pool address from localStorage when the hook remounts', async () => {
+      const { result, unmount } = await renderLbpForm()
+
+      const dirtyPoolAddress = '0x1234567890123456789012345678901234567890'
+
+      act(() => {
+        result.current.saleStructureForm.setValue('saleTokenAmount', '250')
+        result.current.saleStructureForm.setValue(
+          'launchTokenAddress',
+          '0xba100000625a3754423978a60c9317c58a424e3d'
+        )
+        result.current.projectInfoForm.setValue('name', 'Persisted project')
+        result.current.projectInfoForm.setValue('description', 'Persisted description')
+        result.current.setPoolAddress(dirtyPoolAddress)
+      })
 
       await waitFor(() => {
-        expect(result.current.saleStructureForm.isHydrated).toBe(true)
-        expect(result.current.projectInfoForm.isHydrated).toBe(true)
+        const persisted = JSON.parse(
+          window.localStorage.getItem(LS_KEYS.LbpConfig.SaleStructure) ?? '{}'
+        )
+        expect(persisted.saleTokenAmount).toBe('250')
       })
+
+      unmount()
+
+      const { result: remounted } = await renderLbpForm()
+
+      expect(remounted.current.saleStructureForm.getValues('saleTokenAmount')).toBe('250')
+      expect(remounted.current.saleStructureForm.getValues('launchTokenAddress')).toBe(
+        '0xba100000625a3754423978a60c9317c58a424e3d'
+      )
+      expect(remounted.current.projectInfoForm.getValues('name')).toBe('Persisted project')
+      expect(remounted.current.projectInfoForm.getValues('description')).toBe(
+        'Persisted description'
+      )
+      expect(remounted.current.poolAddress).toBe(dirtyPoolAddress)
+    })
+  })
+
+  describe('resetLbpCreation', () => {
+    it('reverts sale structure, project info, step index, and pool address to initial values', async () => {
+      // Seed step index before render so useLocalStorage initializes with it
+      window.localStorage.setItem(LS_KEYS.LbpConfig.StepIndex, '2')
+      window.localStorage.setItem(LS_KEYS.LbpConfig.IsMetadataSaved, 'true')
+
+      const { result } = await renderLbpForm()
+
+      expect(result.current.currentStepIndex).toBe(2)
 
       const dirtyPoolAddress = '0x1234567890123456789012345678901234567890'
 
@@ -51,20 +101,47 @@ describe('useLbpFormLogic', () => {
         result.current.setPoolAddress(dirtyPoolAddress)
       })
 
-      window.localStorage.setItem(LS_KEYS.LbpConfig.StepIndex, '2')
-      window.localStorage.setItem(LS_KEYS.LbpConfig.IsMetadataSaved, 'true')
-
       act(() => {
         result.current.resetLbpCreation()
       })
 
-      expect(result.current.saleStructureForm.getValues('launchTokenAddress')).toBe('')
-      expect(result.current.saleStructureForm.getValues('saleTokenAmount')).toBe('')
-      expect(result.current.projectInfoForm.getValues('name')).toBe('')
-      expect(result.current.projectInfoForm.getValues('description')).toBe('')
+      expect(result.current.saleStructureForm.getValues()).toEqual(INITIAL_SALE_STRUCTURE)
+      expect(result.current.projectInfoForm.getValues()).toEqual(INITIAL_PROJECT_INFO)
       expect(result.current.poolAddress).toBeUndefined()
+      expect(result.current.currentStepIndex).toBe(0)
+
+      // All persisted keys should reflect initial values (or be cleared for poolAddress)
+      await waitFor(() => {
+        expect(
+          JSON.parse(window.localStorage.getItem(LS_KEYS.LbpConfig.SaleStructure) ?? '{}')
+        ).toEqual(INITIAL_SALE_STRUCTURE)
+      })
+      expect(
+        JSON.parse(window.localStorage.getItem(LS_KEYS.LbpConfig.ProjectInfo) ?? '{}')
+      ).toEqual(INITIAL_PROJECT_INFO)
+      expect(window.localStorage.getItem(LS_KEYS.LbpConfig.PoolAddress)).toBeNull()
       expect(window.localStorage.getItem(LS_KEYS.LbpConfig.StepIndex)).toBe('0')
       expect(window.localStorage.getItem(LS_KEYS.LbpConfig.IsMetadataSaved)).toBe('false')
+    })
+  })
+
+  describe('isProjectInfoLocked', () => {
+    it('is false initially and becomes true once a pool address is set', async () => {
+      const { result } = await renderLbpForm()
+
+      expect(result.current.isProjectInfoLocked).toBe(false)
+
+      act(() => {
+        result.current.setPoolAddress('0x1234567890123456789012345678901234567890')
+      })
+
+      expect(result.current.isProjectInfoLocked).toBe(true)
+
+      act(() => {
+        result.current.setPoolAddress(undefined)
+      })
+
+      expect(result.current.isProjectInfoLocked).toBe(false)
     })
   })
 })

--- a/packages/lib/modules/lbp/LbpFormProvider.integration.spec.tsx
+++ b/packages/lib/modules/lbp/LbpFormProvider.integration.spec.tsx
@@ -1,0 +1,70 @@
+import { testHook } from '@repo/lib/test/utils/custom-renderers'
+import { useLbpFormLogic } from './LbpFormProvider'
+import { clearLocalStorageMock, mockLocalStorage } from '@repo/lib/test/utils/localstorage-mock'
+import { LS_KEYS } from '@repo/lib/modules/local-storage/local-storage.constants'
+import { FiatFxRatesProvider } from '@repo/lib/shared/hooks/FxRatesProvider'
+import { act, waitFor } from '@testing-library/react'
+import { PropsWithChildren } from 'react'
+
+function LbpTestWrapper({ children }: PropsWithChildren) {
+  return <FiatFxRatesProvider data={undefined}>{children}</FiatFxRatesProvider>
+}
+
+vi.mock('next/navigation', async importOriginal => {
+  const actual = await importOriginal<typeof import('next/navigation')>()
+  return {
+    ...actual,
+    useParams: () => ({ variant: 'v2' }),
+    usePathname: () => '/lbp/create',
+    useSearchParams: () => new URLSearchParams(),
+  }
+})
+
+beforeEach(() => {
+  mockLocalStorage()
+})
+
+afterAll(() => {
+  clearLocalStorageMock()
+})
+
+describe('useLbpFormLogic', () => {
+  describe('resetLbpCreation', () => {
+    it('reverts sale structure, project info, step index, and pool address to initial values', async () => {
+      const { result } = testHook(() => useLbpFormLogic(), { wrapper: LbpTestWrapper })
+
+      await waitFor(() => {
+        expect(result.current.saleStructureForm.isHydrated).toBe(true)
+        expect(result.current.projectInfoForm.isHydrated).toBe(true)
+      })
+
+      const dirtyPoolAddress = '0x1234567890123456789012345678901234567890'
+
+      act(() => {
+        result.current.saleStructureForm.setValue(
+          'launchTokenAddress',
+          '0xba100000625a3754423978a60c9317c58a424e3d'
+        )
+        result.current.saleStructureForm.setValue('saleTokenAmount', '100')
+        result.current.projectInfoForm.setValue('name', 'The Phoenix Project')
+        result.current.projectInfoForm.setValue('description', 'Rises from the ashes')
+        result.current.setPoolAddress(dirtyPoolAddress)
+      })
+
+      window.localStorage.setItem(LS_KEYS.LbpConfig.StepIndex, '2')
+      window.localStorage.setItem(LS_KEYS.LbpConfig.IsMetadataSaved, 'true')
+
+      act(() => {
+        result.current.resetLbpCreation()
+      })
+
+      expect(result.current.saleStructureForm.getValues('launchTokenAddress')).toBe('')
+      expect(result.current.saleStructureForm.getValues('saleTokenAmount')).toBe('')
+      expect(result.current.projectInfoForm.getValues('name')).toBe('')
+      expect(result.current.projectInfoForm.getValues('description')).toBe('')
+      expect(result.current.poolAddress).toBeUndefined()
+      expect(window.localStorage.getItem(LS_KEYS.LbpConfig.StepIndex)).toBe('0')
+      expect(window.localStorage.getItem(LS_KEYS.LbpConfig.IsMetadataSaved)).toBe('false')
+    })
+  })
+})

--- a/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
+++ b/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
@@ -2,13 +2,17 @@ import { testHook } from '@repo/lib/test/utils/custom-renderers'
 import { usePoolFormLogic } from './PoolCreationFormProvider'
 import { clearLocalStorageMock, mockLocalStorage } from '@repo/lib/test/utils/localstorage-mock'
 import { LS_KEYS } from '@repo/lib/modules/local-storage/local-storage.constants'
+import {
+  INITIAL_POOL_CREATION_FORM,
+  INITIAL_ECLP_CONFIG,
+  INITIAL_RECLAMM_CONFIG,
+} from './constants'
 import { act, waitFor } from '@testing-library/react'
 
 vi.mock('next/navigation', async importOriginal => {
   const actual = await importOriginal<typeof import('next/navigation')>()
   return {
     ...actual,
-    useParams: () => ({ variant: 'v2' }),
     usePathname: () => '/create',
     useSearchParams: () => new URLSearchParams(),
   }
@@ -22,35 +26,157 @@ afterAll(() => {
   clearLocalStorageMock()
 })
 
+async function renderPoolForm() {
+  const rendered = testHook(() => usePoolFormLogic())
+  await waitFor(() => expect(rendered.result.current.poolCreationForm.isHydrated).toBe(true))
+  return rendered
+}
+
 describe('usePoolFormLogic', () => {
+  describe('persistence', () => {
+    it('rehydrates form values from localStorage when the hook remounts', async () => {
+      const { result, unmount } = await renderPoolForm()
+
+      act(() => {
+        result.current.poolCreationForm.setValue('name', 'Persisted name')
+        result.current.poolCreationForm.setValue('symbol', 'PERSIST')
+        result.current.reClammConfigForm.setValue('initialTargetPrice', '42')
+        result.current.eclpConfigForm.setValue('alpha', '1.5')
+      })
+
+      // Wait for debounced-ish persistence effect to flush values to localStorage
+      await waitFor(() => {
+        const persisted = JSON.parse(window.localStorage.getItem(LS_KEYS.PoolCreation.Form) ?? '{}')
+        expect(persisted.name).toBe('Persisted name')
+      })
+
+      unmount()
+
+      const { result: remounted } = await renderPoolForm()
+
+      expect(remounted.current.poolCreationForm.getValues('name')).toBe('Persisted name')
+      expect(remounted.current.poolCreationForm.getValues('symbol')).toBe('PERSIST')
+      expect(remounted.current.reClammConfigForm.getValues('initialTargetPrice')).toBe('42')
+      expect(remounted.current.eclpConfigForm.getValues('alpha')).toBe('1.5')
+    })
+  })
+
   describe('resetPoolCreationForm', () => {
     it('reverts all persistent forms, step index, and pool address to initial values', async () => {
-      const { result } = testHook(() => usePoolFormLogic())
+      // Seed step index before render so useLocalStorage initializes with it
+      window.localStorage.setItem(LS_KEYS.PoolCreation.StepIndex, '2')
 
-      await waitFor(() => expect(result.current.poolCreationForm.isHydrated).toBe(true))
+      const { result } = await renderPoolForm()
 
+      expect(result.current.currentStepIndex).toBe(2)
+
+      // protocol is overridden at runtime by PoolCreationFormProvider, so capture the actual initial
+      const initialProtocol = result.current.poolCreationForm.getValues('protocol')
       const dirtyPoolAddress = '0x1234567890123456789012345678901234567890'
 
       act(() => {
         result.current.poolCreationForm.setValue('name', 'Mutated name')
         result.current.poolCreationForm.setValue('symbol', 'MUT')
+        result.current.poolCreationForm.setValue('protocol', 'CoW')
+        result.current.addPoolToken()
         result.current.reClammConfigForm.setValue('initialTargetPrice', '100')
         result.current.eclpConfigForm.setValue('alpha', '1.5')
         result.current.setPoolAddress(dirtyPoolAddress)
       })
 
-      window.localStorage.setItem(LS_KEYS.PoolCreation.StepIndex, '2')
+      expect(result.current.poolCreationForm.getValues('poolTokens')).toHaveLength(
+        INITIAL_POOL_CREATION_FORM.poolTokens.length + 1
+      )
 
       act(() => {
         result.current.resetPoolCreationForm()
       })
 
-      expect(result.current.poolCreationForm.getValues('name')).toBe('')
-      expect(result.current.poolCreationForm.getValues('symbol')).toBe('')
-      expect(result.current.reClammConfigForm.getValues('initialTargetPrice')).toBe('')
-      expect(result.current.eclpConfigForm.getValues('alpha')).toBe('')
+      expect(result.current.poolCreationForm.getValues()).toEqual({
+        ...INITIAL_POOL_CREATION_FORM,
+        protocol: initialProtocol,
+      })
+      expect(result.current.reClammConfigForm.getValues()).toEqual(INITIAL_RECLAMM_CONFIG)
+      expect(result.current.eclpConfigForm.getValues()).toEqual(INITIAL_ECLP_CONFIG)
       expect(result.current.poolAddress).toBeUndefined()
+      expect(result.current.currentStepIndex).toBe(0)
+
+      await waitFor(() => {
+        expect(JSON.parse(window.localStorage.getItem(LS_KEYS.PoolCreation.Form) ?? '{}')).toEqual({
+          ...INITIAL_POOL_CREATION_FORM,
+          protocol: initialProtocol,
+        })
+      })
+      expect(
+        JSON.parse(window.localStorage.getItem(LS_KEYS.PoolCreation.ReClammConfig) ?? '{}')
+      ).toEqual(INITIAL_RECLAMM_CONFIG)
+      expect(
+        JSON.parse(window.localStorage.getItem(LS_KEYS.PoolCreation.EclpConfig) ?? '{}')
+      ).toEqual(INITIAL_ECLP_CONFIG)
+      expect(window.localStorage.getItem(LS_KEYS.PoolCreation.Address)).toBeNull()
       expect(window.localStorage.getItem(LS_KEYS.PoolCreation.StepIndex)).toBe('0')
+    })
+  })
+
+  describe('invertGyroEclpPriceParams', () => {
+    it('inverts alpha/beta/peakPrice, swaps s<->c, preserves lambda, and reverses poolTokens', async () => {
+      const { result } = await renderPoolForm()
+
+      const tokenA = { ...INITIAL_POOL_CREATION_FORM.poolTokens[0], weight: '50' }
+      const tokenB = { ...INITIAL_POOL_CREATION_FORM.poolTokens[1], weight: '50' }
+
+      act(() => {
+        result.current.poolCreationForm.setValue('poolTokens', [tokenA, tokenB])
+        result.current.eclpConfigForm.setValue('alpha', '2')
+        result.current.eclpConfigForm.setValue('beta', '4')
+        result.current.eclpConfigForm.setValue('peakPrice', '5')
+        result.current.eclpConfigForm.setValue('s', '0.1')
+        result.current.eclpConfigForm.setValue('c', '0.9')
+        result.current.eclpConfigForm.setValue('lambda', '100')
+      })
+
+      act(() => {
+        result.current.invertGyroEclpPriceParams()
+      })
+
+      const eclp = result.current.eclpConfigForm.getValues()
+      // alpha<->beta and peakPrice are inverted (1/x); compare numerically to avoid coupling to NUM_FORMAT
+      expect(Number(eclp.alpha)).toBeCloseTo(0.25)
+      expect(Number(eclp.beta)).toBeCloseTo(0.5)
+      expect(Number(eclp.peakPrice)).toBeCloseTo(0.2)
+      // s and c are swapped as-is (no inversion, no reformat)
+      expect(eclp.s).toBe('0.9')
+      expect(eclp.c).toBe('0.1')
+      // lambda is preserved
+      expect(eclp.lambda).toBe('100')
+      expect(result.current.poolCreationForm.getValues('poolTokens')).toEqual([tokenB, tokenA])
+    })
+  })
+
+  describe('invertReClammPriceParams', () => {
+    it('inverts target price, swaps min<->max with inversion, and reverses poolTokens', async () => {
+      const { result } = await renderPoolForm()
+
+      const tokenA = { ...INITIAL_POOL_CREATION_FORM.poolTokens[0], weight: 'A' }
+      const tokenB = { ...INITIAL_POOL_CREATION_FORM.poolTokens[1], weight: 'B' }
+
+      act(() => {
+        result.current.poolCreationForm.setValue('poolTokens', [tokenA, tokenB])
+        result.current.reClammConfigForm.setValue('initialMinPrice', '2')
+        result.current.reClammConfigForm.setValue('initialMaxPrice', '8')
+        result.current.reClammConfigForm.setValue('initialTargetPrice', '4')
+      })
+
+      act(() => {
+        result.current.invertReClammPriceParams()
+      })
+
+      const reclamm = result.current.reClammConfigForm.getValues()
+      expect(reclamm.initialMinPrice).toBe('0.125')
+      expect(reclamm.initialMaxPrice).toBe('0.5')
+      expect(reclamm.initialTargetPrice).toBe('0.25')
+
+      expect(result.current.poolCreationForm.getValues('poolTokens')).toEqual([tokenB, tokenA])
     })
   })
 })

--- a/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
+++ b/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
@@ -1,0 +1,56 @@
+import { testHook } from '@repo/lib/test/utils/custom-renderers'
+import { usePoolFormLogic } from './PoolCreationFormProvider'
+import { clearLocalStorageMock, mockLocalStorage } from '@repo/lib/test/utils/localstorage-mock'
+import { LS_KEYS } from '@repo/lib/modules/local-storage/local-storage.constants'
+import { act, waitFor } from '@testing-library/react'
+
+vi.mock('next/navigation', async importOriginal => {
+  const actual = await importOriginal<typeof import('next/navigation')>()
+  return {
+    ...actual,
+    useParams: () => ({ variant: 'v2' }),
+    usePathname: () => '/create',
+    useSearchParams: () => new URLSearchParams(),
+  }
+})
+
+beforeEach(() => {
+  mockLocalStorage()
+})
+
+afterAll(() => {
+  clearLocalStorageMock()
+})
+
+describe('usePoolFormLogic', () => {
+  describe('resetPoolCreationForm', () => {
+    it('reverts all persistent forms, step index, and pool address to initial values', async () => {
+      const { result } = testHook(() => usePoolFormLogic())
+
+      await waitFor(() => expect(result.current.poolCreationForm.isHydrated).toBe(true))
+
+      const dirtyPoolAddress = '0x1234567890123456789012345678901234567890'
+
+      act(() => {
+        result.current.poolCreationForm.setValue('name', 'Mutated name')
+        result.current.poolCreationForm.setValue('symbol', 'MUT')
+        result.current.reClammConfigForm.setValue('initialTargetPrice', '100')
+        result.current.eclpConfigForm.setValue('alpha', '1.5')
+        result.current.setPoolAddress(dirtyPoolAddress)
+      })
+
+      window.localStorage.setItem(LS_KEYS.PoolCreation.StepIndex, '2')
+
+      act(() => {
+        result.current.resetPoolCreationForm()
+      })
+
+      expect(result.current.poolCreationForm.getValues('name')).toBe('')
+      expect(result.current.poolCreationForm.getValues('symbol')).toBe('')
+      expect(result.current.reClammConfigForm.getValues('initialTargetPrice')).toBe('')
+      expect(result.current.eclpConfigForm.getValues('alpha')).toBe('')
+      expect(result.current.poolAddress).toBeUndefined()
+      expect(window.localStorage.getItem(LS_KEYS.PoolCreation.StepIndex)).toBe('0')
+    })
+  })
+})


### PR DESCRIPTION
- use snapshot / revert pattern for pool creation tests
- remove e2e tests for pool creation "reset form" since fork state not required
- add integration tests for form providers ( includes reset form)