### PR TITLE
docs: expand AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,79 +14,35 @@ Both apps share `packages/lib`; the active project is resolved from `NEXT_PUBLIC
 
 - Use `PROJECT_CONFIG.projectName`, `projectUrl`, `projectLogo` instead of literal `"Balancer"` / `"Beets"` / domain strings.
 - Gate project-only features (maBEETS, relics, etc.) with `isBalancer` / `isBeets`.
-- New config fields go in `config.types.ts` and must be populated in **both** `projects/balancer.ts` and `projects/beets.ts`.lines
+- New config fields go in `config.types.ts` and must be populated in **both** `projects/balancer.ts` and `projects/beets.ts`.
 
 ## Architecture
 
-**Monorepo** using pnpm workspaces + Turborepo.
-
-### Apps (Next.js with Turbopack, React, Chakra UI)
-
-- `apps/frontend-v3` — Balancer app (balancer.fi). Next.js App Router in `app/`.
-- `apps/beets-frontend-v3` — Beets app (same stack, different branding/config).
-
-Both apps are thin shells: routing lives in `app/(app)/` (pools, swap, portfolio, create, vebal, lbp) and `app/(marketing)/`. Almost all business logic is in `packages/lib`.
-
-### packages/lib — Shared library (`@repo/lib`)
-
-Most domain logic lives here; prefer adding new code to `packages/lib` unless it is genuinely app-specific. Two top-level directories:
-
-- **`modules/`** — Domain-specific feature modules (pool, swap, tokens, transactions, web3, vebal, staking, lbp, reclamm, eclp, cow, etc.). Each module typically contains components, hooks, helpers, actions, and tests.
-- **`shared/`** — Cross-cutting concerns:
-  - `shared/services/` — API clients (GraphQL codegen via `graphql:gen`), Chakra theming, viem config, coingecko, fathom analytics, etc.
-  - `shared/components/` — Reusable UI components (inputs, buttons, layouts, modals, etc.)
-  - `shared/hooks/` — Shared React hooks (currency, breakpoints, debounce, etc.)
-  - `shared/utils/` — Pure utility functions
-
-### Other packages
-
-- `packages/e2e-tests` — Playwright E2E tests
-- `packages/test` (`@repo/test`) — Shared test utilities (wagmi mock config, render helpers)
-- `packages/eslint-config`, `packages/prettier-config`, `packages/typescript-config` — Shared configs
+pnpm workspaces + Turborepo. Both `apps/frontend-v3` (Balancer) and `apps/beets-frontend-v3` (Beets) are thin Next.js App Router shells — almost all business logic lives in `packages/lib` (`@repo/lib`). Prefer adding new code to `packages/lib` unless it is genuinely app-specific.
 
 ### Key patterns
 
-- **Blockchain interaction**: viem + wagmi + RainbowKit for wallet connection. Pool actions (add/remove liquidity, swaps) go through handler patterns in `modules/pool/actions/`. Each action directory typically follows a consistent shape: `form/`, `handlers/`, `queries/`, `modal/`.
-- **Data fetching**: Apollo Client for GraphQL (Balancer API), react-query for other async state. GraphQL codegen runs concurrently with `next dev` (via `graphql:gen --watch`) and runs once before `next build`; generated types land in `packages/lib/shared/services/api/generated/`.
-- **Multi-chain**: Chain-specific config in `modules/chains/`. The app supports Ethereum, Arbitrum, Base, Gnosis, Optimism, Avalanche, Sonic, and others.
+- **Blockchain interaction**: viem + wagmi + RainbowKit. Pool actions (add/remove liquidity, swaps) go through handler patterns in `modules/pool/actions/`.
+- **Data fetching**: Apollo Client for GraphQL (Balancer API), react-query for other async state. GraphQL codegen runs concurrently with `next dev` (via `graphql:gen --watch`) and runs once before `next build`; generated types land in `packages/lib/shared/services/api/generated/` — don't run `graphql:gen` manually unless regenerating outside a dev/build cycle.
+- **Multi-chain**: Chain-specific config in `modules/chains/`.
 - **URL state**: `nuqs` for query-string-based state management.
 - **Pool types**: Weighted, Stable, CowAmm, LBP, reCLAMM, ECLP — each with specific UI and action handlers.
 
 ## Build & Development Commands
 
-```bash
-pnpm install                  # install dependencies
-pnpm dev:bal                  # dev server for Balancer app (localhost:3000)
-pnpm dev:beets                # dev server for Beets app
-pnpm dev:bal:fork             # dev server against local anvil fork (needs make fork-ethereum running)
-pnpm build                    # build all apps/packages via turbo
-pnpm typecheck                # typecheck all packages
-pnpm lint                     # eslint (all packages)
-pnpm lint:fix                 # eslint autofix
-pnpm lint:all                 # eslint + prettier + stylelint
-pnpm lint:all:fix             # autofix all linters
-pnpm graphql:gen              # regenerate GraphQL types
-```
-
-Pre-commit hook runs `lint-staged` (eslint + prettier on staged files).
+- `pnpm dev:bal:fork` — dev server against a local anvil fork. Requires `make fork-ethereum` running separately (needs `TEST_ACCOUNT_MNEMONIC` and `ETHEREUM_RPC_URL` env vars).
+- Pre-commit hook runs `lint-staged` (eslint + prettier on staged files).
 
 ## Testing
 
+Vitest across all packages. Integration tests live in `packages/lib` and use a separate config.
+
+Run a single integration test file:
+
 ```bash
