### PR TITLE
chore: surface flaky test query error

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/queries/usePoolStateWithBalancesQuery.integration.spec.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/queries/usePoolStateWithBalancesQuery.integration.spec.ts
@@ -2,7 +2,7 @@ import { GqlPoolElement } from '@repo/lib/shared/services/api/generated/graphql'
 import { buildDefaultPoolTestProvider, testHook } from '@repo/lib/test/utils/custom-renderers'
 import { waitFor } from '@testing-library/react'
 import { getApiPoolMock } from '../../../__mocks__/api-mocks/api-mocks'
-import { partialBoosted } from '../../../__mocks__/pool-examples/boosted'
+import { partialBoostedSepolia } from '../../../__mocks__/pool-examples/boosted'
 import { Pool } from '../../../pool.types'
 import { usePoolStateWithBalancesQuery } from './usePoolStateWithBalancesQuery'
 
@@ -15,17 +15,14 @@ async function testQuery(pool: Pool) {
 
 describe('usePoolStateWithBalances', () => {
   it('for a partial boosted pool', async () => {
-    const pool = getApiPoolMock(partialBoosted)
+    const pool = getApiPoolMock(partialBoostedSepolia)
 
     const result = await testQuery(pool)
 
-    await waitFor(
-      () => {
-        if (result.current.error) throw result.current.error
-        expect(result.current.isSuccess).toBe(true)
-      },
-      { timeout: 30_000 }
-    )
+    await waitFor(() => {
+      if (result.current.error) throw result.current.error
+      expect(result.current.isSuccess).toBe(true)
+    })
 
     expect(result.current.data?.id).toBeDefined()
   })

--- a/packages/lib/modules/pool/actions/add-liquidity/queries/usePoolStateWithBalancesQuery.integration.spec.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/queries/usePoolStateWithBalancesQuery.integration.spec.ts
@@ -19,9 +19,14 @@ describe('usePoolStateWithBalances', () => {
 
     const result = await testQuery(pool)
 
-    await waitFor(() => expect(result.current.data?.id).toBeDefined())
+    await waitFor(
+      () => {
+        if (result.current.error) throw result.current.error
+        expect(result.current.isSuccess).toBe(true)
+      },
+      { timeout: 30_000 }
+    )
 
-    expect(result.current.isLoading).toBeFalsy()
     expect(result.current.data?.id).toBeDefined()
   })
 })


### PR DESCRIPTION
test flaked again:
https://github.com/balancer/frontend-monorepo/actions/runs/24688245149/job/72203120657

 suggest we surface error and switch mock to sepolia to see if related to gnosis rpc url

or maybe we should just dump the test?
