### PR TITLE
chore: block TypeScript major upgrades in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -169,6 +169,12 @@
       "matchPackageNames": ["zod"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Block TypeScript major upgrades until moduleResolution and deep import issues are resolved.",
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a Renovate block rule to prevent automatic major version upgrades of TypeScript.

## Why

TypeScript 6.x introduces breaking changes that require:
1. Updating `moduleResolution` from ``node`` to ``bundler`` in shared tsconfigs
2. Fixing deep imports from packages like `@rainbow-me/rainbowkit` that aren't compatible with the new resolution strategy

These changes need to be coordinated carefully across the monorepo. Blocking major upgrades until the toolchain is ready.

## Changes

- Added `enabled: false` package rule for `typescript` major updates in `renovate.json`