-# Unit tests (vitest, across all packages)
-pnpm test:unit
-pnpm test:unit:watch
-
-# Integration tests (vitest with separate config)
-pnpm test:integration
-pnpm test:integration:watch
-
-# Run a single test file from packages/lib:
 pnpm --filter @repo/lib exec vitest run -c ./vitest.config.integration.ts <path-relative-to-packages/lib>
-# For unit tests, omit the -c flag (uses default vitest.config.ts)
-
-# E2E tests (Playwright) — requires .env.local + local anvil fork
-make fork-ethereum              # start local fork
-pnpm dev:bal:fork               # start app in fork mode
-pnpm test:e2e:dev:ui:bal        # launch Playwright UI
 ```
+
+For unit tests, omit the `-c` flag (uses default `vitest.config.ts`).
+
+**Don't use `pnpm test:integration -- <pattern>`** — the argument doesn't reliably filter to a single file. Use the `pnpm --filter` form above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,14 @@ This file provides guidance to coding agents working in this repository.
 
 ### Next.js: ALWAYS read docs before coding
 
-Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+Before any Next.js work, find and read the relevant doc in `apps/frontend-v3/node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
 
 ### Never hardcode project-specific values in `packages/lib`
 
 Both apps share `packages/lib`; the active project is resolved from `NEXT_PUBLIC_PROJECT_ID` in `config/getProjectConfig.ts`, which exposes `PROJECT_CONFIG` and `isBalancer` / `isBeets`. Hardcoding breaks the other app silently.
 
 - Use `PROJECT_CONFIG.projectName`, `projectUrl`, `projectLogo` instead of literal `"Balancer"` / `"Beets"` / domain strings.
