### PR TITLE
chore(renovate): document why @nktkas/hyperliquid updates are blocked

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "prConcurrentLimit": 5,
   "automerge": false,
 
-  "ignoreDeps": ["viem", "@balancer/sdk", "@nktkas/hyperliquid"],
+  "ignoreDeps": ["viem", "@balancer/sdk"],
 
   "packageRules": [
     {
@@ -186,6 +186,11 @@
       "description": "Block vitest-mock-extended major upgrades — v4 requires vitest 4 which is not yet in the project.",
       "matchPackageNames": ["vitest-mock-extended"],
       "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Block @nktkas/hyperliquid updates. The library introduces frequent breaking changes (client redesigns, schema refactors, renamed parameters) between minor versions. Updating past 0.23.1 would require significant refactoring of packages/lib/modules/chains/hyperevm/useHyperEvm.ts.",
+      "matchPackageNames": ["@nktkas/hyperliquid"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Moves \@nktkas/hyperliquid\ from the undocumented \ignoreDeps\ list to a proper Renovate \packageRules\ entry with a descriptive reason.

The library introduces frequent breaking changes (client redesigns, schema refactors, renamed parameters) between minor versions. Updating past v0.23.1 would require significant refactoring of the HyperEVM integration in \packages/lib/modules/chains/hyperevm/useHyperEvm.ts\.

This change:
- Removes the dependency from the opaque \ignoreDeps\ array
- Adds a self-documenting \packageRules\ entry following the existing patterns in renovate.json
- References issue #2348

Closes #2348