### PR TITLE
fix: sentry config

### DIFF
--- a/apps/beets-frontend-v3/package.json
+++ b/apps/beets-frontend-v3/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --filter @repo/lib graphql:gen && next build",
-    "dev": "concurrently \"pnpm --filter @repo/lib graphql:gen --watch\" \"next dev -p 3001 --turbopack\"",
-    "dev:no-gen": "next dev --turbo -p 3001",
+    "dev": "concurrently \"pnpm --filter @repo/lib graphql:gen --watch\" \"next dev -p 3001\"",
+    "dev:no-gen": "next dev -p 3001",
     "gen:wagmi": "pnpm wagmi generate",
     "lint": "eslint . --max-warnings 0 --cache",
     "lint:fix": "eslint . --fix --max-warnings 0 --cache",

--- a/apps/frontend-v3/package.json
+++ b/apps/frontend-v3/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "start": "next start",
     "build": "pnpm --filter @repo/lib graphql:gen && next build",
-    "dev": "concurrently \"pnpm --filter @repo/lib graphql:gen --watch\" \"next dev --turbopack\"",
-    "dev:no-gen": "next dev --turbo",
+    "dev": "concurrently \"pnpm --filter @repo/lib graphql:gen --watch\" \"next dev\"",
+    "dev:no-gen": "next dev",
     "gen:wagmi": "pnpm wagmi generate",
     "lint": "eslint . --max-warnings 0 --cache",
     "lint:fix": "eslint . --fix --max-warnings 0 --cache",

--- a/apps/frontend-v3/sentry.config.ts
+++ b/apps/frontend-v3/sentry.config.ts
@@ -21,15 +21,6 @@ export const sentryOptions: SentryBuildOptions = {
   // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
   tunnelRoute: '/monitoring',
 
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
-
-  // Enables automatic instrumentation of Vercel Cron Monitors.
-  // See the following for more information:
-  // https://docs.sentry.io/product/crons/
-  // https://vercel.com/docs/cron-jobs
-  automaticVercelMonitors: true,
-
   sourcemaps: { disable: !shouldEnableSourceMaps },
   telemetry: shouldEnableSourceMaps,
   _experimental: {

--- a/apps/frontend-v3/sentry.config.ts
+++ b/apps/frontend-v3/sentry.config.ts
@@ -32,7 +32,11 @@ export const sentryOptions: SentryBuildOptions = {
 
   sourcemaps: { disable: !shouldEnableSourceMaps },
   telemetry: shouldEnableSourceMaps,
-  reactComponentAnnotation: { enabled: shouldEnableSourceMaps },
+  _experimental: {
+    turbopackReactComponentAnnotation: {
+      enabled: shouldEnableSourceMaps,
+    },
+  },
 }
 
 const productionSentryDSN =


### PR DESCRIPTION
- remove `--turbo(pack)` switches since it's default in Next 16 now
- remove deprecated webpack options `disableLogger` & `automaticVercelMonitors` that have no replacement for Turbopack
- replace webpack option `reactComponentAnnotation` with (experimental) Turbopack option