-- Gate project-only features (veBAL, LBP, maBEETS, etc.) with `isBalancer` / `isBeets`.
+- Gate project-only features (maBEETS, relics, etc.) with `isBalancer` / `isBeets`.
 - New config fields go in `config.types.ts` and must be populated in **both** `projects/balancer.ts` and `projects/beets.ts`.lines
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,6 @@ pnpm workspaces + Turborepo. Both `apps/frontend-v3` (Balancer) and `apps/beets-
 - **URL state**: `nuqs` for query-string-based state management.
 - **Pool types**: Weighted, Stable, CowAmm, LBP, reCLAMM, ECLP — each with specific UI and action handlers.
 
-## Build & Development Commands
-
-- `pnpm dev:bal:fork` — dev server against a local anvil fork. Requires `make fork-ethereum` running separately (needs `TEST_ACCOUNT_MNEMONIC` and `ETHEREUM_RPC_URL` env vars).
-- Pre-commit hook runs `lint-staged` (eslint + prettier on staged files).
-
 ## Testing
 
 Vitest across all packages. Integration tests live in `packages/lib` and use a separate config.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,82 @@
-<!-- BEGIN:nextjs-agent-rules -->
+# AGENTS.md
 
-# Next.js: ALWAYS read docs before coding
+This file provides guidance to coding agents working in this repository.
+
+## Working with Next.js: ALWAYS read docs before coding
 
 Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
 
-<!-- END:nextjs-agent-rules -->
+## Build & Development Commands
+
+```bash
+pnpm install                  # install dependencies
+pnpm dev:bal                  # dev server for Balancer app (localhost:3000)
+pnpm dev:beets                # dev server for Beets app
+pnpm dev:bal:fork             # dev server against local anvil fork (needs make fork-ethereum running)
+pnpm build                    # build all apps/packages via turbo
+pnpm typecheck                # typecheck all packages
+pnpm lint                     # eslint (all packages)
+pnpm lint:fix                 # eslint autofix
+pnpm lint:all                 # eslint + prettier + stylelint
+pnpm lint:all:fix             # autofix all linters
+pnpm graphql:gen              # regenerate GraphQL types
+```
+
+## Testing
+
+```bash
+# Unit tests (vitest, across all packages)
+pnpm test:unit
+pnpm test:unit:watch
+
+# Integration tests (vitest with separate config)
+pnpm test:integration
+pnpm test:integration:watch
+
+# Run a single test file from packages/lib:
+pnpm --filter @repo/lib exec vitest run -c ./vitest.config.integration.ts <path-relative-to-packages/lib>
+# For unit tests, omit the -c flag (uses default vitest.config.ts)
+
+# E2E tests (Playwright) — requires .env.local + local anvil fork
+make fork-ethereum              # start local fork
+pnpm dev:bal:fork               # start app in fork mode
+pnpm test:e2e:dev:ui:bal        # launch Playwright UI
+```
+
+Pre-commit hook runs `lint-staged` (eslint + prettier on staged files).
+
+## Architecture
+
+**Monorepo** using pnpm workspaces + Turborepo. Node 24.x, pnpm 10.x.
+
+### Apps (Next.js 16 with Turbopack, React 19, Chakra UI v2)
+
+- `apps/frontend-v3` — Balancer app (balancer.fi). Next.js App Router in `app/`.
+- `apps/beets-frontend-v3` — Beets app (same stack, different branding/config).
+
+Both apps are thin shells: routing lives in `app/(app)/` (pools, swap, portfolio, create, vebal, lbp) and `app/(marketing)/`. Almost all business logic is in `packages/lib`.
+
+### packages/lib — Shared library (`@repo/lib`)
+
+This is where ~90% of the code lives. Two main directories:
+
+- **`modules/`** — Domain-specific feature modules (pool, swap, tokens, transactions, web3, vebal, staking, lbp, reclamm, eclp, cow, etc.). Each module typically contains components, hooks, helpers, actions, and tests.
+- **`shared/`** — Cross-cutting concerns:
+  - `shared/services/` — API clients (GraphQL codegen via `graphql:gen`), Chakra theming, viem config, coingecko, fathom analytics, etc.
+  - `shared/components/` — Reusable UI components (inputs, buttons, layouts, modals, etc.)
+  - `shared/hooks/` — Shared React hooks (currency, breakpoints, debounce, etc.)
+  - `shared/utils/` — Pure utility functions
+
+### Other packages
+
+- `packages/e2e-tests` — Playwright E2E tests
+- `packages/test` (`@repo/test`) — Shared test utilities (wagmi mock config, render helpers)
+- `packages/eslint-config`, `packages/prettier-config`, `packages/typescript-config` — Shared configs
+
+### Key patterns
+
+- **Blockchain interaction**: viem + wagmi + RainbowKit for wallet connection. Pool actions (add/remove liquidity, swaps) go through handler patterns in `modules/pool/actions/`. Each action directory typically follows a consistent shape: `form/`, `handlers/`, `queries/`, `modal/`.
+- **Data fetching**: Apollo Client for GraphQL (Balancer API), react-query for other async state. GraphQL codegen runs concurrently with `next dev` (via `graphql:gen --watch`) and runs once before `next build`; generated types land in `packages/lib/shared/services/api/generated/`.
+- **Multi-chain**: Chain-specific config in `modules/chains/`. The app supports Ethereum, Arbitrum, Base, Gnosis, Optimism, Avalanche, Sonic, and others.
+- **URL state**: `nuqs` for query-string-based state management.
+- **Pool types**: Weighted, Stable, CowAmm, LBP, reCLAMM, ECLP — each with specific UI and action handlers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,54 +2,25 @@
 
 This file provides guidance to coding agents working in this repository.
 
-## Working with Next.js: ALWAYS read docs before coding
+## Rules
+
+### Next.js: ALWAYS read docs before coding
 
 Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
 
-## Build & Development Commands
+### Never hardcode project-specific values in `packages/lib`
 
-```bash
-pnpm install                  # install dependencies
-pnpm dev:bal                  # dev server for Balancer app (localhost:3000)
-pnpm dev:beets                # dev server for Beets app
-pnpm dev:bal:fork             # dev server against local anvil fork (needs make fork-ethereum running)
-pnpm build                    # build all apps/packages via turbo
-pnpm typecheck                # typecheck all packages
-pnpm lint                     # eslint (all packages)
-pnpm lint:fix                 # eslint autofix
-pnpm lint:all                 # eslint + prettier + stylelint
-pnpm lint:all:fix             # autofix all linters
-pnpm graphql:gen              # regenerate GraphQL types
-```
+Both apps share `packages/lib`; the active project is resolved from `NEXT_PUBLIC_PROJECT_ID` in `config/getProjectConfig.ts`, which exposes `PROJECT_CONFIG` and `isBalancer` / `isBeets`. Hardcoding breaks the other app silently.
 
-## Testing
-
-```bash
-# Unit tests (vitest, across all packages)
-pnpm test:unit
-pnpm test:unit:watch
-
-# Integration tests (vitest with separate config)
-pnpm test:integration
-pnpm test:integration:watch
-
-# Run a single test file from packages/lib:
-pnpm --filter @repo/lib exec vitest run -c ./vitest.config.integration.ts <path-relative-to-packages/lib>
-# For unit tests, omit the -c flag (uses default vitest.config.ts)
-
-# E2E tests (Playwright) — requires .env.local + local anvil fork
-make fork-ethereum              # start local fork
-pnpm dev:bal:fork               # start app in fork mode
-pnpm test:e2e:dev:ui:bal        # launch Playwright UI
-```
-
-Pre-commit hook runs `lint-staged` (eslint + prettier on staged files).
+- Use `PROJECT_CONFIG.projectName`, `projectUrl`, `projectLogo` instead of literal `"Balancer"` / `"Beets"` / domain strings.
+- Gate project-only features (veBAL, LBP, maBEETS, etc.) with `isBalancer` / `isBeets`.
+- New config fields go in `config.types.ts` and must be populated in **both** `projects/balancer.ts` and `projects/beets.ts`.lines
 
 ## Architecture
 
-**Monorepo** using pnpm workspaces + Turborepo. Node 24.x, pnpm 10.x.
+**Monorepo** using pnpm workspaces + Turborepo.
 
-### Apps (Next.js 16 with Turbopack, React 19, Chakra UI v2)
+### Apps (Next.js with Turbopack, React, Chakra UI)
 
 - `apps/frontend-v3` — Balancer app (balancer.fi). Next.js App Router in `app/`.
 - `apps/beets-frontend-v3` — Beets app (same stack, different branding/config).
@@ -58,7 +29,7 @@ Both apps are thin shells: routing lives in `app/(app)/` (pools, swap, portfolio
 
 ### packages/lib — Shared library (`@repo/lib`)
 
-This is where ~90% of the code lives. Two main directories:
+Most domain logic lives here; prefer adding new code to `packages/lib` unless it is genuinely app-specific. Two top-level directories:
 
 - **`modules/`** — Domain-specific feature modules (pool, swap, tokens, transactions, web3, vebal, staking, lbp, reclamm, eclp, cow, etc.). Each module typically contains components, hooks, helpers, actions, and tests.
 - **`shared/`** — Cross-cutting concerns:
@@ -80,3 +51,42 @@ This is where ~90% of the code lives. Two main directories:
 - **Multi-chain**: Chain-specific config in `modules/chains/`. The app supports Ethereum, Arbitrum, Base, Gnosis, Optimism, Avalanche, Sonic, and others.
 - **URL state**: `nuqs` for query-string-based state management.
 - **Pool types**: Weighted, Stable, CowAmm, LBP, reCLAMM, ECLP — each with specific UI and action handlers.
+
+## Build & Development Commands
+
+```bash
+pnpm install                  # install dependencies
+pnpm dev:bal                  # dev server for Balancer app (localhost:3000)
+pnpm dev:beets                # dev server for Beets app
+pnpm dev:bal:fork             # dev server against local anvil fork (needs make fork-ethereum running)
+pnpm build                    # build all apps/packages via turbo
+pnpm typecheck                # typecheck all packages
+pnpm lint                     # eslint (all packages)
+pnpm lint:fix                 # eslint autofix
+pnpm lint:all                 # eslint + prettier + stylelint
+pnpm lint:all:fix             # autofix all linters
+pnpm graphql:gen              # regenerate GraphQL types
+```
+
+Pre-commit hook runs `lint-staged` (eslint + prettier on staged files).
+
+## Testing
+
+```bash
+# Unit tests (vitest, across all packages)
+pnpm test:unit
+pnpm test:unit:watch
+
+# Integration tests (vitest with separate config)
+pnpm test:integration
+pnpm test:integration:watch
+
+# Run a single test file from packages/lib:
+pnpm --filter @repo/lib exec vitest run -c ./vitest.config.integration.ts <path-relative-to-packages/lib>
+# For unit tests, omit the -c flag (uses default vitest.config.ts)
+
+# E2E tests (Playwright) — requires .env.local + local anvil fork
+make fork-ethereum              # start local fork
+pnpm dev:bal:fork               # start app in fork mode
+pnpm test:e2e:dev:ui:bal        # launch Playwright UI
+```


### PR DESCRIPTION
## Summary
- Expands `AGENTS.md` from a single Next.js rule into full onboarding content for coding agents (Claude Code, Cursor, Copilot, etc.)
- Adds build/dev commands, testing workflows (including single-file invocation), and a monorepo architecture overview
- Keeps the Next.js "read local docs before coding" rule prominent near the top

## Why this helps
- **Faster ramp per session** — agents pick up conventions on first read instead of re-discovering commands, folder layout, and patterns every time
- **Shared source of truth** — lives in-repo and applies to every agent tool, rather than being hidden in per-developer config files
- **Surfaces non-obvious details** — single-file integration test invocation, pool-action subdir shape (`form/handlers/queries/modal/`), GraphQL codegen pipeline, and where generated types land — things that otherwise require reading several files to figure out
- **Reduces command-lookup friction** — fork targets, filtered test runs, and the `lint` vs `lint:all` distinction are written down once
