### PR TITLE
chore: block vitest-mock-extended major upgrades in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -169,6 +169,12 @@
       "matchPackageNames": ["zod"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Block vitest-mock-extended major upgrades — v4 requires vitest 4 which is not yet in the project.",
+      "matchPackageNames": ["vitest-mock-extended"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a Renovate block rule to prevent automatic major version upgrades of `vitest-mock-extended`.

## Why

`vitest-mock-extended@4.0.0` requires `vitest@>=4.0.0` but the project uses `vitest@3.2.4`. The vitest major upgrade is already blocked in Renovate, so this package's major upgrade should also be blocked to stay in sync.

## Changes

- Added `enabled: false` package rule for `vitest-mock-extended` major updates in `renovate.json`