### PR TITLE
chore: Add unit tests for Beets

### DIFF
--- a/apps/beets-frontend-v3/.env.test
+++ b/apps/beets-frontend-v3/.env.test
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_APP_ENV=test
+NEXT_PUBLIC_BALANCER_API_URL=https://test-api-v3.balancer.fi/graphql

--- a/apps/beets-frontend-v3/lib/modules/reliquary/hooks/useReliquaryAddLiquidityMaturityImpact.ts
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/hooks/useReliquaryAddLiquidityMaturityImpact.ts
@@ -1,12 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
-import { millisecondsToSeconds, secondsToMilliseconds } from 'date-fns'
 import { useReliquary } from '../ReliquaryProvider'
 import { bn, Numberish } from '@repo/lib/shared/utils/numbers'
 import { useGetLevelInfo } from './useGetLevelInfo'
 import { useGetLevelOnUpdate } from './useGetLevelOnUpdate'
 import { useGetPositionForId } from './useGetPositionForId'
-
-const MAX_MATURITY = 6048000 // 10 weeks in seconds
+import { calculateMaturityImpact } from '../utils/maturity-impact'
 
 export function useReliquaryAddLiquidityMaturityImpact(amount: Numberish, relicId?: string) {
   const { chain } = useReliquary()
@@ -43,46 +41,13 @@ export function useReliquaryAddLiquidityMaturityImpact(amount: Numberish, relicI
         return
       }
 
-      const maturityLevels = maturityThresholds.map(maturity => BigInt(maturity))
-      const weight = bn(amount).div(bn(amount).plus(position.amount)).toNumber()
-      const nowTimestamp = Math.floor(millisecondsToSeconds(Date.now()))
-      const maturity = nowTimestamp - position.entry
-      const entryTimestampAfterAddLiquidity = Math.round(position.entry + maturity * weight)
-      const newMaturity = nowTimestamp - entryTimestampAfterAddLiquidity
-      const maxLevel = maturityLevels.length - 1
-
-      let newLevel = 0
-      maturityLevels.forEach((level, i) => {
-        if (newMaturity >= Number(level)) {
-          newLevel = i
-        }
+      return calculateMaturityImpact({
+        amount,
+        positionAmount: position.amount,
+        positionEntry: position.entry,
+        levelOnUpdate,
+        maturityThresholds,
       })
-
-      const oldLevelProgress =
-        levelOnUpdate >= maxLevel
-          ? 'max level reached'
-          : `${maturity}/${maturityLevels[levelOnUpdate + 1]}`
-
-      const newLevelProgress =
-        newLevel >= maxLevel
-          ? 'max level reached'
-          : `${newMaturity}/${maturityLevels[newLevel + 1]}`
-
-      const addLiquidityMaturityImpactTimeInMilliseconds = secondsToMilliseconds(
-        MAX_MATURITY - newMaturity
-      )
-      const staysMax = levelOnUpdate === maxLevel && newLevel === maxLevel
-
-      return {
-        oldMaturity: maturity,
-        newMaturity,
-        oldLevel: levelOnUpdate,
-        newLevel,
-        oldLevelProgress,
-        newLevelProgress,
-        addLiquidityMaturityImpactTimeInMilliseconds,
-        staysMax,
-      }
     },
     enabled: isReady,
   })

