### PR TITLE
fix(portfolio): reduce re-renders and visual jumpiness on load

### DIFF
--- a/packages/lib/modules/pool/queries/useUserStakedBalance.tsx
+++ b/packages/lib/modules/pool/queries/useUserStakedBalance.tsx
@@ -74,14 +74,18 @@ export function useUserStakedBalance(pools: Pool[] = []) {
     )
   }, [stakedPoolBalances, contracts, poolByStaking, userAddress, isFetching])
 
-  const stakedBalancesByPoolId = groupBy(stakedBalances, 'poolId')
+  const stakedBalancesByPoolId = useMemo(() => {
+    const byPoolId = groupBy(stakedBalances, 'poolId')
 
-  // return empty results for pools without stakings
-  pools.forEach(pool => {
-    if (!stakedBalancesByPoolId[pool.id]) {
-      stakedBalancesByPoolId[pool.id] = []
-    }
-  })
+    // return empty results for pools without stakings
+    pools.forEach(pool => {
+      if (!byPoolId[pool.id]) {
+        byPoolId[pool.id] = []
+      }
+    })
+
+    return byPoolId
+  }, [stakedBalances, pools])
 
   return {
     stakedBalancesByPoolId,

--- a/packages/lib/modules/pool/queries/useUserStakedBalance.tsx
+++ b/packages/lib/modules/pool/queries/useUserStakedBalance.tsx
@@ -72,7 +72,7 @@ export function useUserStakedBalance(pools: Pool[] = []) {
         }
       })
     )
-  }, [stakedPoolBalances, contracts, poolByStaking, userAddress, isFetching])
+  }, [stakedPoolBalances, contracts, poolByStaking, isFetching, priceFor])
 
   const stakedBalancesByPoolId = useMemo(() => {
     const byPoolId = groupBy(stakedBalances, 'poolId')

--- a/packages/lib/modules/pool/queries/useUserStakedBalance.tsx
+++ b/packages/lib/modules/pool/queries/useUserStakedBalance.tsx
@@ -21,8 +21,11 @@ export type StakedBalancesByPoolId = ReturnType<
 export function useUserStakedBalance(pools: Pool[] = []) {
   const { userAddress, isConnected } = useUserAccount()
   const { priceFor } = useTokens()
-  const poolByStaking = createPoolByStakingRecord(pools)
-  const contracts = poolContracts(poolByStaking, userAddress)
+  const poolByStaking = useMemo(() => createPoolByStakingRecord(pools), [pools])
+  const contracts = useMemo(
+    () => poolContracts(poolByStaking, userAddress),
+    [poolByStaking, userAddress]
+  )
 
   const {
     data: stakedPoolBalances = [],

--- a/packages/lib/modules/pool/queries/useUserUnstakedBalance.tsx
+++ b/packages/lib/modules/pool/queries/useUserUnstakedBalance.tsx
@@ -69,9 +69,9 @@ export function useUserUnstakedBalance(pools: Pool[] = []) {
         }
       })
     )
-  }, [isLoading, unstakedPoolBalances, pools, userAddress, isFetching])
+  }, [unstakedPoolBalances, pools, isFetching, priceFor])
 
-  const unstakedBalanceByPoolId = keyBy(balances, 'poolId')
+  const unstakedBalanceByPoolId = useMemo(() => keyBy(balances, 'poolId'), [balances])
 
   return {
     unstakedBalanceByPoolId,

--- a/packages/lib/modules/pool/queries/useUserUnstakedBalance.tsx
+++ b/packages/lib/modules/pool/queries/useUserUnstakedBalance.tsx
@@ -9,6 +9,9 @@ import { BPT_DECIMALS } from '../pool.constants'
 import { useMemo } from 'react'
 import { useTokens } from '../../tokens/TokensProvider'
 
+// All pool versions implement balanceOf, so the same ABI can be reused.
+const balanceOfAbi = parseAbi(['function balanceOf(address account) view returns (uint256)'])
+
 export type UnstakedBalanceByPoolId = ReturnType<
   typeof useUserUnstakedBalance
 >['unstakedBalanceByPoolId']
@@ -16,9 +19,6 @@ export type UnstakedBalanceByPoolId = ReturnType<
 export function useUserUnstakedBalance(pools: Pool[] = []) {
   const { userAddress, isConnected } = useUserAccount()
   const { priceFor } = useTokens()
-
-  // All pool version will implement balanceOf the same ABI function is shared
-  const balanceOfAbi = parseAbi(['function balanceOf(address account) view returns (uint256)'])
 
   const contracts = useMemo(
     () =>

--- a/packages/lib/modules/pool/queries/useUserUnstakedBalance.tsx
+++ b/packages/lib/modules/pool/queries/useUserUnstakedBalance.tsx
@@ -20,6 +20,21 @@ export function useUserUnstakedBalance(pools: Pool[] = []) {
   // All pool version will implement balanceOf the same ABI function is shared
   const balanceOfAbi = parseAbi(['function balanceOf(address account) view returns (uint256)'])
 
+  const contracts = useMemo(
+    () =>
+      pools.map(
+        pool =>
+          ({
+            abi: balanceOfAbi,
+            address: pool.address as Address,
+            functionName: 'balanceOf',
+            args: [userAddress as Address],
+            chainId: getChainId(pool.chain),
+          }) as const
+      ),
+    [pools, userAddress]
+  )
+
   const {
     data: unstakedPoolBalances = [],
     isLoading,
@@ -31,16 +46,7 @@ export function useUserUnstakedBalance(pools: Pool[] = []) {
     query: {
       enabled: isConnected,
     },
-    contracts: pools.map(
-      pool =>
-        ({
-          abi: balanceOfAbi,
-          address: pool.address as Address,
-          functionName: 'balanceOf',
-          args: [userAddress as Address],
-          chainId: getChainId(pool.chain),
-        }) as const
-    ),
+    contracts,
   })
 
   // for each pool get the unstaked balance

--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
@@ -351,26 +351,25 @@ export function ClaimNetworkPools() {
                 </SimpleGrid>
               )
             })()}
-
-            <ClaimProtocolRevenueModal
-              isOpen={isOpenedProtocolRevenueModal}
-              onClose={() => setIsOpenedProtocolRevenueModal(false)}
-            />
-            <ClaimHiddenHandRewardsModal
-              isOpen={isOpenedHiddenHandRewardsModal}
-              onClose={() => setIsOpenedHiddenHandRewardsModal(false)}
-            />
-            <ClaimRecoveredFundsModal
-              isOpen={isClaimRecoveredFundModalOpen}
-              onClose={onClaimRecoveredFundModalClose}
-            />
-            <RecoveredFundsLearnMoreModal
-              isOpen={isRecoveredFundsLearnMoreModalOpen}
-              onClose={onRecoveredFundsLearnMoreModalClose}
-            />
           </>
         )}
       </Stack>
+      <ClaimProtocolRevenueModal
+        isOpen={isOpenedProtocolRevenueModal}
+        onClose={() => setIsOpenedProtocolRevenueModal(false)}
+      />
+      <ClaimHiddenHandRewardsModal
+        isOpen={isOpenedHiddenHandRewardsModal}
+        onClose={() => setIsOpenedHiddenHandRewardsModal(false)}
+      />
+      <ClaimRecoveredFundsModal
+        isOpen={isClaimRecoveredFundModalOpen}
+        onClose={onClaimRecoveredFundModalClose}
+      />
+      <RecoveredFundsLearnMoreModal
+        isOpen={isRecoveredFundsLearnMoreModalOpen}
+        onClose={onRecoveredFundsLearnMoreModalClose}
+      />
     </FadeInOnView>
   )
 }

--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
@@ -235,120 +235,122 @@ export function ClaimNetworkPools() {
                 ))}
               </SimpleGrid>
             )}
