### PR TITLE
chore: add trusted fork pr gate

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,6 +3,7 @@ name: Checks
 on:
   pull_request:
     types: [opened, synchronize]
+  workflow_dispatch:
 
 env:
   NEXT_PUBLIC_BALANCER_API_URL: https://test-api-v3.balancer.fi/graphql

--- a/.github/workflows/trusted-fork-pr.yml
+++ b/.github/workflows/trusted-fork-pr.yml
@@ -1,0 +1,26 @@
+# allow gh ci actions to run for trusted users
+name: Trusted fork PR gate
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  gate:
+    # 20125808 - groninge01
+    if: contains(
+      fromJson('[20125808]'),
+      github.event.pull_request.user.id
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger normal CI workflow
+        run: |
+          gh workflow run checks.yml \
+            --ref "${{ github.event.pull_request.head.sha }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
allow gh ci actions to run for trusted users