### PR TITLE
ci: consolidate checks to all use ubuntu-latest

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
   #       run: pnpm run build
 
   Lint:
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup
@@ -42,7 +42,7 @@ jobs:
         run: pnpm stylelint
 
   Unit-Test:
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup
@@ -63,7 +63,7 @@ jobs:
       #     retention-days: 30
 
   Integration-Test:
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup


### PR DESCRIPTION
## Summary
- Switches CI checks from `macos-14` to `ubuntu-latest`, so all jobs share single `node-cache-Linux-x64-pnpm-*` instead of maintaining parallel ~270 MiB Linux and macOS-arm64 caches.
- The [original switch to macOS](https://github.com/balancer/frontend-monorepo/pull/216) was justified at the time by warm-cache speed and anvil reliability on Linux; both premises have shifted (`ubuntu-latest` is now 4 vCPU / 16 GB, and `foundry-toolchain` is stable on Linux — our existing E2E jobs already prove this).

## Testing

Integration and unit tests in 2m instead of 4-7m?!?!

### other PR running on mac OS: 

<img width="994" height="182" alt="image" src="https://github.com/user-attachments/assets/c072cc44-e28c-4fc4-829d-996f270b5bf3" />


### this PR on ubuntu-latest:
<img width="839" height="190" alt="image" src="https://github.com/user-attachments/assets/eca601fe-adf2-4590-bbbf-a47b144e912a" />