-            <SimpleGrid columns={claimGridColumns} spacing="md">
-              {(() => {
-                // Collect all claimable items
-                const claimableItems = []
+            {(() => {
+              // Collect all claimable items
+              const claimableItems = []
 
-                poolsWithChain.forEach(([, pools]) => {
-                  if (pools[0] && totalFiatClaimableBalanceByChain[pools[0].chain].toNumber() > 0) {
-                    claimableItems.push({
-                      type: 'chain',
-                      chain: pools[0].chain,
-                      amount: totalFiatClaimableBalanceByChain[pools[0].chain].toNumber(),
-                    })
-                  }
+              poolsWithChain.forEach(([, pools]) => {
+                if (pools[0] && totalFiatClaimableBalanceByChain[pools[0].chain].toNumber() > 0) {
+                  claimableItems.push({
+                    type: 'chain',
+                    chain: pools[0].chain,
+                    amount: totalFiatClaimableBalanceByChain[pools[0].chain].toNumber(),
+                  })
+                }
+              })
+
+              if (hasProtocolRewards) {
+                claimableItems.push({
+                  type: 'protocol',
+                  chain: GqlChain.Mainnet,
+                  amount: protocolRewardsBalance.toNumber(),
                 })
+              }
 
-                if (hasProtocolRewards) {
-                  claimableItems.push({
-                    type: 'protocol',
-                    chain: GqlChain.Mainnet,
-                    amount: protocolRewardsBalance.toNumber(),
-                  })
-                }
+              if (hasHiddenHandRewards && !isPastJulyFirst) {
+                claimableItems.push({
+                  type: 'hidden-hand',
+                  chain: PROJECT_CONFIG.defaultNetwork,
+                  amount: hiddenHandRewardsData.totalValueUsd,
+                })
+              }
 
-                if (hasHiddenHandRewards && !isPastJulyFirst) {
-                  claimableItems.push({
-                    type: 'hidden-hand',
-                    chain: PROJECT_CONFIG.defaultNetwork,
-                    amount: hiddenHandRewardsData.totalValueUsd,
-                  })
-                }
+              if (isBalancer && hasRecoveredFunds) {
+                claimableItems.push({
+                  type: 'recovered-funds',
+                  chain: PROJECT_CONFIG.defaultNetwork,
+                  amount: sumRecoveredFundsTotal(recoveredFundsClaims),
+                  icon: '/images/icons/heart.svg',
+                })
+              }
 
-                if (isBalancer && hasRecoveredFunds) {
-                  claimableItems.push({
-                    type: 'recovered-funds',
-                    chain: PROJECT_CONFIG.defaultNetwork,
-                    amount: sumRecoveredFundsTotal(recoveredFundsClaims),
-                    icon: '/images/icons/heart.svg',
-                  })
-                }
+              // Sort by amount (highest first)
+              claimableItems.sort((a, b) => b.amount - a.amount)
 
-                // Sort by amount (highest first)
-                claimableItems.sort((a, b) => b.amount - a.amount)
+              // If no claimable items, don't render the grid. An empty grid adds stack gap.
+              if (claimableItems.length === 0) {
+                return null
+              }
 
-                // If no claimable items, don't render anything
-                if (claimableItems.length === 0) {
-                  return null
-                }
-
-                // Render all claimable items
-                const items = claimableItems.map((item, index) => {
-                  const handleClick = () => {
-                    switch (item.type) {
-                      case 'protocol':
-                        setIsOpenedProtocolRevenueModal(true)
-                        break
-                      case 'hidden-hand':
-                        setIsOpenedHiddenHandRewardsModal(true)
-                        break
-                      case 'recovered-funds':
-                        openClaimRecoveredFundModal()
-                        break
-                      default:
-                        router.push(`/portfolio/${chainToSlugMap[item.chain]}`)
-                    }
+              // Render all claimable items
+              const items = claimableItems.map((item, index) => {
+                const handleClick = () => {
+                  switch (item.type) {
+                    case 'protocol':
+                      setIsOpenedProtocolRevenueModal(true)
+                      break
+                    case 'hidden-hand':
+                      setIsOpenedHiddenHandRewardsModal(true)
+                      break
+                    case 'recovered-funds':
+                      openClaimRecoveredFundModal()
+                      break
+                    default:
+                      router.push(`/portfolio/${chainToSlugMap[item.chain]}`)
                   }
+                }
 
-                  return (
-                    <motion.div
-                      animate={{ opacity: 1, scale: 1 }}
-                      initial={{ opacity: 0, scale: 0.95 }}
-                      key={`item-${index}`}
-                      style={{ transformOrigin: 'top' }}
-                      transition={{ duration: 0.3, delay: index * 0.08, ease: easeOut }}
-                    >
-                      <ClaimNetworkBlock
-                        chain={item.chain}
-                        icon={item.icon}
-                        networkTotalClaimableFiatBalance={item.amount}
-                        onClick={handleClick}
-                        title={getCardTitle(item.type)}
-                      />
-                    </motion.div>
+                return (
+                  <motion.div
+                    animate={{ opacity: 1, scale: 1 }}
+                    initial={{ opacity: 0, scale: 0.95 }}
+                    key={`item-${index}`}
+                    style={{ transformOrigin: 'top' }}
+                    transition={{ duration: 0.3, delay: index * 0.08, ease: easeOut }}
+                  >
+                    <ClaimNetworkBlock
+                      chain={item.chain}
+                      icon={item.icon}
+                      networkTotalClaimableFiatBalance={item.amount}
+                      onClick={handleClick}
+                      title={getCardTitle(item.type)}
+                    />
+                  </motion.div>
+                )
+              })
+
+              // Add placeholders only if we have fewer items than max columns
+              if (claimableItems.length < networkSlotCount) {
+                const placeholdersNeeded = networkSlotCount - claimableItems.length
+
+                for (let i = 0; i < placeholdersNeeded; i++) {
+                  const slotIndex = claimableItems.length + i
+
+                  const displayProps =
+                    slotIndex === 2
+                      ? { base: 'none', md: 'none', lg: 'block' }
+                      : { base: 'none', md: 'block' }
+
+                  items.push(
+                    <Card
+                      display={displayProps}
+                      flex="1"
+                      key={`placeholder-${i}`}
+                      p={['sm', 'md']}
+                      shadow="innerLg"
+                      variant="level1"
+                      w="full"
+                    />
                   )
-                })
-
-                // Add placeholders only if we have fewer items than max columns
-                if (claimableItems.length < networkSlotCount) {
-                  const placeholdersNeeded = networkSlotCount - claimableItems.length
-
-                  for (let i = 0; i < placeholdersNeeded; i++) {
-                    const slotIndex = claimableItems.length + i
-
-                    const displayProps =
-                      slotIndex === 2
-                        ? { base: 'none', md: 'none', lg: 'block' }
-                        : { base: 'none', md: 'block' }
-
-                    items.push(
-                      <Card
-                        display={displayProps}
-                        flex="1"
-                        key={`placeholder-${i}`}
-                        p={['sm', 'md']}
-                        shadow="innerLg"
-                        variant="level1"
-                        w="full"
-                      />
-                    )
-                  }
                 }
+              }
 
-                return items
-              })()}
-            </SimpleGrid>
+              return (
+                <SimpleGrid columns={claimGridColumns} spacing="md">
+                  {items}
+                </SimpleGrid>
+              )
+            })()}
 
             <ClaimProtocolRevenueModal
               isOpen={isOpenedProtocolRevenueModal}

--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
@@ -67,6 +67,9 @@ const beetsNetworksConfig: NetworkConfig[] = [
   { chain: GqlChain.Sonic, name: 'Sonic', displayProps: {} },
 ]
 
+const SLOT_COUNT = 3
+const GRID_COLUMNS = { base: 1, md: 2, lg: 3 }
+
 export function ClaimNetworkPools() {
   const {
     poolsByChainMap,
@@ -181,9 +184,6 @@ export function ClaimNetworkPools() {
     recoveredFundsClaims,
   ])
 
-  const slotCount = 3
-  const gridColumns = { base: 1, md: 2, lg: 3 }
-
   return (
     <FadeInOnView>
       <Stack gap={5}>
@@ -218,15 +218,15 @@ export function ClaimNetworkPools() {
           </AnimatedAlert>
         )}
         {isLoadingRewards || isLoadingPortfolio ? (
-          <SimpleGrid columns={gridColumns} spacing="md">
-            {Array.from({ length: slotCount }).map((_, index) => (
+          <SimpleGrid columns={GRID_COLUMNS} spacing="md">
+            {Array.from({ length: SLOT_COUNT }).map((_, index) => (
               <Skeleton height="85px" key={`claim-network-skeleton-${index}`} w="full" />
             ))}
           </SimpleGrid>
         ) : !isConnected ? (
           <ConnectButton.Custom>
             {({ openConnectModal }: { openConnectModal: () => void }) => (
-              <SimpleGrid columns={gridColumns} spacing="md">
+              <SimpleGrid columns={GRID_COLUMNS} spacing="md">
                 {currentNetworks.map(network => (
                   <Card
                     flex="1"
@@ -267,7 +267,7 @@ export function ClaimNetworkPools() {
               </AnimatedAlert>
             )}
             {noRewards && (
-              <SimpleGrid columns={gridColumns} spacing="md">
+              <SimpleGrid columns={GRID_COLUMNS} spacing="md">
                 {currentNetworks.map(network => (
                   <Card
                     flex="1"
@@ -296,7 +296,7 @@ export function ClaimNetworkPools() {
               </SimpleGrid>
             )}
             {claimableItems.length > 0 && (
-              <SimpleGrid columns={gridColumns} spacing="md">
+              <SimpleGrid columns={GRID_COLUMNS} spacing="md">
                 {claimableItems.map((item, index) => {
                   const handleClick = () => {
                     switch (item.type) {
@@ -332,8 +332,8 @@ export function ClaimNetworkPools() {
                     </motion.div>
                   )
                 })}
-                {claimableItems.length < slotCount &&
-                  Array.from({ length: slotCount - claimableItems.length }).map((_, i) => {
+                {claimableItems.length < SLOT_COUNT &&
+                  Array.from({ length: SLOT_COUNT - claimableItems.length }).map((_, i) => {
                     const slotIndex = claimableItems.length + i
 
                     const displayProps =

--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
@@ -64,11 +64,6 @@ const balancerNetworksConfig: NetworkConfig[] = [
 
 const beetsNetworksConfig: NetworkConfig[] = [
   { chain: GqlChain.Sonic, name: 'Sonic', displayProps: {} },
-  {
-    chain: GqlChain.Optimism,
-    name: 'Optimism',
-    displayProps: { display: { base: 'none', md: 'block' } },
-  },
 ]
 
 export function ClaimNetworkPools() {
@@ -109,6 +104,14 @@ export function ClaimNetworkPools() {
   const iconSize = isDesktop ? 12 : 8
 
   const currentNetworks = isBeets ? beetsNetworksConfig : balancerNetworksConfig
+  const networkSlotCount = currentNetworks.length
+  const claimGridColumns = { base: 1, md: Math.min(networkSlotCount, 2), lg: networkSlotCount }
+  const loadingGridColumns = {
+    base: 1,
+    md: 1,
+    lg: Math.min(networkSlotCount, 2),
+    xl: networkSlotCount,
+  }
 
   const poolsWithChain = Object.entries(poolsByChainMap).sort(
     ([a], [b]) =>
@@ -159,22 +162,15 @@ export function ClaimNetworkPools() {
         {deprecatedChains.length > 0 && <DeprecatedChainsAlert chains={deprecatedChains} />}
 
         {isLoadingRewards || isLoadingPortfolio ? (
-          <SimpleGrid columns={{ base: 1, md: 1, lg: 2, xl: isBeets ? 2 : 3 }} spacing="md">
-            <Skeleton height="85px" w="full" />
-            <Skeleton height="85px" w="full" />
-            {!isBeets && <Skeleton height="85px" w="full" />}
+          <SimpleGrid columns={loadingGridColumns} spacing="md">
+            {Array.from({ length: networkSlotCount }).map((_, index) => (
+              <Skeleton height="85px" key={`claim-network-skeleton-${index}`} w="full" />
+            ))}
           </SimpleGrid>
         ) : !isConnected ? (
           <ConnectButton.Custom>
             {({ openConnectModal }: { openConnectModal: () => void }) => (
-              <SimpleGrid
-                columns={{
-                  base: 1,
-                  md: 2,
-                  lg: isBeets ? 2 : 3,
-                }}
-                spacing="md"
-              >
+              <SimpleGrid columns={claimGridColumns} spacing="md">
                 {currentNetworks.map(network => (
                   <Card
                     flex="1"
@@ -211,14 +207,7 @@ export function ClaimNetworkPools() {
           <>
             {hasMerklRewards && <MerklAlert />}
             {noRewards && (
-              <SimpleGrid
-                columns={{
-                  base: 1,
-                  md: 2,
-                  lg: isBeets ? 2 : 3,
-                }}
-                spacing="md"
-              >
+              <SimpleGrid columns={claimGridColumns} spacing="md">
                 {currentNetworks.map(network => (
                   <Card
                     flex="1"
@@ -246,14 +235,7 @@ export function ClaimNetworkPools() {
                 ))}
               </SimpleGrid>
             )}
-            <SimpleGrid
-              columns={{
-                base: 1,
-                md: 2,
-                lg: isBeets ? 2 : 3,
-              }}
-              spacing="md"
-            >
+            <SimpleGrid columns={claimGridColumns} spacing="md">
               {(() => {
                 // Collect all claimable items
                 const claimableItems = []
@@ -301,9 +283,6 @@ export function ClaimNetworkPools() {
                   return null
                 }
 
-                // Determine max columns for first row based on breakpoint
-                const maxColumns = isBeets ? 2 : 3
-
                 // Render all claimable items
                 const items = claimableItems.map((item, index) => {
                   const handleClick = () => {
@@ -342,16 +321,14 @@ export function ClaimNetworkPools() {
                 })
 
                 // Add placeholders only if we have fewer items than max columns
-                if (claimableItems.length < maxColumns) {
-                  const placeholdersNeeded = maxColumns - claimableItems.length
+                if (claimableItems.length < networkSlotCount) {
+                  const placeholdersNeeded = networkSlotCount - claimableItems.length
 
                   for (let i = 0; i < placeholdersNeeded; i++) {
                     const slotIndex = claimableItems.length + i
 
-                    // For !isBeets: slot 0-1 show on md+, slot 2 shows only on lg+
-                    // For isBeets: slots 0-1 show on md+
                     const displayProps =
-                      !isBeets && slotIndex === 2
+                      slotIndex === 2
                         ? { base: 'none', md: 'none', lg: 'block' }
                         : { base: 'none', md: 'block' }
 

--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
@@ -104,14 +104,6 @@ export function ClaimNetworkPools() {
   const iconSize = isDesktop ? 12 : 8
 
   const currentNetworks = isBeets ? beetsNetworksConfig : balancerNetworksConfig
-  const networkSlotCount = currentNetworks.length
-  const claimGridColumns = { base: 1, md: Math.min(networkSlotCount, 2), lg: networkSlotCount }
-  const loadingGridColumns = {
-    base: 1,
-    md: 1,
-    lg: Math.min(networkSlotCount, 2),
-    xl: networkSlotCount,
-  }
 
   const poolsWithChain = Object.entries(poolsByChainMap).sort(
     ([a], [b]) =>
@@ -131,6 +123,58 @@ export function ClaimNetworkPools() {
   const deprecatedChains = poolsWithChain
     .map(item => item[0])
     .filter(chain => isChainDeprecated(chain as GqlChain)) as GqlChain[]
+
+  // Build claimable items
+  const claimableItems = []
+
+  poolsWithChain.forEach(([, pools]) => {
+    if (pools[0] && totalFiatClaimableBalanceByChain[pools[0].chain].toNumber() > 0) {
+      claimableItems.push({
+        type: 'chain',
+        chain: pools[0].chain,
+        amount: totalFiatClaimableBalanceByChain[pools[0].chain].toNumber(),
+      })
+    }
+  })
+
+  if (hasProtocolRewards) {
+    claimableItems.push({
+      type: 'protocol',
+      chain: GqlChain.Mainnet,
+      amount: protocolRewardsBalance.toNumber(),
+    })
+  }
+
+  if (hasHiddenHandRewards && !isPastJulyFirst) {
+    claimableItems.push({
+      type: 'hidden-hand',
+      chain: PROJECT_CONFIG.defaultNetwork,
+      amount: hiddenHandRewardsData.totalValueUsd,
+    })
+  }
+
+  if (isBalancer && hasRecoveredFunds) {
+    claimableItems.push({
+      type: 'recovered-funds',
+      chain: PROJECT_CONFIG.defaultNetwork,
+      amount: sumRecoveredFundsTotal(recoveredFundsClaims),
+      icon: '/images/icons/heart.svg',
+    })
+  }
+
+  // Sort by amount (highest first)
+  claimableItems.sort((a, b) => b.amount - a.amount)
+
+  const networkSlotCount =
+    claimableItems.length > 0 ? claimableItems.length : currentNetworks.length
+  const loadingSlotCount = isBeets ? 2 : 3
+  const claimGridColumns = { base: 1, md: Math.min(networkSlotCount, 2), lg: networkSlotCount }
+  const loadingGridColumns = {
+    base: 1,
+    md: 1,
+    lg: Math.min(loadingSlotCount, 2),
+    xl: loadingSlotCount,
+  }
 
   return (
     <FadeInOnView>
@@ -163,7 +207,7 @@ export function ClaimNetworkPools() {
 
         {isLoadingRewards || isLoadingPortfolio ? (
           <SimpleGrid columns={loadingGridColumns} spacing="md">
-            {Array.from({ length: networkSlotCount }).map((_, index) => (
+            {Array.from({ length: loadingSlotCount }).map((_, index) => (
               <Skeleton height="85px" key={`claim-network-skeleton-${index}`} w="full" />
             ))}
           </SimpleGrid>
@@ -235,122 +279,45 @@ export function ClaimNetworkPools() {
                 ))}
               </SimpleGrid>
             )}
-            {(() => {
-              // Collect all claimable items
-              const claimableItems = []
-
-              poolsWithChain.forEach(([, pools]) => {
-                if (pools[0] && totalFiatClaimableBalanceByChain[pools[0].chain].toNumber() > 0) {
-                  claimableItems.push({
-                    type: 'chain',
-                    chain: pools[0].chain,
-                    amount: totalFiatClaimableBalanceByChain[pools[0].chain].toNumber(),
-                  })
-                }
-              })
-
-              if (hasProtocolRewards) {
-                claimableItems.push({
-                  type: 'protocol',
-                  chain: GqlChain.Mainnet,
-                  amount: protocolRewardsBalance.toNumber(),
-                })
-              }
-
-              if (hasHiddenHandRewards && !isPastJulyFirst) {
-                claimableItems.push({
-                  type: 'hidden-hand',
-                  chain: PROJECT_CONFIG.defaultNetwork,
-                  amount: hiddenHandRewardsData.totalValueUsd,
-                })
-              }
-
-              if (isBalancer && hasRecoveredFunds) {
-                claimableItems.push({
-                  type: 'recovered-funds',
-                  chain: PROJECT_CONFIG.defaultNetwork,
-                  amount: sumRecoveredFundsTotal(recoveredFundsClaims),
-                  icon: '/images/icons/heart.svg',
-                })
-              }
-
-              // Sort by amount (highest first)
-              claimableItems.sort((a, b) => b.amount - a.amount)
-
-              // If no claimable items, don't render the grid. An empty grid adds stack gap.
-              if (claimableItems.length === 0) {
-                return null
-              }
-
-              // Render all claimable items
-              const items = claimableItems.map((item, index) => {
-                const handleClick = () => {
-                  switch (item.type) {
-                    case 'protocol':
-                      setIsOpenedProtocolRevenueModal(true)
-                      break
-                    case 'hidden-hand':
-                      setIsOpenedHiddenHandRewardsModal(true)
-                      break
-                    case 'recovered-funds':
-                      openClaimRecoveredFundModal()
-                      break
-                    default:
-                      router.push(`/portfolio/${chainToSlugMap[item.chain]}`)
+            {claimableItems.length > 0 && (
+              <SimpleGrid columns={claimGridColumns} spacing="md">
+                {claimableItems.map((item, index) => {
+                  const handleClick = () => {
+                    switch (item.type) {
+                      case 'protocol':
+                        setIsOpenedProtocolRevenueModal(true)
+                        break
+                      case 'hidden-hand':
+                        setIsOpenedHiddenHandRewardsModal(true)
+                        break
+                      case 'recovered-funds':
+                        openClaimRecoveredFundModal()
+                        break
+                      default:
+                        router.push(`/portfolio/${chainToSlugMap[item.chain]}`)
+                    }
                   }
-                }
 
-                return (
-                  <motion.div
-                    animate={{ opacity: 1, scale: 1 }}
-                    initial={{ opacity: 0, scale: 0.95 }}
-                    key={`item-${index}`}
-                    style={{ transformOrigin: 'top' }}
-                    transition={{ duration: 0.3, delay: index * 0.08, ease: easeOut }}
-                  >
-                    <ClaimNetworkBlock
-                      chain={item.chain}
-                      icon={item.icon}
-                      networkTotalClaimableFiatBalance={item.amount}
-                      onClick={handleClick}
-                      title={getCardTitle(item.type)}
-                    />
-                  </motion.div>
-                )
-              })
-
-              // Add placeholders only if we have fewer items than max columns
-              if (claimableItems.length < networkSlotCount) {
-                const placeholdersNeeded = networkSlotCount - claimableItems.length
-
-                for (let i = 0; i < placeholdersNeeded; i++) {
-                  const slotIndex = claimableItems.length + i
-
-                  const displayProps =
-                    slotIndex === 2
-                      ? { base: 'none', md: 'none', lg: 'block' }
-                      : { base: 'none', md: 'block' }
-
-                  items.push(
-                    <Card
-                      display={displayProps}
-                      flex="1"
-                      key={`placeholder-${i}`}
-                      p={['sm', 'md']}
-                      shadow="innerLg"
-                      variant="level1"
-                      w="full"
-                    />
+                  return (
+                    <motion.div
+                      animate={{ opacity: 1, scale: 1 }}
+                      initial={{ opacity: 0, scale: 0.95 }}
+                      key={`item-${index}`}
+                      style={{ transformOrigin: 'top' }}
+                      transition={{ duration: 0.3, delay: index * 0.08, ease: easeOut }}
+                    >
+                      <ClaimNetworkBlock
+                        chain={item.chain}
+                        icon={item.icon}
+                        networkTotalClaimableFiatBalance={item.amount}
+                        onClick={handleClick}
+                        title={getCardTitle(item.type)}
+                      />
+                    </motion.div>
                   )
-                }
-              }
-
-              return (
-                <SimpleGrid columns={claimGridColumns} spacing="md">
-                  {items}
-                </SimpleGrid>
-              )
-            })()}
+                })}
+              </SimpleGrid>
+            )}
           </>
         )}
       </Stack>

--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   useDisclosure,
   Link,
+  Box,
 } from '@chakra-ui/react'
 import { usePortfolio } from '../../PortfolioProvider'
 import { ClaimNetworkBlock } from './ClaimNetworkBlock'
@@ -81,16 +82,19 @@ export function ClaimNetworkPools() {
 
   const [isOpenedProtocolRevenueModal, setIsOpenedProtocolRevenueModal] = useState(false)
   const [isOpenedHiddenHandRewardsModal, setIsOpenedHiddenHandRewardsModal] = useState(false)
+
   const {
     isOpen: isClaimRecoveredFundModalOpen,
     onOpen: openClaimRecoveredFundModal,
     onClose: onClaimRecoveredFundModalClose,
   } = useDisclosure()
+
   const {
     isOpen: isRecoveredFundsLearnMoreModalOpen,
     onOpen: openRecoveredFundsLearnMoreModal,
     onClose: onRecoveredFundsLearnMoreModalClose,
   } = useDisclosure()
+
   const { isConnected } = useUserAccount()
   const router = useRouter()
 
@@ -165,16 +169,8 @@ export function ClaimNetworkPools() {
   // Sort by amount (highest first)
   claimableItems.sort((a, b) => b.amount - a.amount)
 
-  const networkSlotCount =
-    claimableItems.length > 0 ? claimableItems.length : currentNetworks.length
-  const loadingSlotCount = isBeets ? 2 : 3
-  const claimGridColumns = { base: 1, md: Math.min(networkSlotCount, 2), lg: networkSlotCount }
-  const loadingGridColumns = {
-    base: 1,
-    md: 1,
-    lg: Math.min(loadingSlotCount, 2),
-    xl: loadingSlotCount,
-  }
+  const slotCount = 3
+  const gridColumns = { base: 1, md: 2, lg: 3 }
 
   return (
     <FadeInOnView>
@@ -182,14 +178,12 @@ export function ClaimNetworkPools() {
         <Heading size="h4" variant="special">
           Claimable incentives
         </Heading>
-
         {hasHiddenHandRewards && !isPastJulyFirst && (
           <BalAlert
             content="Your Hidden Hand rewards are expiring soon. Hidden Hand has been shutdown. Claim your incentives before they permanently expire after June 30, 2026 (23:59 UTC)."
             status="warning"
           />
         )}
-
         {isBalancer && hasRecoveredFunds && (
           <BalAlert
             content={
@@ -202,19 +196,17 @@ export function ClaimNetworkPools() {
             status="warning"
           />
         )}
-
         {deprecatedChains.length > 0 && <DeprecatedChainsAlert chains={deprecatedChains} />}
-
         {isLoadingRewards || isLoadingPortfolio ? (
-          <SimpleGrid columns={loadingGridColumns} spacing="md">
-            {Array.from({ length: loadingSlotCount }).map((_, index) => (
+          <SimpleGrid columns={gridColumns} spacing="md">
+            {Array.from({ length: slotCount }).map((_, index) => (
               <Skeleton height="85px" key={`claim-network-skeleton-${index}`} w="full" />
             ))}
           </SimpleGrid>
         ) : !isConnected ? (
           <ConnectButton.Custom>
             {({ openConnectModal }: { openConnectModal: () => void }) => (
-              <SimpleGrid columns={claimGridColumns} spacing="md">
+              <SimpleGrid columns={gridColumns} spacing="md">
                 {currentNetworks.map(network => (
                   <Card
                     flex="1"
@@ -251,7 +243,7 @@ export function ClaimNetworkPools() {
           <>
             {hasMerklRewards && <MerklAlert />}
             {noRewards && (
-              <SimpleGrid columns={claimGridColumns} spacing="md">
+              <SimpleGrid columns={gridColumns} spacing="md">
                 {currentNetworks.map(network => (
                   <Card
                     flex="1"
@@ -280,7 +272,7 @@ export function ClaimNetworkPools() {
               </SimpleGrid>
             )}
             {claimableItems.length > 0 && (
-              <SimpleGrid columns={claimGridColumns} spacing="md">
+              <SimpleGrid columns={gridColumns} spacing="md">
                 {claimableItems.map((item, index) => {
                   const handleClick = () => {
                     switch (item.type) {
@@ -316,6 +308,17 @@ export function ClaimNetworkPools() {
                     </motion.div>
                   )
                 })}
+                {claimableItems.length < slotCount &&
+                  Array.from({ length: slotCount - claimableItems.length }).map((_, i) => {
+                    const slotIndex = claimableItems.length + i
+
+                    const displayProps =
+                      slotIndex === 2
+                        ? { base: 'none', md: 'none', lg: 'block' }
+                        : { base: 'none', md: 'block' }
+
+                    return <Box display={displayProps} key={`placeholder-${i}`} />
+                  })}
               </SimpleGrid>
             )}
           </>

--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
@@ -179,24 +179,32 @@ export function ClaimNetworkPools() {
           Claimable incentives
         </Heading>
         {hasHiddenHandRewards && !isPastJulyFirst && (
-          <BalAlert
-            content="Your Hidden Hand rewards are expiring soon. Hidden Hand has been shutdown. Claim your incentives before they permanently expire after June 30, 2026 (23:59 UTC)."
-            status="warning"
-          />
+          <AnimatedAlert>
+            <BalAlert
+              content="Your Hidden Hand rewards are expiring soon. Hidden Hand has been shutdown. Claim your incentives before they permanently expire after June 30, 2026 (23:59 UTC)."
+              status="warning"
+            />
+          </AnimatedAlert>
         )}
         {isBalancer && hasRecoveredFunds && (
-          <BalAlert
-            content={
-              <Text color="font.dark" fontWeight="medium">
-                Claim your share of recovered funds from the November 2025 security incident
-                affecting some v2 Composable Stable pools.{' '}
-                <BalAlertLink onClick={openRecoveredFundsLearnMoreModal}>Learn more</BalAlertLink>
-              </Text>
-            }
-            status="warning"
-          />
+          <AnimatedAlert>
+            <BalAlert
+              content={
+                <Text color="font.dark" fontWeight="medium">
+                  Claim your share of recovered funds from the November 2025 security incident
+                  affecting some v2 Composable Stable pools.{' '}
+                  <BalAlertLink onClick={openRecoveredFundsLearnMoreModal}>Learn more</BalAlertLink>
+                </Text>
+              }
+              status="warning"
+            />
+          </AnimatedAlert>
         )}
-        {deprecatedChains.length > 0 && <DeprecatedChainsAlert chains={deprecatedChains} />}
+        {deprecatedChains.length > 0 && (
+          <AnimatedAlert>
+            <DeprecatedChainsAlert chains={deprecatedChains} />
+          </AnimatedAlert>
+        )}
         {isLoadingRewards || isLoadingPortfolio ? (
           <SimpleGrid columns={gridColumns} spacing="md">
             {Array.from({ length: slotCount }).map((_, index) => (
@@ -241,7 +249,11 @@ export function ClaimNetworkPools() {
           </ConnectButton.Custom>
         ) : (
           <>
-            {hasMerklRewards && <MerklAlert />}
+            {hasMerklRewards && (
+              <AnimatedAlert>
+                <MerklAlert />
+              </AnimatedAlert>
+            )}
             {noRewards && (
               <SimpleGrid columns={gridColumns} spacing="md">
                 {currentNetworks.map(network => (
@@ -341,6 +353,14 @@ export function ClaimNetworkPools() {
         onClose={onRecoveredFundsLearnMoreModalClose}
       />
     </FadeInOnView>
+  )
+}
+
+function AnimatedAlert({ children }: { children: React.ReactNode }) {
+  return (
+    <motion.div animate={{ opacity: 1, height: 'auto' }} initial={{ opacity: 0, height: 0 }} layout>
+      {children}
+    </motion.div>
   )
 }
 

--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
@@ -19,7 +19,7 @@ import { ClaimNetworkBlock } from './ClaimNetworkBlock'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { chainToSlugMap } from '../../../pool/pool.utils'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
-import { useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import ClaimProtocolRevenueModal from '../ClaimProtocolRevenueModal'
 import ClaimHiddenHandRewardsModal from '../ClaimHiddenHandRewardsModal'
 import { useRouter } from 'next/navigation'
@@ -129,45 +129,57 @@ export function ClaimNetworkPools() {
     .filter(chain => isChainDeprecated(chain as GqlChain)) as GqlChain[]
 
   // Build claimable items
-  const claimableItems = []
+  const claimableItems = useMemo(() => {
+    const items = []
 
-  poolsWithChain.forEach(([, pools]) => {
-    if (pools[0] && totalFiatClaimableBalanceByChain[pools[0].chain].toNumber() > 0) {
-      claimableItems.push({
-        type: 'chain',
-        chain: pools[0].chain,
-        amount: totalFiatClaimableBalanceByChain[pools[0].chain].toNumber(),
+    poolsWithChain.forEach(([, pools]) => {
+      if (pools[0] && totalFiatClaimableBalanceByChain[pools[0].chain].toNumber() > 0) {
+        items.push({
+          type: 'chain',
+          chain: pools[0].chain,
+          amount: totalFiatClaimableBalanceByChain[pools[0].chain].toNumber(),
+        })
+      }
+    })
+
+    if (hasProtocolRewards) {
+      items.push({
+        type: 'protocol',
+        chain: GqlChain.Mainnet,
+        amount: protocolRewardsBalance.toNumber(),
       })
     }
-  })
 
-  if (hasProtocolRewards) {
-    claimableItems.push({
-      type: 'protocol',
-      chain: GqlChain.Mainnet,
-      amount: protocolRewardsBalance.toNumber(),
-    })
-  }
+    if (hasHiddenHandRewards && !isPastJulyFirst) {
+      items.push({
+        type: 'hidden-hand',
+        chain: PROJECT_CONFIG.defaultNetwork,
+        amount: hiddenHandRewardsData.totalValueUsd,
+      })
+    }
 
-  if (hasHiddenHandRewards && !isPastJulyFirst) {
-    claimableItems.push({
-      type: 'hidden-hand',
-      chain: PROJECT_CONFIG.defaultNetwork,
-      amount: hiddenHandRewardsData.totalValueUsd,
-    })
-  }
+    if (isBalancer && hasRecoveredFunds) {
+      items.push({
+        type: 'recovered-funds',
+        chain: PROJECT_CONFIG.defaultNetwork,
+        amount: sumRecoveredFundsTotal(recoveredFundsClaims),
+        icon: '/images/icons/heart.svg',
+      })
+    }
 
-  if (isBalancer && hasRecoveredFunds) {
-    claimableItems.push({
-      type: 'recovered-funds',
-      chain: PROJECT_CONFIG.defaultNetwork,
-      amount: sumRecoveredFundsTotal(recoveredFundsClaims),
-      icon: '/images/icons/heart.svg',
-    })
-  }
-
-  // Sort by amount (highest first)
-  claimableItems.sort((a, b) => b.amount - a.amount)
+    // Sort by amount (highest first)
+    return items.sort((a, b) => b.amount - a.amount)
+  }, [
+    poolsWithChain,
+    totalFiatClaimableBalanceByChain,
+    hasProtocolRewards,
+    protocolRewardsBalance,
+    hasHiddenHandRewards,
+    isPastJulyFirst,
+    hiddenHandRewardsData,
+    hasRecoveredFunds,
+    recoveredFundsClaims,
+  ])
 
   const slotCount = 3
   const gridColumns = { base: 1, md: 2, lg: 3 }
@@ -329,7 +341,7 @@ export function ClaimNetworkPools() {
                         ? { base: 'none', md: 'none', lg: 'block' }
                         : { base: 'none', md: 'block' }
 
-                    return <Box display={displayProps} key={`placeholder-${i}`} />
+                    return <Box aria-hidden display={displayProps} key={`placeholder-${i}`} />
                   })}
               </SimpleGrid>
             )}
@@ -356,7 +368,7 @@ export function ClaimNetworkPools() {
   )
 }
 
-function AnimatedAlert({ children }: { children: React.ReactNode }) {
+function AnimatedAlert({ children }: { children: ReactNode }) {
   return (
     <motion.div animate={{ opacity: 1, height: 'auto' }} initial={{ opacity: 0, height: 0 }} layout>
       {children}

--- a/packages/lib/modules/portfolio/PortfolioProvider.tsx
+++ b/packages/lib/modules/portfolio/PortfolioProvider.tsx
@@ -79,9 +79,9 @@ export function usePortfolioLogic() {
     skip: !isConnected || idIn.length === 0,
   })
 
-  const poolsData = uniqBy(
-    [...(poolsUserAddressData?.pools || []), ...(poolsIdData?.pools || [])],
-    'id'
+  const poolsData = useMemo(
+    () => uniqBy([...(poolsUserAddressData?.pools || []), ...(poolsIdData?.pools || [])], 'id'),
+    [poolsUserAddressData?.pools, poolsIdData?.pools]
   )
 
   const { data: poolsWithOnchainUserBalances, isLoading: isLoadingOnchainUserBalances } =

--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
@@ -227,7 +227,7 @@ const PortfolioTableLoadingGate = memo(function PortfolioTableLoadingGate({
 }) {
   const { isLoadingPortfolio } = usePortfolio()
 
-  if (isLoadingPortfolio && sortedPools.length === 0) {
+  if (isLoadingPortfolio) {
     return (
       <>
         <PortfolioTableHeader

--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
@@ -33,6 +33,7 @@ import { getChainId } from '@repo/lib/config/app.config'
 import { MigrationAlert } from '../../pool/migrations/MigrationAlert'
 import { isChainDeprecated } from '../../chains/chain.utils'
 import { BalAlert } from '@repo/lib/shared/components/alerts/BalAlert'
+import { memo } from 'react'
 
 const rowProps = (needsLastColumnWider: boolean) => ({
   px: [0, 4],
@@ -42,7 +43,6 @@ const rowProps = (needsLastColumnWider: boolean) => ({
 })
 
 export function PortfolioTable() {
-  const { isLoadingPortfolio } = usePortfolio()
   const { isConnected } = useUserAccount()
   const isFilterVisible = usePortfolioFilterTagsVisible()
   const isMd = useBreakpointValue({ base: false, md: true })
@@ -164,49 +164,12 @@ export function PortfolioTable() {
             w={{ base: '100vw', lg: 'full' }}
           >
             <Box minW="max-content" w="full">
-              {isLoadingPortfolio ? (
-                <>
-                  <PortfolioTableHeader
-                    currentSortingObj={currentSortingObj}
-                    setCurrentSortingObj={setSorting}
-                    {...rowProps(hasStakingBoost)}
-                  />
-                  <Divider />
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <Box key={`skeleton-${i}`} px="xs" py="xs" w="full">
-                      <Skeleton height="68px" w="full" />
-                    </Box>
-                  ))}
-                </>
-              ) : (
-                <PaginatedTable
-                  alignItems="flex-start"
-                  getRowId={row => row.uniqueKey}
-                  items={sortedPools}
-                  left={{ base: '-4px', sm: '0' }}
-                  loading={false}
-                  noItemsFoundLabel="You have no current positions"
-                  paginationProps={undefined}
-                  position="relative"
-                  renderTableHeader={() => (
-                    <PortfolioTableHeader
-                      currentSortingObj={currentSortingObj}
-                      setCurrentSortingObj={setSorting}
-                      {...rowProps(hasStakingBoost)}
-                    />
-                  )}
-                  renderTableRow={({ item }) => {
-                    return (
-                      <PortfolioTableRow
-                        keyValue={item.id}
-                        pool={item}
-                        {...rowProps(hasStakingBoost)}
-                      />
-                    )
-                  }}
-                  showPagination={false}
-                />
-              )}
+              <PortfolioTableLoadingGate
+                currentSortingObj={currentSortingObj}
+                hasStakingBoost={hasStakingBoost}
+                setSorting={setSorting}
+                sortedPools={sortedPools}
+              />
             </Box>
           </Card>
         ) : (
@@ -249,3 +212,80 @@ export function PortfolioTable() {
     </FadeInOnView>
   )
 }
+
+const PortfolioTableLoadingGate = memo(function PortfolioTableLoadingGate({
+  currentSortingObj,
+  hasStakingBoost,
+  setSorting,
+  sortedPools,
+}: {
+  currentSortingObj: ReturnType<typeof usePortfolioSorting>['currentSortingObj']
+  hasStakingBoost: boolean
+  setSorting: ReturnType<typeof usePortfolioSorting>['setSorting']
+  sortedPools: ReturnType<typeof usePortfolioSorting>['sortedPools']
+}) {
+  const { isLoadingPortfolio } = usePortfolio()
+
+  if (isLoadingPortfolio) {
+    return (
+      <>
+        <PortfolioTableHeader
+          currentSortingObj={currentSortingObj}
+          setCurrentSortingObj={setSorting}
+          {...rowProps(hasStakingBoost)}
+        />
+        <Divider />
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Box key={`skeleton-${i}`} px="xs" py="xs" w="full">
+            <Skeleton height="68px" w="full" />
+          </Box>
+        ))}
+      </>
+    )
+  }
+
+  return (
+    <LoadedPortfolioTableContent
+      currentSortingObj={currentSortingObj}
+      hasStakingBoost={hasStakingBoost}
+      setSorting={setSorting}
+      sortedPools={sortedPools}
+    />
+  )
+})
+
+const LoadedPortfolioTableContent = memo(function LoadedPortfolioTableContent({
+  currentSortingObj,
+  hasStakingBoost,
+  setSorting,
+  sortedPools,
+}: {
+  currentSortingObj: ReturnType<typeof usePortfolioSorting>['currentSortingObj']
+  hasStakingBoost: boolean
+  setSorting: ReturnType<typeof usePortfolioSorting>['setSorting']
+  sortedPools: ReturnType<typeof usePortfolioSorting>['sortedPools']
+}) {
+  return (
+    <PaginatedTable
+      alignItems="flex-start"
+      getRowId={row => row.uniqueKey}
+      items={sortedPools}
+      left={{ base: '-4px', sm: '0' }}
+      loading={false}
+      noItemsFoundLabel="You have no current positions"
+      paginationProps={undefined}
+      position="relative"
+      renderTableHeader={() => (
+        <PortfolioTableHeader
+          currentSortingObj={currentSortingObj}
+          setCurrentSortingObj={setSorting}
+          {...rowProps(hasStakingBoost)}
+        />
+      )}
+      renderTableRow={({ item }) => {
+        return <PortfolioTableRow keyValue={item.id} pool={item} {...rowProps(hasStakingBoost)} />
+      }}
+      showPagination={false}
+    />
+  )
+})

--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
@@ -84,7 +84,7 @@ export function PortfolioTable() {
         .sort(
           (a, b) => (b.userBalance?.totalBalanceUsd || 0) - (a.userBalance?.totalBalanceUsd || 0)
         )
-        .filter((item, pos, ary) => !pos || item.id != ary[pos - 1].id), // deduplication
+        .filter((item, pos, ary) => !pos || item.id !== ary[pos - 1].id), // deduplication
     [sortedPools, needsMigration]
   )
 

--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
@@ -10,6 +10,7 @@ import {
   Divider,
   Heading,
   HStack,
+  Skeleton,
   Stack,
   Text,
   useBreakpointValue,
@@ -163,33 +164,49 @@ export function PortfolioTable() {
             w={{ base: '100vw', lg: 'full' }}
           >
             <Box minW="max-content" w="full">
-              <PaginatedTable
-                alignItems="flex-start"
-                getRowId={row => row.uniqueKey}
-                items={sortedPools}
-                left={{ base: '-4px', sm: '0' }}
-                loading={isLoadingPortfolio}
-                noItemsFoundLabel="You have no current positions"
-                paginationProps={undefined}
-                position="relative"
-                renderTableHeader={() => (
+              {isLoadingPortfolio ? (
+                <>
                   <PortfolioTableHeader
                     currentSortingObj={currentSortingObj}
                     setCurrentSortingObj={setSorting}
                     {...rowProps(hasStakingBoost)}
                   />
-                )}
-                renderTableRow={({ item }) => {
-                  return (
-                    <PortfolioTableRow
-                      keyValue={item.id}
-                      pool={item}
+                  <Divider />
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Box key={`skeleton-${i}`} px="xs" py="xs" w="full">
+                      <Skeleton height="68px" w="full" />
+                    </Box>
+                  ))}
+                </>
+              ) : (
+                <PaginatedTable
+                  alignItems="flex-start"
+                  getRowId={row => row.uniqueKey}
+                  items={sortedPools}
+                  left={{ base: '-4px', sm: '0' }}
+                  loading={false}
+                  noItemsFoundLabel="You have no current positions"
+                  paginationProps={undefined}
+                  position="relative"
+                  renderTableHeader={() => (
+                    <PortfolioTableHeader
+                      currentSortingObj={currentSortingObj}
+                      setCurrentSortingObj={setSorting}
                       {...rowProps(hasStakingBoost)}
                     />
-                  )
-                }}
-                showPagination={false}
-              />
+                  )}
+                  renderTableRow={({ item }) => {
+                    return (
+                      <PortfolioTableRow
+                        keyValue={item.id}
+                        pool={item}
+                        {...rowProps(hasStakingBoost)}
+                      />
+                    )
+                  }}
+                  showPagination={false}
+                />
+              )}
             </Box>
           </Card>
         ) : (

--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
@@ -77,10 +77,16 @@ export function PortfolioTable() {
   }
 
   const { needsMigration } = usePoolMigrations()
-  const poolsThatNeedMigration = sortedPools
-    .filter(pool => needsMigration(pool.protocolVersion, getChainId(pool.chain), pool.id))
-    .sort((a, b) => (b.userBalance?.totalBalanceUsd || 0) - (a.userBalance?.totalBalanceUsd || 0))
-    .filter((item, pos, ary) => !pos || item.id != ary[pos - 1].id) // deduplication
+  const poolsThatNeedMigration = useMemo(
+    () =>
+      sortedPools
+        .filter(pool => needsMigration(pool.protocolVersion, getChainId(pool.chain), pool.id))
+        .sort(
+          (a, b) => (b.userBalance?.totalBalanceUsd || 0) - (a.userBalance?.totalBalanceUsd || 0)
+        )
+        .filter((item, pos, ary) => !pos || item.id != ary[pos - 1].id), // deduplication
+    [sortedPools, needsMigration]
+  )
 
   const deprecatedChainPools = sortedPools.filter(pool => isChainDeprecated(pool.chain)).length
 

--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
@@ -33,7 +33,7 @@ import { getChainId } from '@repo/lib/config/app.config'
 import { MigrationAlert } from '../../pool/migrations/MigrationAlert'
 import { isChainDeprecated } from '../../chains/chain.utils'
 import { BalAlert } from '@repo/lib/shared/components/alerts/BalAlert'
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 
 const rowProps = (needsLastColumnWider: boolean) => ({
   px: [0, 4],
@@ -51,6 +51,7 @@ export function PortfolioTable() {
   const hasStakingBoost = sortedPools.some(pool =>
     pool.dynamicData?.aprItems?.some(item => item.type === 'STAKING_BOOST')
   )
+  const tableRowProps = useMemo(() => rowProps(hasStakingBoost), [hasStakingBoost])
 
   const {
     selectedNetworks,
@@ -166,9 +167,9 @@ export function PortfolioTable() {
             <Box minW="max-content" w="full">
               <PortfolioTableLoadingGate
                 currentSortingObj={currentSortingObj}
-                hasStakingBoost={hasStakingBoost}
                 setSorting={setSorting}
                 sortedPools={sortedPools}
+                tableRowProps={tableRowProps}
               />
             </Box>
           </Card>
@@ -185,7 +186,7 @@ export function PortfolioTable() {
             <PortfolioTableHeader
               currentSortingObj={currentSortingObj}
               setCurrentSortingObj={setSorting}
-              {...rowProps(hasStakingBoost)}
+              {...tableRowProps}
             />
             <Divider />
             <Center h="160px" rounded="lg" w="full">
@@ -215,24 +216,24 @@ export function PortfolioTable() {
 
 const PortfolioTableLoadingGate = memo(function PortfolioTableLoadingGate({
   currentSortingObj,
-  hasStakingBoost,
   setSorting,
   sortedPools,
+  tableRowProps,
 }: {
   currentSortingObj: ReturnType<typeof usePortfolioSorting>['currentSortingObj']
-  hasStakingBoost: boolean
   setSorting: ReturnType<typeof usePortfolioSorting>['setSorting']
   sortedPools: ReturnType<typeof usePortfolioSorting>['sortedPools']
+  tableRowProps: ReturnType<typeof rowProps>
 }) {
   const { isLoadingPortfolio } = usePortfolio()
 
-  if (isLoadingPortfolio) {
+  if (isLoadingPortfolio && sortedPools.length === 0) {
     return (
       <>
         <PortfolioTableHeader
           currentSortingObj={currentSortingObj}
           setCurrentSortingObj={setSorting}
-          {...rowProps(hasStakingBoost)}
+          {...tableRowProps}
         />
         <Divider />
         {Array.from({ length: 5 }).map((_, i) => (
@@ -247,23 +248,23 @@ const PortfolioTableLoadingGate = memo(function PortfolioTableLoadingGate({
   return (
     <LoadedPortfolioTableContent
       currentSortingObj={currentSortingObj}
-      hasStakingBoost={hasStakingBoost}
       setSorting={setSorting}
       sortedPools={sortedPools}
+      tableRowProps={tableRowProps}
     />
   )
 })
 
 const LoadedPortfolioTableContent = memo(function LoadedPortfolioTableContent({
   currentSortingObj,
-  hasStakingBoost,
   setSorting,
   sortedPools,
+  tableRowProps,
 }: {
   currentSortingObj: ReturnType<typeof usePortfolioSorting>['currentSortingObj']
-  hasStakingBoost: boolean
   setSorting: ReturnType<typeof usePortfolioSorting>['setSorting']
   sortedPools: ReturnType<typeof usePortfolioSorting>['sortedPools']
+  tableRowProps: ReturnType<typeof rowProps>
 }) {
   return (
     <PaginatedTable
@@ -279,11 +280,11 @@ const LoadedPortfolioTableContent = memo(function LoadedPortfolioTableContent({
         <PortfolioTableHeader
           currentSortingObj={currentSortingObj}
           setCurrentSortingObj={setSorting}
-          {...rowProps(hasStakingBoost)}
+          {...tableRowProps}
         />
       )}
       renderTableRow={({ item }) => {
-        return <PortfolioTableRow keyValue={item.id} pool={item} {...rowProps(hasStakingBoost)} />
+        return <PortfolioTableRow keyValue={item.id} pool={item} {...tableRowProps} />
       }}
       showPagination={false}
     />

--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTableRow.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTableRow.tsx
@@ -52,7 +52,11 @@ const getStakingFilterKey = (poolType: ExpandedPoolType): StakingFilterKeyType =
   }
 }
 
-export function PortfolioTableRow({ pool, keyValue, ...rest }: Props) {
+export const PortfolioTableRow = memo(function PortfolioTableRow({
+  pool,
+  keyValue,
+  ...rest
+}: Props) {
   const { toCurrency } = useCurrency()
   const { name } = usePoolMetadata(pool)
   const { needsMigration } = usePoolMigrations()
@@ -138,7 +142,7 @@ export function PortfolioTableRow({ pool, keyValue, ...rest }: Props) {
       </Box>
     </FadeInOnView>
   )
-}
+})
 
 function StakingIcons({ pool, showIcon }: { pool: ExpandedPoolInfo; showIcon: boolean }) {
   const canStake = getCanStake(pool)

--- a/packages/lib/modules/portfolio/PortfolioTable/usePortfolioSorting.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/usePortfolioSorting.tsx
@@ -4,7 +4,6 @@ import { getCanStake } from '../../pool/actions/stake.helpers'
 import { getTotalApr } from '../../pool/pool.utils'
 import { ExpandedPoolInfo, ExpandedPoolType } from './useExpandedPools'
 import { usePortfolioFilters } from './PortfolioFiltersProvider'
-import { usePortfolio } from '../PortfolioProvider'
 import { bn } from '@repo/lib/shared/utils/numbers'
 
 export type PortfolioTableSortingId = 'staking' | 'vebal' | 'liquidity' | 'apr'
@@ -66,8 +65,6 @@ function sortingReducer(state: SortingState, action: SortingAction): SortingStat
 export function usePortfolioSorting() {
   const { filteredExpandedPools, selectedNetworks, selectedPoolTypes, selectedStakingTypes } =
     usePortfolioFilters()
-
-  const { portfolioData } = usePortfolio()
 
   const [manualSortingObj, dispatch] = useReducer(sortingReducer, null)
 
@@ -166,7 +163,7 @@ export function usePortfolioSorting() {
 
       return 0
     })
-  }, [portfolioData?.pools, filteredExpandedPools, currentSortingObj.id, currentSortingObj.desc])
+  }, [filteredExpandedPools, currentSortingObj.id, currentSortingObj.desc])
 
   return { sortedPools, setSorting, currentSortingObj }
 }


### PR DESCRIPTION
## Summary

Fixes the portfolio page rendering multiple times on load and the associated visual jumpiness (skeletons → spinner-on-blurred-rows → rows).

## Problem

The portfolio page experienced a cascade of re-renders during data loading due to:
1. **Object reference churn** — arrays/objects recreated on every render even when underlying data was unchanged
2. **Stale useMemo dependencies** — `usePortfolioSorting` depended on `portfolioData?.pools` even though `filteredExpandedPools` already derived from it
3. **Side-effects during render** — `useUserStakedBalance` mutated `stakedBalancesByPoolId` during render
4. **Blur overlay flash** — `PaginatedTable` showed a blur+spinner overlay on top of existing rows when `isLoadingPortfolio` was true but items had already arrived from Apollo, causing a jumpy skeleton → blur → rows sequence

## Changes

| Commit | File | What |
|--------|------|------|
| `5f0eae74` | `usePortfolioSorting.tsx` | Remove redundant `portfolioData?.pools` from `sortedPools` useMemo deps |
| `20bccb53` | `PortfolioTableRow.tsx` | Wrap `PortfolioTableRow` with `React.memo` to prevent unnecessary row re-renders |
| `7a2f564e` | `PortfolioProvider.tsx`, `useUserUnstakedBalance.tsx`, `useUserStakedBalance.tsx` | Memoize `poolsData`, `contracts`, `poolByStaking` to stop reference-churn cascade |
| `c6bf5e02` | `useUserStakedBalance.tsx` | Wrap `groupBy` + mutation in `useMemo` to eliminate render side-effect |
| `e87d71cb` | `PortfolioTable.tsx` | Render skeletons directly while loading instead of using `PaginatedTable`'s blur+spinner overlay |

## Result

- Table stays in a stable skeleton state until ALL data (Apollo + on-chain) is ready
- Then swaps cleanly to final rows — no more blur/spinner flash
- Rows don't re-render when parent re-renders unless the actual pool data changed

fixes #2452