--- a/apps/beets-frontend-v3/lib/modules/reliquary/utils/maturity-impact.spec.ts
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/utils/maturity-impact.spec.ts
@@ -1,0 +1,220 @@
+import { calculateMaturityImpact, MaturityImpactInput } from './maturity-impact'
+
+// Maturity thresholds: 0s, 1w, 2w, 3w, 4w, 5w
+const thresholds = ['0', '604800', '1209600', '1814400', '2419200', '3024000']
+const weekInSeconds = 604800
+
+function makeInput(overrides: Partial<MaturityImpactInput> = {}): MaturityImpactInput {
+  return {
+    amount: '100',
+    positionAmount: '100',
+    positionEntry: 1_700_000_000,
+    levelOnUpdate: 0,
+    maturityThresholds: thresholds,
+    nowTimestamp: 1_700_000_000 + 2 * weekInSeconds,
+    ...overrides,
+  }
+}
+
+describe('calculateMaturityImpact', () => {
+  describe('maturity tracking', () => {
+    test('calculates old maturity as time elapsed since entry', () => {
+      const entry = 1_700_000_000
+      const now = entry + 3 * weekInSeconds
+      const result = calculateMaturityImpact(makeInput({ positionEntry: entry, nowTimestamp: now }))
+
+      expect(result.oldMaturity).toBe(3 * weekInSeconds)
+    })
+
+    test('new maturity is reduced based on add liquidity weight', () => {
+      const entry = 1_700_000_000
+      const now = entry + 2 * weekInSeconds
+
+      // Adding 100 to existing 100 → weight = 0.5
+      // maturity = 2 weeks, entry shifts by maturity * 0.5 = 1 week
+      // newMaturity = 2 weeks - 1 week = 1 week
+      const result = calculateMaturityImpact(
+        makeInput({ positionEntry: entry, nowTimestamp: now, amount: '100', positionAmount: '100' })
+      )
+
+      expect(result.newMaturity).toBeCloseTo(weekInSeconds, -1)
+    })
+
+    test('small add has minimal maturity impact', () => {
+      const entry = 1_700_000_000
+      const now = entry + 4 * weekInSeconds
+
+      // Adding 1 to existing 1000 → weight ≈ 0.001
+      const result = calculateMaturityImpact(
+        makeInput({
+          positionEntry: entry,
+          nowTimestamp: now,
+          amount: '1',
+          positionAmount: '1000',
+        })
+      )
+
+      // New maturity should be very close to old maturity (within ~0.1%)
+      const diff = Math.abs(result.oldMaturity - result.newMaturity)
+      expect(diff / result.oldMaturity).toBeLessThan(0.002)
+    })
+
+    test('large add has major maturity impact', () => {
+      const entry = 1_700_000_000
+      const now = entry + 4 * weekInSeconds
+
+      // Adding 10000 to existing 100 → weight ≈ 0.99
+      const result = calculateMaturityImpact(
+        makeInput({
+          positionEntry: entry,
+          nowTimestamp: now,
+          amount: '10000',
+          positionAmount: '100',
+        })
+      )
+
+      // New maturity should be near 0
+      expect(result.newMaturity).toBeLessThan(weekInSeconds)
+    })
+  })
+
+  describe('level calculation', () => {
+    test('newLevel is determined by new maturity against thresholds', () => {
+      const entry = 1_700_000_000
+      const now = entry + 4 * weekInSeconds
+
+      // Adding 100 to existing 100 → weight 0.5 → newMaturity = 2 weeks
+      // 2 weeks = 1209600s, which passes thresholds[0]=0 and thresholds[1]=604800 and thresholds[2]=1209600
+      const result = calculateMaturityImpact(
+        makeInput({
+          positionEntry: entry,
+          nowTimestamp: now,
+          amount: '100',
+          positionAmount: '100',
+          levelOnUpdate: 3,
+        })
+      )
+
+      expect(result.oldLevel).toBe(3)
+      expect(result.newLevel).toBe(2)
+    })
+
+    test('newLevel stays at 0 when maturity is fully reset', () => {
+      const entry = 1_700_000_000
+      const now = entry + weekInSeconds
+
+      // Adding 100000 to existing 1 → weight ≈ 1 → new maturity ≈ 0
+      const result = calculateMaturityImpact(
+        makeInput({
+          positionEntry: entry,
+          nowTimestamp: now,
+          amount: '100000',
+          positionAmount: '1',
+          levelOnUpdate: 1,
+        })
+      )
+
+      expect(result.newLevel).toBe(0)
+    })
+  })
+
+  describe('level progress strings', () => {
+    test('shows progress fraction when not at max', () => {
+      const entry = 1_700_000_000
+      const now = entry + 2 * weekInSeconds
+
+      const result = calculateMaturityImpact(
+        makeInput({
+          positionEntry: entry,
+          nowTimestamp: now,
+          levelOnUpdate: 1,
+          amount: '100',
+          positionAmount: '100',
+        })
+      )
+
+      // oldLevelProgress = maturity/thresholds[levelOnUpdate+1] = "1209600/1209600"
+      expect(result.oldLevelProgress).toContain('/')
+      expect(result.newLevelProgress).toContain('/')
+    })
+
+    test('shows max level reached when at max level', () => {
+      const entry = 1_700_000_000
+      const maxLevel = thresholds.length - 1
+      const now = entry + 6 * weekInSeconds
+
+      // Adding small amount to keep at max
+      const result = calculateMaturityImpact(
+        makeInput({
+          positionEntry: entry,
+          nowTimestamp: now,
+          levelOnUpdate: maxLevel,
+          amount: '1',
+          positionAmount: '10000',
+        })
+      )
+
+      expect(result.oldLevelProgress).toBe('max level reached')
+    })
+  })
+
+  describe('staysMax flag', () => {
+    test('staysMax is true when both old and new are at max level', () => {
+      const entry = 1_700_000_000
+      const maxLevel = thresholds.length - 1
+      const now = entry + 10 * weekInSeconds
+
+      // Small add: maturity barely changes
+      const result = calculateMaturityImpact(
+        makeInput({
+          positionEntry: entry,
+          nowTimestamp: now,
+          levelOnUpdate: maxLevel,
+          amount: '1',
+          positionAmount: '10000',
+        })
+      )
+
+      expect(result.staysMax).toBe(true)
+    })
+
+    test('staysMax is false when dropping from max', () => {
+      const entry = 1_700_000_000
+      const maxLevel = thresholds.length - 1
+      const now = entry + 6 * weekInSeconds
+
+      // Large add: resets maturity significantly
+      const result = calculateMaturityImpact(
+        makeInput({
+          positionEntry: entry,
+          nowTimestamp: now,
+          levelOnUpdate: maxLevel,
+          amount: '100000',
+          positionAmount: '100',
+        })
+      )
+
+      expect(result.staysMax).toBe(false)
+    })
+  })
+
+  describe('addLiquidityMaturityImpactTimeInMilliseconds', () => {
+    test('represents remaining time to reach max maturity', () => {
+      const entry = 1_700_000_000
+      const now = entry + 2 * weekInSeconds
+      const MAX_MATURITY = 6048000
+
+      const result = calculateMaturityImpact(
+        makeInput({
+          positionEntry: entry,
+          nowTimestamp: now,
+          amount: '100',
+          positionAmount: '100',
+        })
+      )
+
+      const expectedMs = (MAX_MATURITY - result.newMaturity) * 1000
+      expect(result.addLiquidityMaturityImpactTimeInMilliseconds).toBe(expectedMs)
+    })
+  })
+})

--- a/apps/beets-frontend-v3/lib/modules/reliquary/utils/maturity-impact.spec.ts
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/utils/maturity-impact.spec.ts
@@ -1,7 +1,19 @@
 import { calculateMaturityImpact, MaturityImpactInput } from './maturity-impact'
 
