### PR TITLE
fix: remove duplicate pnpm store cache in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,8 +5,6 @@ runs:
   steps:
     - name: Set up pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-      with:
-        cache: true
 
     - name: Install Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6


### PR DESCRIPTION
we seem to be duplicating the CI cache with the `Set up pnpm` and `Install Node.js` steps

```                                                                                         
- pnpm/action-setup with cache: true → pnpm-cache-<os>-<hash> (~270 MiB)                                                                                            
- actions/setup-node with cache: pnpm → node-cache-<os>-pnpm-<hash> (~270 MiB)
```

### test command
```
gh cache list --limit 25 --sort created_at --order desc
```                                                                                                                                                                   

### Before

```
ID          KEY                                                                                                           SIZE        CREATED              ACCESSED  
3900832396  pnpm-cache-Linux-x64-4dd4efa3a613d95ee25bb3fc34f9450ee82049347c9271326b4e46a77713a963                        268.57 MiB  about 6 hours ago     about 2 hours ago
3900829841  node-cache-Linux-x64-pnpm-4dd4efa3a613d95ee25bb3fc34f9450ee82049347c9271326b4e46a77713a963                   268.52 MiB  about 6 hours ago     about 2 hours ago
3900817519  pnpm-cache-macOS-arm64-4dd4efa3a613d95ee25bb3fc34f9450ee82049347c9271326b4e46a77713a963                      269.06 MiB  about 6 hours ago     about 2 hours ago
3900823719  darwin-foundry-chain-fork-Integration-Test-b82648b2d0747a5ef5740fb4f1779c98e9bff687                          134.83 KiB  about 6 hours ago     about 6 hours ago
3900798543  node-cache-macOS-arm64-pnpm-4dd4efa3a613d95ee25bb3fc34f9450ee82049347c9271326b4e46a77713a963                 269.07 MiB  about 6 hours ago     about 2 hours ago
```

### This PR

```
ID          KEY                                                                                                           SIZE        CREATED              ACCESSED            
3908694480  node-cache-Linux-x64-pnpm-4dd4efa3a613d95ee25bb3fc34f9450ee82049347c9271326b4e46a77713a963                    268.51 MiB  about 8 minutes ago  about 8 minutes ago
3908692263  linux-foundry-chain-fork-E2E-Dev-Test-Beets-e166f3528688dee225200056d674eb4f8bd5fd20                          780 B       about 8 minutes ago  about 8 minutes ago
3908670665  node-cache-macOS-arm64-pnpm-4dd4efa3a613d95ee25bb3fc34f9450ee82049347c9271326b4e46a77713a963                  269.53 MiB  about 9 minutes ago  about 9 minutes ago
3908671839  darwin-foundry-chain-fork-Integration-Test-e166f3528688dee225200056d674eb4f8bd5fd20                           363.14 KiB  about 9 minutes ago  about 9 minutes ago
```

https://github.com/actions/setup-node#caching-global-packages-data