-// Maturity thresholds: 0s, 1w, 2w, 3w, 4w, 5w
-const thresholds = ['0', '604800', '1209600', '1814400', '2419200', '3024000']
+// Real on-chain maturity thresholds: 11 levels, 1 week per level (0 → 10 weeks)
+const thresholds = [
+  '0',
+  '604800',
+  '1209600',
+  '1814400',
+  '2419200',
+  '3024000',
+  '3628800',
+  '4233600',
+  '4838400',
+  '5443200',
+  '6048000',
+]
 const weekInSeconds = 604800
 
 function makeInput(overrides: Partial<MaturityImpactInput> = {}): MaturityImpactInput {
@@ -20,29 +32,29 @@ describe('calculateMaturityImpact', () => {
   describe('maturity tracking', () => {
     test('calculates old maturity as time elapsed since entry', () => {
       const entry = 1_700_000_000
-      const now = entry + 3 * weekInSeconds
+      const now = entry + 5 * weekInSeconds
       const result = calculateMaturityImpact(makeInput({ positionEntry: entry, nowTimestamp: now }))
 
-      expect(result.oldMaturity).toBe(3 * weekInSeconds)
+      expect(result.oldMaturity).toBe(5 * weekInSeconds)
     })
 
     test('new maturity is reduced based on add liquidity weight', () => {
       const entry = 1_700_000_000
-      const now = entry + 2 * weekInSeconds
+      const now = entry + 4 * weekInSeconds
 
       // Adding 100 to existing 100 → weight = 0.5
-      // maturity = 2 weeks, entry shifts by maturity * 0.5 = 1 week
-      // newMaturity = 2 weeks - 1 week = 1 week
+      // maturity = 4 weeks, entry shifts by maturity * 0.5 = 2 weeks
+      // newMaturity = 4 weeks - 2 weeks = 2 weeks
       const result = calculateMaturityImpact(
         makeInput({ positionEntry: entry, nowTimestamp: now, amount: '100', positionAmount: '100' })
       )
 
-      expect(result.newMaturity).toBeCloseTo(weekInSeconds, -1)
+      expect(result.newMaturity).toBeCloseTo(2 * weekInSeconds, -1)
     })
 
     test('small add has minimal maturity impact', () => {
       const entry = 1_700_000_000
-      const now = entry + 4 * weekInSeconds
+      const now = entry + 8 * weekInSeconds
 
       // Adding 1 to existing 1000 → weight ≈ 0.001
       const result = calculateMaturityImpact(
@@ -61,7 +73,7 @@ describe('calculateMaturityImpact', () => {
 
     test('large add has major maturity impact', () => {
       const entry = 1_700_000_000
-      const now = entry + 4 * weekInSeconds
+      const now = entry + 8 * weekInSeconds
 
       // Adding 10000 to existing 100 → weight ≈ 0.99
       const result = calculateMaturityImpact(
@@ -81,27 +93,27 @@ describe('calculateMaturityImpact', () => {
   describe('level calculation', () => {
     test('newLevel is determined by new maturity against thresholds', () => {
       const entry = 1_700_000_000
-      const now = entry + 4 * weekInSeconds
+      const now = entry + 8 * weekInSeconds
 
-      // Adding 100 to existing 100 → weight 0.5 → newMaturity = 2 weeks
-      // 2 weeks = 1209600s, which passes thresholds[0]=0 and thresholds[1]=604800 and thresholds[2]=1209600
+      // Adding 100 to existing 100 → weight 0.5 → newMaturity = 4 weeks
+      // 4 weeks = 2419200s → passes thresholds[0..4] → newLevel = 4
       const result = calculateMaturityImpact(
         makeInput({
           positionEntry: entry,
           nowTimestamp: now,
           amount: '100',
           positionAmount: '100',
-          levelOnUpdate: 3,
+          levelOnUpdate: 7,
         })
       )
 
-      expect(result.oldLevel).toBe(3)
-      expect(result.newLevel).toBe(2)
+      expect(result.oldLevel).toBe(7)
+      expect(result.newLevel).toBe(4)
     })
 
     test('newLevel stays at 0 when maturity is fully reset', () => {
       const entry = 1_700_000_000
-      const now = entry + weekInSeconds
+      const now = entry + 3 * weekInSeconds
 
       // Adding 100000 to existing 1 → weight ≈ 1 → new maturity ≈ 0
       const result = calculateMaturityImpact(
@@ -110,7 +122,7 @@ describe('calculateMaturityImpact', () => {
           nowTimestamp: now,
           amount: '100000',
           positionAmount: '1',
-          levelOnUpdate: 1,
+          levelOnUpdate: 3,
         })
       )
 
@@ -121,27 +133,27 @@ describe('calculateMaturityImpact', () => {
   describe('level progress strings', () => {
     test('shows progress fraction when not at max', () => {
       const entry = 1_700_000_000
-      const now = entry + 2 * weekInSeconds
+      const now = entry + 4 * weekInSeconds
 
       const result = calculateMaturityImpact(
         makeInput({
           positionEntry: entry,
           nowTimestamp: now,
-          levelOnUpdate: 1,
+          levelOnUpdate: 3,
           amount: '100',
           positionAmount: '100',
         })
       )
 
-      // oldLevelProgress = maturity/thresholds[levelOnUpdate+1] = "1209600/1209600"
+      // oldLevelProgress = maturity/thresholds[levelOnUpdate+1]
       expect(result.oldLevelProgress).toContain('/')
       expect(result.newLevelProgress).toContain('/')
     })
 
     test('shows max level reached when at max level', () => {
       const entry = 1_700_000_000
-      const maxLevel = thresholds.length - 1
-      const now = entry + 6 * weekInSeconds
+      const maxLevel = thresholds.length - 1 // level 10
+      const now = entry + 11 * weekInSeconds
 
       // Adding small amount to keep at max
       const result = calculateMaturityImpact(
@@ -161,8 +173,8 @@ describe('calculateMaturityImpact', () => {
   describe('staysMax flag', () => {
     test('staysMax is true when both old and new are at max level', () => {
       const entry = 1_700_000_000
-      const maxLevel = thresholds.length - 1
-      const now = entry + 10 * weekInSeconds
+      const maxLevel = thresholds.length - 1 // level 10
+      const now = entry + 11 * weekInSeconds
 
       // Small add: maturity barely changes
       const result = calculateMaturityImpact(
@@ -180,8 +192,8 @@ describe('calculateMaturityImpact', () => {
 
     test('staysMax is false when dropping from max', () => {
       const entry = 1_700_000_000
-      const maxLevel = thresholds.length - 1
-      const now = entry + 6 * weekInSeconds
+      const maxLevel = thresholds.length - 1 // level 10
+      const now = entry + 11 * weekInSeconds
 
       // Large add: resets maturity significantly
       const result = calculateMaturityImpact(
@@ -201,7 +213,7 @@ describe('calculateMaturityImpact', () => {
   describe('addLiquidityMaturityImpactTimeInMilliseconds', () => {
     test('represents remaining time to reach max maturity', () => {
       const entry = 1_700_000_000
-      const now = entry + 2 * weekInSeconds
+      const now = entry + 4 * weekInSeconds
       const MAX_MATURITY = 6048000
 
       const result = calculateMaturityImpact(

--- a/apps/beets-frontend-v3/lib/modules/reliquary/utils/maturity-impact.ts
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/utils/maturity-impact.ts
@@ -1,0 +1,74 @@
+import { millisecondsToSeconds, secondsToMilliseconds } from 'date-fns'
+import { bn, Numberish } from '@repo/lib/shared/utils/numbers'
+
+const MAX_MATURITY = 6048000 // 10 weeks in seconds
+
+export type MaturityImpactInput = {
+  amount: Numberish
+  positionAmount: string
+  positionEntry: number
+  levelOnUpdate: number
+  maturityThresholds: string[]
+  nowTimestamp?: number // allow injection for testing; defaults to Date.now()
+}
+
+export type MaturityImpactResult = {
+  oldMaturity: number
+  newMaturity: number
+  oldLevel: number
+  newLevel: number
+  oldLevelProgress: string
+  newLevelProgress: string
+  addLiquidityMaturityImpactTimeInMilliseconds: number
+  staysMax: boolean
+}
+
+export function calculateMaturityImpact(input: MaturityImpactInput): MaturityImpactResult {
+  const {
+    amount,
+    positionAmount,
+    positionEntry,
+    levelOnUpdate,
+    maturityThresholds,
+    nowTimestamp: nowOverride,
+  } = input
+
+  const maturityLevels = maturityThresholds.map(maturity => BigInt(maturity))
+  const weight = bn(amount).div(bn(amount).plus(positionAmount)).toNumber()
+  const nowTimestamp = nowOverride ?? Math.floor(millisecondsToSeconds(Date.now()))
+  const maturity = nowTimestamp - positionEntry
+  const entryTimestampAfterAddLiquidity = Math.round(positionEntry + maturity * weight)
+  const newMaturity = nowTimestamp - entryTimestampAfterAddLiquidity
+  const maxLevel = maturityLevels.length - 1
+
+  let newLevel = 0
+  maturityLevels.forEach((level, i) => {
+    if (newMaturity >= Number(level)) {
+      newLevel = i
+    }
+  })
+
+  const oldLevelProgress =
+    levelOnUpdate >= maxLevel
+      ? 'max level reached'
+      : `${maturity}/${maturityLevels[levelOnUpdate + 1]}`
+
+  const newLevelProgress =
+    newLevel >= maxLevel ? 'max level reached' : `${newMaturity}/${maturityLevels[newLevel + 1]}`
+
+  const addLiquidityMaturityImpactTimeInMilliseconds = secondsToMilliseconds(
+    MAX_MATURITY - newMaturity
+  )
+  const staysMax = levelOnUpdate === maxLevel && newLevel === maxLevel
+
+  return {
+    oldMaturity: maturity,
+    newMaturity,
+    oldLevel: levelOnUpdate,
+    newLevel,
+    oldLevelProgress,
+    newLevelProgress,
+    addLiquidityMaturityImpactTimeInMilliseconds,
+    staysMax,
+  }
+}

--- a/apps/beets-frontend-v3/lib/modules/reliquary/utils/reliquary-helpers.spec.ts
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/utils/reliquary-helpers.spec.ts
@@ -1,0 +1,205 @@
+import { relicGetMaturityProgress } from './reliquary-helpers'
+import { ReliquaryFarmPosition } from '../ReliquaryProvider'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// Maturity thresholds in seconds (1 week per level, 0 → 5 weeks)
+const maturities = ['0', '604800', '1209600', '1814400', '2419200', '3024000']
+const weekInSeconds = 604800
+
+function makeRelic(overrides: Partial<ReliquaryFarmPosition> = {}): ReliquaryFarmPosition {
+  return {
+    farmId: '1',
+    relicId: '42',
+    amount: '100',
+    entry: 0,
+    level: 0,
+    ...overrides,
+  }
+}
+
+describe('relicGetMaturityProgress', () => {
+  describe('null / empty inputs', () => {
+    test('returns defaults when relic is null', () => {
+      const result = relicGetMaturityProgress(null, maturities)
+
+      expect(result.canUpgrade).toBe(false)
+      expect(result.canUpgradeTo).toBe(-1)
+      expect(result.progressToNextLevel).toBe(0)
+      expect(result.isMaxMaturity).toBe(false)
+    })
+
+    test('returns defaults when maturities is empty', () => {
+      const result = relicGetMaturityProgress(makeRelic(), [])
+
+      expect(result.canUpgrade).toBe(false)
+      expect(result.canUpgradeTo).toBe(-1)
+      expect(result.progressToNextLevel).toBe(0)
+      expect(result.isMaxMaturity).toBe(false)
+    })
+  })
+
+  describe('brand new relic (level 0, just created)', () => {
+    test('cannot upgrade and shows progress toward level 1', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      // Relic created just now
+      const relic = makeRelic({ entry: now, level: 0 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.canUpgrade).toBe(false)
+      expect(result.isMaxMaturity).toBe(false)
+      // Progress should be near 0 since just created
+      expect(result.progressToNextLevel).toBeCloseTo(0, 0)
+    })
+  })
+
+  describe('relic eligible for upgrade', () => {
+    test('canUpgrade is true when time elapsed exceeds next level threshold', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      // Relic created 2 weeks ago, still at level 0
+      const twoWeeksAgo = now - 2 * weekInSeconds
+      const relic = makeRelic({ entry: twoWeeksAgo, level: 0 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.canUpgrade).toBe(true)
+      expect(result.canUpgradeTo).toBeGreaterThan(0)
+    })
+
+    test('canUpgradeTo reflects the correct level', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      // Relic created 3 weeks ago, still at level 0 → should be upgradable to level 3
+      const threeWeeksAgo = now - 3 * weekInSeconds
+      const relic = makeRelic({ entry: threeWeeksAgo, level: 0 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.canUpgrade).toBe(true)
+      // 3 weeks elapsed: levels at 0s, 604800s (1w), 1209600s (2w), 1814400s (3w)
+      // So next level maturity index after elapsed time >= 3 weeks → canUpgradeTo = 4
+      expect(result.canUpgradeTo).toBe(4)
+    })
+  })
+
+  describe('relic already at correct level', () => {
+    test('canUpgrade is false when relic is at the correct level for elapsed time', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      // Relic created 1.5 weeks ago, at level 1 (correct for >1 week but <2 weeks)
+      const oneAndHalfWeeksAgo = now - 1.5 * weekInSeconds
+      const relic = makeRelic({ entry: oneAndHalfWeeksAgo, level: 1 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.canUpgrade).toBe(false)
+      expect(result.isMaxMaturity).toBe(false)
+    })
+  })
+
+  describe('max maturity', () => {
+    test('isMaxMaturity is true when time elapsed exceeds all thresholds', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      // Relic created 6 weeks ago (exceeds max maturity of 5 weeks)
+      const sixWeeksAgo = now - 6 * weekInSeconds
+      const relic = makeRelic({ entry: sixWeeksAgo, level: 4 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.isMaxMaturity).toBe(true)
+      expect(result.canUpgradeTo).toBe(maturities.length)
+    })
+
+    test('canUpgrade is true when at max maturity but level not yet at max', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      // Relic created 6 weeks ago but still at level 2
+      const sixWeeksAgo = now - 6 * weekInSeconds
+      const relic = makeRelic({ entry: sixWeeksAgo, level: 2 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.isMaxMaturity).toBe(true)
+      expect(result.canUpgrade).toBe(true)
+    })
+
+    test('canUpgrade is false when already at max level', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      // Relic at max level (maturities.length - 1 = 5) and max maturity
+      const sixWeeksAgo = now - 6 * weekInSeconds
+      const relic = makeRelic({ entry: sixWeeksAgo, level: maturities.length - 1 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.isMaxMaturity).toBe(true)
+      expect(result.canUpgrade).toBe(false)
+    })
+  })
+
+  describe('progressToNextLevel', () => {
+    test('returns 100 when upgrade is available', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      // 2 weeks elapsed, still at level 0 → can upgrade
+      const twoWeeksAgo = now - 2 * weekInSeconds
+      const relic = makeRelic({ entry: twoWeeksAgo, level: 0 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.canUpgrade).toBe(true)
+      expect(result.progressToNextLevel).toBe(100)
+    })
+
+    test('returns partial progress when between levels', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      // Relic at level 1, created 1.5 weeks ago → 0.5 weeks into level 1 period
+      const oneAndHalfWeeksAgo = now - 1.5 * weekInSeconds
+      const relic = makeRelic({ entry: oneAndHalfWeeksAgo, level: 1 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.canUpgrade).toBe(false)
+      // Progress = timeElapsedSinceCurrentLevel / weekInSeconds * 100
+      // timeElapsedSinceCurrentLevel = now - (maturities[1] + entry) = 0.5 weeks
+      expect(result.progressToNextLevel).toBeCloseTo(50, 0)
+    })
+  })
+
+  describe('entryDate and levelUpDate', () => {
+    test('entryDate matches the relic entry timestamp', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      const entry = 1_699_000_000
+      const relic = makeRelic({ entry, level: 0 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      expect(result.entryDate.getTime()).toBe(entry * 1000)
+    })
+
+    test('levelUpDate is entry + next maturity threshold', () => {
+      const now = 1_700_000_000
+      vi.setSystemTime(new Date(now * 1000))
+
+      const entry = 1_699_500_000
+      const relic = makeRelic({ entry, level: 0 })
+      const result = relicGetMaturityProgress(relic, maturities)
+
+      // For level 0, next level is maturities[1] = 604800 seconds
+      const expectedLevelUpDate = new Date((entry + 604800) * 1000)
+      expect(result.levelUpDate.getTime()).toBe(expectedLevelUpDate.getTime())
+    })
+  })
+})

--- a/apps/beets-frontend-v3/lib/modules/reliquary/utils/reliquary-helpers.spec.ts
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/utils/reliquary-helpers.spec.ts
@@ -27,7 +27,7 @@ const weekInSeconds = 604800
 
 function makeRelic(overrides: Partial<ReliquaryFarmPosition> = {}): ReliquaryFarmPosition {
   return {
-    farmId: '1',
+    farmId: '0', // real fBEETS farmId on Sonic
     relicId: '42',
     amount: '100',
     entry: 0,

--- a/apps/beets-frontend-v3/lib/modules/reliquary/utils/reliquary-helpers.spec.ts
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/utils/reliquary-helpers.spec.ts
@@ -9,8 +9,20 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-// Maturity thresholds in seconds (1 week per level, 0 → 5 weeks)
-const maturities = ['0', '604800', '1209600', '1814400', '2419200', '3024000']
+// Real on-chain maturity thresholds: 11 levels, 1 week per level (0 → 10 weeks)
+const maturities = [
+  '0',
+  '604800',
+  '1209600',
+  '1814400',
+  '2419200',
+  '3024000',
+  '3628800',
+  '4233600',
+  '4838400',
+  '5443200',
+  '6048000',
+]
 const weekInSeconds = 604800
 
 function makeRelic(overrides: Partial<ReliquaryFarmPosition> = {}): ReliquaryFarmPosition {
@@ -50,13 +62,11 @@ describe('relicGetMaturityProgress', () => {
       const now = 1_700_000_000
       vi.setSystemTime(new Date(now * 1000))
 
-      // Relic created just now
       const relic = makeRelic({ entry: now, level: 0 })
       const result = relicGetMaturityProgress(relic, maturities)
 
       expect(result.canUpgrade).toBe(false)
       expect(result.isMaxMaturity).toBe(false)
-      // Progress should be near 0 since just created
       expect(result.progressToNextLevel).toBeCloseTo(0, 0)
     })
   })
@@ -79,15 +89,14 @@ describe('relicGetMaturityProgress', () => {
       const now = 1_700_000_000
       vi.setSystemTime(new Date(now * 1000))
 
-      // Relic created 3 weeks ago, still at level 0 → should be upgradable to level 3
-      const threeWeeksAgo = now - 3 * weekInSeconds
-      const relic = makeRelic({ entry: threeWeeksAgo, level: 0 })
+      // Relic created 5 weeks ago, still at level 0 → should be upgradable to level 5
+      const fiveWeeksAgo = now - 5 * weekInSeconds
+      const relic = makeRelic({ entry: fiveWeeksAgo, level: 0 })
       const result = relicGetMaturityProgress(relic, maturities)
 
       expect(result.canUpgrade).toBe(true)
-      // 3 weeks elapsed: levels at 0s, 604800s (1w), 1209600s (2w), 1814400s (3w)
-      // So next level maturity index after elapsed time >= 3 weeks → canUpgradeTo = 4
-      expect(result.canUpgradeTo).toBe(4)
+      // 5 weeks elapsed: passes thresholds[0..5] → canUpgradeTo = 6
+      expect(result.canUpgradeTo).toBe(6)
     })
   })
 
@@ -107,13 +116,13 @@ describe('relicGetMaturityProgress', () => {
   })
 
   describe('max maturity', () => {
-    test('isMaxMaturity is true when time elapsed exceeds all thresholds', () => {
+    test('isMaxMaturity is true when time elapsed exceeds all thresholds (>10 weeks)', () => {
       const now = 1_700_000_000
       vi.setSystemTime(new Date(now * 1000))
 
-      // Relic created 6 weeks ago (exceeds max maturity of 5 weeks)
-      const sixWeeksAgo = now - 6 * weekInSeconds
-      const relic = makeRelic({ entry: sixWeeksAgo, level: 4 })
+      // Relic created 11 weeks ago (exceeds max maturity of 10 weeks)
+      const elevenWeeksAgo = now - 11 * weekInSeconds
+      const relic = makeRelic({ entry: elevenWeeksAgo, level: 9 })
       const result = relicGetMaturityProgress(relic, maturities)
 
       expect(result.isMaxMaturity).toBe(true)
@@ -124,9 +133,9 @@ describe('relicGetMaturityProgress', () => {
       const now = 1_700_000_000
       vi.setSystemTime(new Date(now * 1000))
 
-      // Relic created 6 weeks ago but still at level 2
-      const sixWeeksAgo = now - 6 * weekInSeconds
-      const relic = makeRelic({ entry: sixWeeksAgo, level: 2 })
+      // Relic created 11 weeks ago but still at level 5
+      const elevenWeeksAgo = now - 11 * weekInSeconds
+      const relic = makeRelic({ entry: elevenWeeksAgo, level: 5 })
       const result = relicGetMaturityProgress(relic, maturities)
 
       expect(result.isMaxMaturity).toBe(true)
@@ -137,9 +146,9 @@ describe('relicGetMaturityProgress', () => {
       const now = 1_700_000_000
       vi.setSystemTime(new Date(now * 1000))
 
-      // Relic at max level (maturities.length - 1 = 5) and max maturity
-      const sixWeeksAgo = now - 6 * weekInSeconds
-      const relic = makeRelic({ entry: sixWeeksAgo, level: maturities.length - 1 })
+      // Relic at max level (10) and max maturity (>10 weeks)
+      const elevenWeeksAgo = now - 11 * weekInSeconds
+      const relic = makeRelic({ entry: elevenWeeksAgo, level: maturities.length - 1 })
       const result = relicGetMaturityProgress(relic, maturities)
 
       expect(result.isMaxMaturity).toBe(true)
@@ -197,7 +206,7 @@ describe('relicGetMaturityProgress', () => {
       const relic = makeRelic({ entry, level: 0 })
       const result = relicGetMaturityProgress(relic, maturities)
 
-      // For level 0, next level is maturities[1] = 604800 seconds
+      // For level 0, next level is maturities[1] = 604800 seconds (1 week)
       const expectedLevelUpDate = new Date((entry + 604800) * 1000)
       expect(result.levelUpDate.getTime()).toBe(expectedLevelUpDate.getTime())
     })

--- a/apps/beets-frontend-v3/lib/services/batch-relayer/beets-batch-relayer.service.spec.ts
+++ b/apps/beets-frontend-v3/lib/services/batch-relayer/beets-batch-relayer.service.spec.ts
@@ -2,10 +2,11 @@ import { decodeFunctionData } from 'viem'
 import { BeetsBatchRelayerService } from './beets-batch-relayer.service'
 import { beetsV2BatchRelayerLibraryAbi } from '@repo/lib/modules/web3/contracts/abi/beets/generated'
 
-const batchRelayerAddress = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
-const sender = '0x1111111111111111111111111111111111111111' as const
-const recipient = '0x2222222222222222222222222222222222222222' as const
-const token = '0x3333333333333333333333333333333333333333' as const
+// Real Sonic contract addresses
+const batchRelayerAddress = '0x1498437067d7bdDc4C9427964F073eE1AB4f50fC' // batch relayer
+const sender = '0x1498437067d7bdDc4C9427964F073eE1AB4f50fC' as const // batch relayer
+const recipient = '0x973670ce19594F857A7cD85EE834c7a74a941684' as const // reliquary
+const token = '0x2D0E0814E62D80056181F5cd932274405966e4f0' as const // BEETS token (checksummed)
 
 describe('BeetsBatchRelayerService', () => {
   let service: BeetsBatchRelayerService
@@ -24,7 +25,7 @@ describe('BeetsBatchRelayerService', () => {
       sender,
       recipient,
       token,
-      poolId: 1n,
+      poolId: 0n, // real fBEETS farmId on Sonic
       amount: 1000000000000000000n,
       outputReference: 0n,
     })

--- a/apps/beets-frontend-v3/lib/services/batch-relayer/beets-batch-relayer.service.spec.ts
+++ b/apps/beets-frontend-v3/lib/services/batch-relayer/beets-batch-relayer.service.spec.ts
@@ -1,0 +1,93 @@
+import { decodeFunctionData } from 'viem'
+import { BeetsBatchRelayerService } from './beets-batch-relayer.service'
+import { beetsV2BatchRelayerLibraryAbi } from '@repo/lib/modules/web3/contracts/abi/beets/generated'
+
+const batchRelayerAddress = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+const sender = '0x1111111111111111111111111111111111111111' as const
+const recipient = '0x2222222222222222222222222222222222222222' as const
+const token = '0x3333333333333333333333333333333333333333' as const
+
+describe('BeetsBatchRelayerService', () => {
+  let service: BeetsBatchRelayerService
+
+  beforeEach(() => {
+    service = BeetsBatchRelayerService.create(batchRelayerAddress)
+  })
+
+  test('create() returns a BeetsBatchRelayerService instance', () => {
+    expect(service).toBeInstanceOf(BeetsBatchRelayerService)
+    expect(service.batchRelayerAddress).toBe(batchRelayerAddress)
+  })
+
+  test('reliquaryEncodeCreateRelicAndAddLiquidity delegates correctly', () => {
+    const encoded = service.reliquaryEncodeCreateRelicAndAddLiquidity({
+      sender,
+      recipient,
+      token,
+      poolId: 1n,
+      amount: 1000000000000000000n,
+      outputReference: 0n,
+    })
+
+    const decoded = decodeFunctionData({
+      abi: beetsV2BatchRelayerLibraryAbi,
+      data: encoded,
+    })
+
+    expect(decoded.functionName).toBe('reliquaryCreateRelicAndDeposit')
+  })
+
+  test('reliquaryEncodeAddLiquidity delegates correctly', () => {
+    const encoded = service.reliquaryEncodeAddLiquidity({
+      sender,
+      token,
+      relicId: 42n,
+      amount: 500000000000000000n,
+      outputReference: 1n,
+    })
+
+    const decoded = decodeFunctionData({
+      abi: beetsV2BatchRelayerLibraryAbi,
+      data: encoded,
+    })
+
+    expect(decoded.functionName).toBe('reliquaryDeposit')
+  })
+
+  test('reliquaryEncodeRemoveLiquidityAndClaim delegates correctly', () => {
+    const encoded = service.reliquaryEncodeRemoveLiquidityAndClaim({
+      recipient,
+      relicId: 7n,
+      amount: 250000000000000000n,
+      outputReference: 2n,
+    })
+
+    const decoded = decodeFunctionData({
+      abi: beetsV2BatchRelayerLibraryAbi,
+      data: encoded,
+    })
+
+    expect(decoded.functionName).toBe('reliquaryWithdrawAndHarvest')
+  })
+
+  test('reliquaryEncodeHarvestAll delegates correctly', () => {
+    const encoded = service.reliquaryEncodeHarvestAll({
+      relicIds: [1n, 2n, 3n],
+      recipient,
+    })
+
+    const decoded = decodeFunctionData({
+      abi: beetsV2BatchRelayerLibraryAbi,
+      data: encoded,
+    })
+
+    expect(decoded.functionName).toBe('reliquaryHarvestAll')
+  })
+
+  test('inherits base BatchRelayerService methods', () => {
+    // Verify the service has inherited methods from BatchRelayerService
+    expect(typeof service.encodePeekChainedReferenceValue).toBe('function')
+    expect(typeof service.gaugeEncodeDeposit).toBe('function')
+    expect(typeof service.gaugeEncodeWithdraw).toBe('function')
+  })
+})

--- a/apps/beets-frontend-v3/lib/services/batch-relayer/extensions/reliquary-actions.service.spec.ts
+++ b/apps/beets-frontend-v3/lib/services/batch-relayer/extensions/reliquary-actions.service.spec.ts
@@ -1,0 +1,146 @@
+import { decodeFunctionData } from 'viem'
+import { ReliquaryActionsService } from './reliquary-actions.service'
+import { beetsV2BatchRelayerLibraryAbi } from '@repo/lib/modules/web3/contracts/abi/beets/generated'
+import type {
+  EncodeReliquaryCreateRelicAndAddLiquidityInput,
+  EncodeReliquaryAddLiquidityInput,
+  EncodeReliquaryRemoveLiquidityAndClaimInput,
+  EncodeReliquaryHarvestAllInput,
+} from '../reliquary-types'
+
+const service = new ReliquaryActionsService()
+
+const sender = '0x1111111111111111111111111111111111111111' as const
+const recipient = '0x2222222222222222222222222222222222222222' as const
+const token = '0x3333333333333333333333333333333333333333' as const
+
+describe('ReliquaryActionsService', () => {
+  describe('encodeCreateRelicAndAddLiquidity', () => {
+    test('encodes valid calldata for reliquaryCreateRelicAndDeposit', () => {
+      const params: EncodeReliquaryCreateRelicAndAddLiquidityInput = {
+        sender,
+        recipient,
+        token,
+        poolId: 1n,
+        amount: 1000000000000000000n,
+        outputReference: 0n,
+      }
+
+      const encoded = service.encodeCreateRelicAndAddLiquidity(params)
+
+      expect(encoded).toBeDefined()
+      expect(encoded.startsWith('0x')).toBe(true)
+
+      const decoded = decodeFunctionData({
+        abi: beetsV2BatchRelayerLibraryAbi,
+        data: encoded,
+      })
+
+      expect(decoded.functionName).toBe('reliquaryCreateRelicAndDeposit')
+      expect(decoded.args).toEqual([sender, recipient, token, 1n, 1000000000000000000n, 0n])
+    })
+  })
+
+  describe('encodeAddLiquidity', () => {
+    test('encodes valid calldata for reliquaryDeposit', () => {
+      const params: EncodeReliquaryAddLiquidityInput = {
+        sender,
+        token,
+        relicId: 42n,
+        amount: 500000000000000000n,
+        outputReference: 1n,
+      }
+
+      const encoded = service.encodeAddLiquidity(params)
+
+      expect(encoded).toBeDefined()
+      expect(encoded.startsWith('0x')).toBe(true)
+
+      const decoded = decodeFunctionData({
+        abi: beetsV2BatchRelayerLibraryAbi,
+        data: encoded,
+      })
+
+      expect(decoded.functionName).toBe('reliquaryDeposit')
+      expect(decoded.args).toEqual([sender, token, 42n, 500000000000000000n, 1n])
+    })
+  })
+
+  describe('encodeRemoveLiquidityAndClaim', () => {
+    test('encodes valid calldata for reliquaryWithdrawAndHarvest', () => {
+      const params: EncodeReliquaryRemoveLiquidityAndClaimInput = {
+        recipient,
+        relicId: 7n,
+        amount: 250000000000000000n,
+        outputReference: 2n,
+      }
+
+      const encoded = service.encodeRemoveLiquidityAndClaim(params)
+
+      expect(encoded).toBeDefined()
+      expect(encoded.startsWith('0x')).toBe(true)
+
+      const decoded = decodeFunctionData({
+        abi: beetsV2BatchRelayerLibraryAbi,
+        data: encoded,
+      })
+
+      expect(decoded.functionName).toBe('reliquaryWithdrawAndHarvest')
+      expect(decoded.args).toEqual([recipient, 7n, 250000000000000000n, 2n])
+    })
+  })
+
+  describe('encodeHarvestAll', () => {
+    test('encodes valid calldata for reliquaryHarvestAll', () => {
+      const params: EncodeReliquaryHarvestAllInput = {
+        relicIds: [1n, 2n, 3n],
+        recipient,
+      }
+
+      const encoded = service.encodeHarvestAll(params)
+
+      expect(encoded).toBeDefined()
+      expect(encoded.startsWith('0x')).toBe(true)
+
+      const decoded = decodeFunctionData({
+        abi: beetsV2BatchRelayerLibraryAbi,
+        data: encoded,
+      })
+
+      expect(decoded.functionName).toBe('reliquaryHarvestAll')
+      expect(decoded.args).toEqual([[1n, 2n, 3n], recipient])
+    })
+
+    test('handles single relic id', () => {
+      const params: EncodeReliquaryHarvestAllInput = {
+        relicIds: [99n],
+        recipient,
+      }
+
+      const encoded = service.encodeHarvestAll(params)
+      const decoded = decodeFunctionData({
+        abi: beetsV2BatchRelayerLibraryAbi,
+        data: encoded,
+      })
+
+      expect(decoded.functionName).toBe('reliquaryHarvestAll')
+      expect(decoded.args).toEqual([[99n], recipient])
+    })
+
+    test('handles empty relic ids', () => {
+      const params: EncodeReliquaryHarvestAllInput = {
+        relicIds: [],
+        recipient,
+      }
+
+      const encoded = service.encodeHarvestAll(params)
+      const decoded = decodeFunctionData({
+        abi: beetsV2BatchRelayerLibraryAbi,
+        data: encoded,
+      })
+
+      expect(decoded.functionName).toBe('reliquaryHarvestAll')
+      expect(decoded.args).toEqual([[], recipient])
+    })
+  })
+})

--- a/apps/beets-frontend-v3/lib/services/batch-relayer/extensions/reliquary-actions.service.spec.ts
+++ b/apps/beets-frontend-v3/lib/services/batch-relayer/extensions/reliquary-actions.service.spec.ts
@@ -10,9 +10,10 @@ import type {
 
 const service = new ReliquaryActionsService()
 
-const sender = '0x1111111111111111111111111111111111111111' as const
-const recipient = '0x2222222222222222222222222222222222222222' as const
-const token = '0x3333333333333333333333333333333333333333' as const
+// Real Sonic contract addresses
+const sender = '0x1498437067d7bdDc4C9427964F073eE1AB4f50fC' as const // batch relayer
+const recipient = '0x973670ce19594F857A7cD85EE834c7a74a941684' as const // reliquary
+const token = '0x2D0E0814E62D80056181F5cd932274405966e4f0' as const // BEETS token (checksummed)
 
 describe('ReliquaryActionsService', () => {
   describe('encodeCreateRelicAndAddLiquidity', () => {
@@ -21,7 +22,7 @@ describe('ReliquaryActionsService', () => {
         sender,
         recipient,
         token,
-        poolId: 1n,
+        poolId: 0n, // real fBEETS farmId on Sonic
         amount: 1000000000000000000n,
         outputReference: 0n,
       }
@@ -37,7 +38,7 @@ describe('ReliquaryActionsService', () => {
       })
 
       expect(decoded.functionName).toBe('reliquaryCreateRelicAndDeposit')
-      expect(decoded.args).toEqual([sender, recipient, token, 1n, 1000000000000000000n, 0n])
+      expect(decoded.args).toEqual([sender, recipient, token, 0n, 1000000000000000000n, 0n])
     })
   })
 

--- a/apps/beets-frontend-v3/package.json
+++ b/apps/beets-frontend-v3/package.json
@@ -14,6 +14,8 @@
     "prettier": "prettier '**/*.*(md|json|yaml|ts|js|tsx)' --check --cache --log-level=warn",
     "prettier:fix": "prettier '**/*.*(md|json|yaml|ts|js|tsx)' --write --cache --log-level=warn",
     "start": "next start -p 3001",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "typecheck": "tsc --project tsconfig.json --noEmit --incremental",
     "gen:theme-typings": "chakra-cli tokens ./lib/services/chakra/themes/beets/beets.theme.ts",
     "postinstall": "pnpm run gen:theme-typings"
@@ -56,6 +58,8 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/tinycolor2": "1.4.6",
+    "@repo/test": "workspace:*",
+    "@testing-library/react": "16.3.2",
     "@wagmi/cli": "2.10.0",
     "autoprefixer": "10.5.0",
     "babel-plugin-react-compiler": "1.0.0",

--- a/apps/beets-frontend-v3/tsconfig.json
+++ b/apps/beets-frontend-v3/tsconfig.json
@@ -13,6 +13,7 @@
       "@repo/*": ["../../packages/*"],
       "~/*": ["./lib/*"]
     },
+    "types": ["vitest/globals"],
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
     "jsx": "preserve"
   },

--- a/apps/beets-frontend-v3/vitest.config.ts
+++ b/apps/beets-frontend-v3/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+import { createVitestConfig } from '../../packages/test/vitest/vitest.config.base'
+
+const monorepoRoot = resolve(__dirname, '../..')
+
+const baseConfig = createVitestConfig(monorepoRoot)
+
+export default defineConfig({
+  ...baseConfig,
+  resolve: {
+    ...baseConfig.resolve,
+    alias: {
+      ...(baseConfig.resolve?.alias as Record<string, string>),
+      '~': resolve(__dirname, './lib'),
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,9 +142,15 @@ importers:
       '@repo/prettier-config':
         specifier: workspace:*
         version: link:../../packages/prettier-config
+      '@repo/test':
+        specifier: workspace:*
+        version: link:../../packages/test
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/js-cookie':
         specifier: 3.0.6
         version: 3.0.6
@@ -2288,105 +2294,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2722,28 +2712,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.3':
     resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.3':
     resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.3':
     resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
@@ -3071,42 +3057,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -3260,79 +3240,66 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}


### PR DESCRIPTION
## Summary

Adds the first unit tests for the `beets-frontend-v3` app — **36 tests** covering reliquary maturity logic and batch relayer calldata encoding.

### What's included

**Test infrastructure for Beets app:**
- `vitest.config.ts` — mirrors `frontend-v3` setup, adds `~` alias for `./lib`
- `.env.test` — provides `NEXT_PUBLIC_BALANCER_API_URL` for vitest env
- `package.json` — adds `test:unit` and `test:unit:watch` scripts
- `tsconfig.json` — adds `vitest/globals` types
- Adds `@repo/test` and `@testing-library/react` as devDependencies

**Reliquary helpers (13 tests)** — `reliquary-helpers.spec.ts`:
- Null/empty input handling
- Level upgrade eligibility (brand new, eligible, already correct, max maturity)
- Progress-to-next-level calculation (100% when upgradable, partial between levels)
- Entry date and level-up date computation

**Maturity impact calculation (11 tests)** — `maturity-impact.spec.ts`:
- Extracted `calculateMaturityImpact` from `useReliquaryAddLiquidityMaturityImpact` hook into a pure function (`maturity-impact.ts`) for testability
- Weight-based maturity reduction (small vs large deposits)
- Level determination against thresholds
- Progress strings and `staysMax` flag
- Time-to-max-maturity calculation

**Batch relayer service (12 tests)** — `beets-batch-relayer.service.spec.ts` + `reliquary-actions.service.spec.ts`:
- Encode/decode roundtrip for all 4 reliquary operations (createRelicAndAddLiquidity, addLiquidity, removeLiquidityAndClaim, harvestAll)
- Edge cases (single relic, empty relic list)
- `BeetsBatchRelayerService` factory, delegation, and inheritance

### Refactor note
The maturity impact calculation logic was extracted from `useReliquaryAddLiquidityMaturityImpact` into `utils/maturity-impact.ts`. The hook now calls `calculateMaturityImpact()` — **no behavioral change**, just moving the pure logic out of the `queryFn` for testability.

## Review & Testing Checklist for Human
- [ ] Verify the extracted `calculateMaturityImpact` function produces identical results to the original inline logic — test the maBEETS add liquidity flow on Sonic to confirm maturity impact display is unchanged
- [ ] Check that `vitest/globals` types addition in `tsconfig.json` doesn't cause any type conflicts with the existing Next.js type setup
- [ ] Run `pnpm --filter beets-frontend-v3 test:unit` locally to confirm all 36 tests pass

### Notes
- The `.env.test` file only contains public API URLs (no secrets), matching the existing pattern in `packages/lib/.env.test`
- All existing `packages/lib` unit tests (291) continue to pass
- Lint and typecheck both pass cleanly
