### PR TITLE
fix: bignumber issues

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,23 +78,47 @@ jobs:
       - name: Run integration tests
         run: pnpm test:integration
 
-  E2E-Smoke-Test:
+  E2E-Smoke-Test-Balancer:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-noble
     env:
+      NEXT_PUBLIC_PROJECT_ID: balancer
       PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Run Playwright smoke tests
-        run: pnpm test:e2e:build
+      - name: Run Playwright smoke tests (Balancer)
+        run: pnpm test:e2e:build:bal
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-smoke-report
+          name: playwright-smoke-report-bal
+          path: |
+            ./packages/e2e-tests/playwright-report/
+          retention-days: 30
+
+  E2E-Smoke-Test-Beets:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+    env:
+      NEXT_PUBLIC_PROJECT_ID: beets
+      NEXT_PUBLIC_BALANCER_API_URL: https://backend-v3.beets-ftm-node.com/
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Run Playwright smoke tests (Beets)
+        run: pnpm test:e2e:build:beets
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-smoke-report-beets
           path: |
             ./packages/e2e-tests/playwright-report/
           retention-days: 30

--- a/apps/beets-frontend-v3/lib/modules/landing-page/sections/LandingBeetsData.tsx
+++ b/apps/beets-frontend-v3/lib/modules/landing-page/sections/LandingBeetsData.tsx
@@ -9,7 +9,7 @@ import {
   GetProtocolStatsQuery,
   GetStakedSonicDataQuery,
 } from '@repo/lib/shared/services/api/generated/graphql'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
 
 function GlobalStatsCard({ label, value }: { label: string; value: string }) {
   return (
@@ -35,10 +35,15 @@ export function LandingBeetsData({
 
   const protocolMetricsAggregated = protocolData.protocolMetricsAggregated
 
-  const totalFees = bn(stakedSonicData.stsGetGqlStakedSonicData.rewardsClaimed24h)
-    .plus(protocolMetricsAggregated.swapFee24h)
-    .plus(protocolMetricsAggregated.yieldCapture24h)
-    .toString()
+  const totalFees =
+    isValidNumber(stakedSonicData.stsGetGqlStakedSonicData.rewardsClaimed24h) &&
+    isValidNumber(protocolMetricsAggregated.swapFee24h) &&
+    isValidNumber(protocolMetricsAggregated.yieldCapture24h)
+      ? bn(stakedSonicData.stsGetGqlStakedSonicData.rewardsClaimed24h)
+          .plus(protocolMetricsAggregated.swapFee24h)
+          .plus(protocolMetricsAggregated.yieldCapture24h)
+          .toString()
+      : '0'
 
   return (
     <DefaultPageContainer noVerticalPadding position="relative" py="3xl">

--- a/apps/beets-frontend-v3/lib/modules/reliquary/ReliquaryProvider.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/ReliquaryProvider.tsx
@@ -7,7 +7,7 @@ import { isDisabledWithReason } from '@repo/lib/shared/utils/functions/isDisable
 import { useTokenInputsValidation } from '@repo/lib/modules/tokens/TokenInputsValidationProvider'
 import { getNetworkConfig } from '@repo/lib/config/app.config'
 import { sumBy } from 'lodash'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { usePool } from '@repo/lib/modules/pool/PoolProvider'
 import { useGetRelicPositionsOfOwner } from './hooks/useGetRelicPositionsOfOwner'
@@ -76,18 +76,23 @@ export function useReliquaryLogic() {
     refetch: refetchMaturityThresholds,
   } = levelInfoQuery
 
-  const relicIds = relicPositions.map(relic => bn(relic.relicId).toNumber())
+  const relicIds = relicPositions
+    .filter(relic => isValidNumber(relic.relicId))
+    .map(relic => bn(relic.relicId).toNumber())
   const beetsPerSecond = pool?.staking?.reliquary?.beetsPerSecond || '0'
   const reliquaryLevels = pool?.staking?.reliquary?.levels || []
 
   const weightedTotalBalance = sumBy(reliquaryLevels, level =>
-    bn(level.balance).times(level.allocationPoints).toNumber()
+    isValidNumber(level.balance) && isValidNumber(level.allocationPoints)
+      ? bn(level.balance).times(level.allocationPoints).toNumber()
+      : 0
   )
 
   const relicPositionsForFarmId = relicPositions.filter(
     position => position.farmId.toString() === farmId
   )
   const totalMaBeetsVP = sumBy(relicPositionsForFarmId, position => {
+    if (!isValidNumber(position.amount)) return 0
     const boost = reliquaryLevels.find(level => level.level === position.level)
 
     return bn(position.amount)

--- a/apps/beets-frontend-v3/lib/modules/reliquary/components/RelicCard.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/components/RelicCard.tsx
@@ -3,7 +3,7 @@ import { useNetworkConfig } from '@repo/lib/config/useNetworkConfig'
 import { usePool } from '@repo/lib/modules/pool/PoolProvider'
 import { getTotalApr } from '@repo/lib/modules/pool/pool.utils'
 import MainAprTooltip from '@repo/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip'
-import { bn, fNum } from '@repo/lib/shared/utils/numbers'
+import { bn, fNum, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
@@ -111,7 +111,7 @@ export function RelicCard({ relic, isSelected = false }: RelicCardSimpleProps) {
     relicGetMaturityProgress(relic, maturityThresholds)
 
   // Check if maBEETS position has balance
-  const hasBalance = bn(relic.amount).gt(0)
+  const hasBalance = isValidNumber(relic.amount) && bn(relic.amount).gt(0)
 
   // Calculate APR with boost
   const baseApr = pool.dynamicData.aprItems.find(
@@ -122,14 +122,18 @@ export function RelicCard({ relic, isSelected = false }: RelicCardSimpleProps) {
       return {
         ...item,
         title: 'BEETS reward APR',
-        apr: bn(relicApr)
-          .minus(baseApr?.apr || 0)
-          .toNumber(),
+        apr:
+          isValidNumber(relicApr) && baseApr && isValidNumber(baseApr.apr)
+            ? bn(relicApr).minus(baseApr.apr).toNumber()
+            : 0,
       }
     } else if (item.title === 'Voting APR Boost' && item.type === 'STAKING_BOOST') {
       return {
         ...item,
-        apr: bn(item.apr).times(allocationPoints).div(100).toNumber(),
+        apr:
+          isValidNumber(item.apr) && isValidNumber(allocationPoints)
+            ? bn(item.apr).times(allocationPoints).div(100).toNumber()
+            : 0,
       }
     } else {
       return item
@@ -140,7 +144,10 @@ export function RelicCard({ relic, isSelected = false }: RelicCardSimpleProps) {
   const formattedApr = fNum('apr', maxTotalApr.toString())
 
   // Calculate Share percentage
-  const weightedRelicAmount = bn(relic.amount).times(allocationPoints)
+  const weightedRelicAmount =
+    isValidNumber(relic.amount) && isValidNumber(allocationPoints)
+      ? bn(relic.amount).times(allocationPoints)
+      : bn(0)
   const relicShare =
     weightedTotalBalance > 0 ? weightedRelicAmount.div(weightedTotalBalance) : bn(0)
   const formattedShare = `${fNum('sharePercent', relicShare.toNumber())}`

--- a/apps/beets-frontend-v3/lib/modules/reliquary/components/ReliquaryRemoveLiquiditySummary.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/components/ReliquaryRemoveLiquiditySummary.tsx
@@ -23,7 +23,7 @@ import { BalAlert } from '@repo/lib/shared/components/alerts/BalAlert'
 import { AnimateHeightChange } from '@repo/lib/shared/components/animations/AnimateHeightChange'
 import { CardPopAnim } from '@repo/lib/shared/components/animations/CardPopAnim'
 import { useBreakpoints } from '@repo/lib/shared/hooks/useBreakpoints'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { useReliquary } from '../ReliquaryProvider'
 
 type Props = RemoveLiquidityReceiptResult & {
@@ -54,7 +54,9 @@ export function ReliquaryRemoveLiquiditySummary({
   const pendingRewardsAmount = relicId ? (pendingRewardsByRelicId[relicId] ?? '0') : '0'
   const networkConfig = getNetworkConfig(chain)
 
-  const _amountsOut = amountsOut.filter(amount => bn(amount.humanAmount).gt(0))
+  const _amountsOut = amountsOut.filter(
+    amount => isValidNumber(amount.humanAmount) && bn(amount.humanAmount).gt(0)
+  )
 
   const shouldShowErrors = hasQuoteContext ? removeLiquidityTxSuccess : removeLiquidityTxHash
   const shouldShowReceipt = removeLiquidityTxHash && !isLoadingReceipt && receivedTokens.length > 0

--- a/apps/beets-frontend-v3/lib/modules/reliquary/components/charts/ReliquaryMaBEETSLevelChart.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/components/charts/ReliquaryMaBEETSLevelChart.tsx
@@ -2,7 +2,7 @@ import { useTheme as useChakraTheme } from '@chakra-ui/react'
 import ReactECharts from 'echarts-for-react'
 import { useMemo } from 'react'
 import { EChartsOption, graphic } from 'echarts'
-import { bn, fNumCustom } from '@repo/lib/shared/utils/numbers'
+import { bn, fNumCustom, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { usePool } from '@repo/lib/modules/pool/PoolProvider'
 
 export function ReliquaryMaBEETSLevelChart() {
@@ -67,7 +67,9 @@ export function ReliquaryMaBEETSLevelChart() {
         {
           data: levels?.map(level => [
             level.level + 1,
-            bn(level.balance).times(level.allocationPoints).toNumber(),
+            isValidNumber(level.balance) && isValidNumber(level.allocationPoints)
+              ? bn(level.balance).times(level.allocationPoints).toNumber()
+              : 0,
           ]),
           type: 'bar',
           itemStyle: {

--- a/apps/beets-frontend-v3/lib/modules/reliquary/components/charts/ReliquaryRelicsCountChart.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/components/charts/ReliquaryRelicsCountChart.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { EChartsOption, graphic } from 'echarts'
 import { format } from 'date-fns'
-import { bn, fNumCustom } from '@repo/lib/shared/utils/numbers'
+import { bn, fNumCustom, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import ReactECharts from 'echarts-for-react'
 import { useTheme as useChakraTheme } from '@chakra-ui/react'
 import { secondsToMilliseconds } from 'date-fns'
@@ -14,7 +14,11 @@ export function ReliquaryRelicsCountChart({ data }: Props) {
   const theme = useChakraTheme()
 
   const chartData = useMemo(
-    () => data.map(item => [secondsToMilliseconds(item.timestamp), bn(item.relicCount).toNumber()]),
+    () =>
+      data.map(item => [
+        secondsToMilliseconds(item.timestamp),
+        isValidNumber(item.relicCount) ? bn(item.relicCount).toNumber() : 0,
+      ]),
     [data]
   )
 

--- a/apps/beets-frontend-v3/lib/modules/reliquary/components/stats/MaBeetsNumbers.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/components/stats/MaBeetsNumbers.tsx
@@ -3,7 +3,7 @@ import { InfoIconPopover } from '@repo/lib/modules/pool/actions/create/InfoIconP
 import { usePool } from '@repo/lib/modules/pool/PoolProvider'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import MainAprTooltip from '@repo/lib/shared/components/tooltips/apr-tooltip/MainAprTooltip'
-import { bn, fNumCustom } from '@repo/lib/shared/utils/numbers'
+import { bn, fNumCustom, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { zeroAddress } from 'viem'
 import { useReliquaryGlobalStats } from '../../hooks/useReliquaryGlobalStats'
 import RelicStat, { StatLabel, StatValueText } from './RelicStat'
@@ -33,8 +33,11 @@ export function MaBeetsNumbers({ onToggleShowMore, chartsVisible }: Props) {
 
   const totalBalance = bn(globalStats?.totalBalance || '0')
   const relicMaturityLevels = globalStats?.levelBalances.map((balance: any) => ({
-    level: bn(balance.level).plus(1),
-    percentageOfTotal: totalBalance.isZero() ? bn(0) : bn(balance.balance).div(totalBalance),
+    level: isValidNumber(balance.level) ? bn(balance.level).plus(1) : bn(0),
+    percentageOfTotal:
+      totalBalance.isZero() || !isValidNumber(balance.balance)
+        ? bn(0)
+        : bn(balance.balance).div(totalBalance),
   }))
 
   const avgRelicMaturity = fNumCustom(

--- a/apps/beets-frontend-v3/lib/modules/reliquary/components/stats/YourMaBeetsStats.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/components/stats/YourMaBeetsStats.tsx
@@ -7,7 +7,7 @@ import {
   VStack,
   useBreakpointValue,
 } from '@chakra-ui/react'
-import { bn, fNum, fNumCustom } from '@repo/lib/shared/utils/numbers'
+import { bn, fNum, fNumCustom, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { useReliquary } from '../../ReliquaryProvider'
 import RelicStat, { StatLabel, StatValueText } from './RelicStat'
 import { usePool } from '@repo/lib/modules/pool/PoolProvider'
@@ -46,7 +46,10 @@ export function YourMaBeetsStats() {
   const avgMaturityLevel =
     relicPositions.length > 0 && userTotalBalance > 0
       ? relicPositions.reduce((sum, relic) => {
-          const weight = bn(relic.amount).div(userTotalBalance).toNumber()
+          const weight =
+            isValidNumber(relic.amount) && userTotalBalance > 0
+              ? bn(relic.amount).div(userTotalBalance).toNumber()
+              : 0
           return sum + (relic.level + 1) * weight // +1 because levels are 0-indexed
         }, 0)
       : 0

--- a/apps/beets-frontend-v3/lib/modules/reliquary/hooks/useGetPendingRewards.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/hooks/useGetPendingRewards.tsx
@@ -7,7 +7,7 @@ import { formatUnits } from 'viem'
 import { minutesToMilliseconds } from 'date-fns'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { sumBy } from 'lodash'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { ReliquaryFarmPosition } from '../ReliquaryProvider'
 
 export type PendingRewardsResult = {
@@ -76,8 +76,12 @@ export function useGetPendingRewards({ chain, farmIds, relicPositions }: Params)
     const validRewards = rewards.filter(
       (reward): reward is NonNullable<typeof reward> => reward !== null
     )
-    const relicIds = validRewards.map(reward => bn(reward.relicId).toNumber())
-    const totalAmount = sumBy(validRewards, reward => bn(reward.amount).toNumber()).toString()
+    const relicIds = validRewards
+      .filter(reward => isValidNumber(reward.relicId))
+      .map(reward => bn(reward.relicId).toNumber())
+    const totalAmount = sumBy(validRewards, reward =>
+      isValidNumber(reward.amount) ? bn(reward.amount).toNumber() : 0
+    ).toString()
 
     return {
       rewards: [{ address: beetsAddress, amount: totalAmount }],
@@ -88,7 +92,7 @@ export function useGetPendingRewards({ chain, farmIds, relicPositions }: Params)
       relicIds,
       numberOfRelics: relicIds.length,
       fBEETSTotalBalance: sumBy(validRewards, reward =>
-        bn(reward.fBEETSBalance).toNumber()
+        isValidNumber(reward.fBEETSBalance) ? bn(reward.fBEETSBalance).toNumber() : 0
       ).toString(),
     }
   }, [config.tokens.addresses.beets, filteredPositions, query.data])

--- a/apps/beets-frontend-v3/lib/modules/reliquary/hooks/useRelicAddLiquidityBalance.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/hooks/useRelicAddLiquidityBalance.tsx
@@ -1,13 +1,14 @@
 import { usePool } from '@repo/lib/modules/pool/PoolProvider'
 import { useReliquary } from '../ReliquaryProvider'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
 
 export function useRelicAddLiquidityBalance(relicId: string) {
   const { relicPositions } = useReliquary()
   const { bptPrice } = usePool()
 
   const relic = relicPositions.find(r => r.relicId === relicId)
-  const relicBalanceUSD = relic ? bn(relic.amount).times(bptPrice).toNumber() : 0
+  const relicBalanceUSD =
+    relic && isValidNumber(relic.amount) ? bn(relic.amount).times(bptPrice).toNumber() : 0
 
   return {
     relicBalanceUSD,

--- a/apps/frontend-v3/lib/vebal/vebal-chart/useVebalLocksChart.tsx
+++ b/apps/frontend-v3/lib/vebal/vebal-chart/useVebalLocksChart.tsx
@@ -14,7 +14,7 @@ import {
 } from 'date-fns'
 import type BigNumber from 'bignumber.js'
 import { UseVebalLockInfoResult } from '../../vebal/useVebalLockInfo'
-import { bn, fNum } from '@repo/lib/shared/utils/numbers'
+import { bn, fNum, isValidNumber } from '@repo/lib/shared/utils/numbers'
 
 type ChartValueAcc = [string, number][]
 
@@ -39,6 +39,7 @@ function groupValuesByDates(chartValues: ChartValueAcc) {
 }
 
 function forecastBalance(snapshot: LockSnapshot, now: BigNumber) {
+  if (!isValidNumber(snapshot.bias) || !isValidNumber(snapshot.slope)) return 0
   const bias = bn(snapshot.bias)
   const slope = bn(snapshot.slope)
   const point2V = bias.minus(slope.times(now.minus(snapshot.timestamp)))
@@ -71,7 +72,7 @@ function processLockSnapshots(lockSnapshots: LockSnapshot[], currentTimestampMs:
   const currentDateSeconds = Math.floor(millisecondsToSeconds(currentTimestampMs))
 
   return lockSnapshots.reduce((acc: ChartValueAcc, snapshot, i) => {
-    const point1Balance = bn(snapshot.bias).toNumber()
+    const point1Balance = isValidNumber(snapshot.bias) ? bn(snapshot.bias).toNumber() : 0
     const point1Date = formatDate(snapshot.timestamp)
 
     const point2Timestamp = bn(lockSnapshots[i + 1]?.timestamp || currentDateSeconds)

--- a/packages/lib/modules/pool/LbpDetail/LbpPoolCharts/LbpPoolChartsProvider.tsx
+++ b/packages/lib/modules/pool/LbpDetail/LbpPoolCharts/LbpPoolChartsProvider.tsx
@@ -16,7 +16,7 @@ import {
 } from 'date-fns'
 import { LbpV3 } from '@repo/lib/modules/pool/pool.types'
 import { isFixedLBP } from '@repo/lib/modules/pool/pool.helpers'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { isSameAddress } from '@repo/lib/shared/utils/addresses'
 
 type LbpPoolChartsContextType = ReturnType<typeof useLbpPoolChartsLogic>
@@ -62,7 +62,7 @@ export function useLbpPoolChartsLogic() {
     .toNumber()
 
   const fundsRaisedGoal =
-    projectToken?.balance && projectTokenRate
+    projectToken?.balance && isValidNumber(projectToken.balance) && projectTokenRate
       ? bn(projectToken.balance).times(projectTokenRate).toNumber()
       : null
 

--- a/packages/lib/modules/pool/PoolDetail/PoolComposition.tsx
+++ b/packages/lib/modules/pool/PoolDetail/PoolComposition.tsx
@@ -18,7 +18,7 @@ import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { useBreakpoints } from '@repo/lib/shared/hooks/useBreakpoints'
 import { useCurrency } from '@repo/lib/shared/hooks/useCurrency'
 import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
-import { bn, fNum } from '@repo/lib/shared/utils/numbers'
+import { bn, fNum, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { useLayoutEffect, useRef, useState, Fragment } from 'react'
 import { Address } from 'viem'
 import { usePoolsMetadata } from '../metadata/PoolsMetadataProvider'
@@ -50,7 +50,10 @@ function CardContent({ totalLiquidity, poolTokens, chain, pool }: CardContentPro
   if (isSeedlessLBP) {
     const virtualToken = pool.poolTokens[pool.reserveTokenIndex].address
     const price = priceFor(virtualToken, chain)
-    virtualAmount = bn(pool.reserveTokenVirtualBalance).times(price).toString()
+    virtualAmount =
+      isValidNumber(pool.reserveTokenVirtualBalance) && isValidNumber(price)
+        ? bn(pool.reserveTokenVirtualBalance).times(price).toString()
+        : '0'
   }
 
   return (
@@ -83,7 +86,9 @@ function CardContent({ totalLiquidity, poolTokens, chain, pool }: CardContentPro
 
           const tokenValue =
             isSeedlessLBP && isVirtualPairedToken
-              ? bn(poolToken.balance).plus(pool.reserveTokenVirtualBalance)
+              ? isValidNumber(poolToken.balance) && isValidNumber(pool.reserveTokenVirtualBalance)
+                ? bn(poolToken.balance).plus(pool.reserveTokenVirtualBalance)
+                : poolToken.balance
               : poolToken.balance
 
           return (
@@ -103,9 +108,11 @@ function CardContent({ totalLiquidity, poolTokens, chain, pool }: CardContentPro
               {poolToken.hasNestedPool && poolToken.nestedPool && (
                 <VStack pl="8" w="full">
                   {getNestedPoolTokens(poolToken).map(nestedPoolToken => {
-                    const calculatedWeight = bn(nestedPoolToken.balanceUSD).div(
-                      bn(poolToken.balanceUSD)
-                    )
+                    const calculatedWeight =
+                      isValidNumber(nestedPoolToken.balanceUSD) &&
+                      isValidNumber(poolToken.balanceUSD)
+                        ? bn(nestedPoolToken.balanceUSD).div(bn(poolToken.balanceUSD))
+                        : bn(0)
                     return (
                       <TokenRow
                         actualWeight={bn(actualWeight).times(calculatedWeight).toString()}
@@ -115,7 +122,10 @@ function CardContent({ totalLiquidity, poolTokens, chain, pool }: CardContentPro
                         isNestedToken
                         key={`nested-pool-${nestedPoolToken.address}`}
                         targetWeight={
-                          nestedPoolToken.weight && poolToken.weight
+                          nestedPoolToken.weight &&
+                          poolToken.weight &&
+                          isValidNumber(nestedPoolToken.weight) &&
+                          isValidNumber(poolToken.weight)
                             ? bn(nestedPoolToken.weight).times(poolToken.weight).toString()
                             : undefined
                         }
@@ -129,10 +139,15 @@ function CardContent({ totalLiquidity, poolTokens, chain, pool }: CardContentPro
               {isVirtualPairedToken && (
                 <VStack pl="8" w="full">
                   <TokenRow
-                    actualWeight={bn(actualWeight)
-                      .times(pool.reserveTokenVirtualBalance)
-                      .div(bn(poolToken.balance).plus(pool.reserveTokenVirtualBalance))
-                      .toString()}
+                    actualWeight={
+                      isValidNumber(poolToken.balance) &&
+                      isValidNumber(pool.reserveTokenVirtualBalance)
+                        ? bn(actualWeight)
+                            .times(pool.reserveTokenVirtualBalance)
+                            .div(bn(poolToken.balance).plus(pool.reserveTokenVirtualBalance))
+                            .toString()
+                        : '0'
+                    }
                     address={poolToken.address as Address}
                     chain={chain}
                     iconSize={28}
@@ -143,10 +158,15 @@ function CardContent({ totalLiquidity, poolTokens, chain, pool }: CardContentPro
                     value={pool.reserveTokenVirtualBalance}
                   />
                   <TokenRow
-                    actualWeight={bn(actualWeight)
-                      .times(poolToken.balance)
-                      .div(bn(poolToken.balance).plus(pool.reserveTokenVirtualBalance))
-                      .toString()}
+                    actualWeight={
+                      isValidNumber(poolToken.balance) &&
+                      isValidNumber(pool.reserveTokenVirtualBalance)
+                        ? bn(actualWeight)
+                            .times(poolToken.balance)
+                            .div(bn(poolToken.balance).plus(pool.reserveTokenVirtualBalance))
+                            .toString()
+                        : '0'
+                    }
                     address={poolToken.address as Address}
                     chain={chain}
                     iconSize={28}

--- a/packages/lib/modules/pool/actions/add-liquidity/useIsMinimumDepositMet.ts
+++ b/packages/lib/modules/pool/actions/add-liquidity/useIsMinimumDepositMet.ts
@@ -100,7 +100,10 @@ export function useIsMinimumDepositMet({ humanAmountsIn, totalUSDValue }: Props)
       isSameAddress((token.underlyingToken?.address || zeroAddress) as Address, amount.tokenAddress)
     ) {
       address = token.underlyingToken.address
-      balance = bn(token.balance).div(token.priceRate).toString()
+      balance =
+        isValidNumber(token.balance) && isValidNumber(token.priceRate)
+          ? bn(token.balance).div(token.priceRate).toString()
+          : '0'
       decimals = token.underlyingToken.decimals
     }
 

--- a/packages/lib/modules/pool/pool.utils.ts
+++ b/packages/lib/modules/pool/pool.utils.ts
@@ -7,7 +7,7 @@ import {
   GqlPoolTokenDetail,
   GqlPoolType,
 } from '@repo/lib/shared/services/api/generated/graphql'
-import { Numberish, bn, fNum } from '@repo/lib/shared/utils/numbers'
+import { Numberish, bn, fNum, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import type BigNumber from 'bignumber.js'
 import { cloneDeep, invert } from 'lodash'
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
@@ -138,6 +138,8 @@ export function getTotalApr(aprItems: GqlPoolAprItem[]): [BigNumber, BigNumber] 
     // Filter known APR types to avoid including new unknown API types that are not yet displayed in the APR tooltip
     .filter(item => TOTAL_APR_TYPES.includes(item.type))
     .forEach(item => {
+      if (!isValidNumber(item.apr)) return
+
       if (item.type === GqlPoolAprItemType.StakingBoost) {
         maxTotal = bn(item.apr).plus(maxTotal)
         return

--- a/packages/lib/modules/pool/useGetPoolRewards.spec.tsx
+++ b/packages/lib/modules/pool/useGetPoolRewards.spec.tsx
@@ -46,6 +46,25 @@ function getPoolWithMultipleStakingGaugeRewards() {
   return pool
 }
 
+function getPoolWithInvalidStakingGaugeRewards() {
+  const pool = getApiPoolMock(boostedCoinshiftUsdcUsdl)
+  if (!pool.staking?.gauge?.rewards) throw new Error('Pool should have staking gauge rewards')
+
+  pool.staking.gauge.rewards = [
+    {
+      id: '0x5bbaed1fadc08c5fb3e4ae3c8848777e2da77103-0xba100000625a3754423978a60c9317c58a424e3d-balgauge',
+      rewardPerSecond: null as any,
+      tokenAddress: '0xba100000625a3754423978a60c9317c58a424e3d',
+    } as GqlPoolStakingGaugeReward,
+    {
+      id: '0x5bbaed1fadc08c5fb3e4ae3c8848777e2da77103-0x6b175474e89094c44da98b954eedeac495271d0f-daigauge',
+      rewardPerSecond: '0.001',
+      tokenAddress: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    } as GqlPoolStakingGaugeReward,
+  ]
+  return pool
+}
+
 function testUseGetPoolRewards(pool: Pool) {
   const { result } = testHook(() => useGetPoolRewards(pool))
   return result
@@ -118,6 +137,22 @@ describe('useGetPoolRewards', () => {
     // Zero rewards token should have '0'
     expect(result.current.weeklyRewardsByToken['0x0000000000000000000000000000000000000000']).toBe(
       '0'
+    )
+  })
+
+  test('handles invalid rewardPerSecond gracefully', async () => {
+    const pool = getPoolWithInvalidStakingGaugeRewards()
+    const result = testUseGetPoolRewards(pool)
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Invalid rewardPerSecond should fallback to '0'
+    expect(result.current.weeklyRewardsByToken['0xba100000625a3754423978a60c9317c58a424e3d']).toBe(
+      '0'
+    )
+    // Valid rewardPerSecond should still calculate correctly
+    expect(result.current.weeklyRewardsByToken['0x6b175474e89094c44da98b954eedeac495271d0f']).toBe(
+      '604.8'
     )
   })
 })

--- a/packages/lib/modules/pool/useGetPoolRewards.tsx
+++ b/packages/lib/modules/pool/useGetPoolRewards.tsx
@@ -2,7 +2,7 @@ import { Pool } from './pool.types'
 import { GqlToken } from '@repo/lib/shared/services/api/generated/graphql'
 import { sumBy } from 'lodash'
 import { useTokens } from '../tokens/TokensProvider'
-import { bn, Numberish } from '@repo/lib/shared/utils/numbers'
+import { bn, Numberish, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { calcPotentialYieldFor } from './pool.utils'
 import { oneWeekInSecs } from '@repo/lib/shared/utils/time'
 
@@ -14,13 +14,15 @@ export function useGetPoolRewards(pool: Pool) {
   const currentRewardsPerWeek = currentRewards.map(reward => {
     return {
       ...reward,
-      rewardPerWeek: bn(reward.rewardPerSecond).times(oneWeekInSecs),
+      rewardPerWeek: isValidNumber(reward.rewardPerSecond)
+        ? bn(reward.rewardPerSecond).times(oneWeekInSecs)
+        : bn(0),
     }
   })
 
   // In case a reward token is undefined, it's icon in TokenIconStack will be a random one
   const tokens = currentRewardsPerWeek
-    .filter(reward => bn(reward.rewardPerSecond).gt(0))
+    .filter(reward => reward.rewardPerWeek.gt(0))
     .map(reward => getToken(reward.tokenAddress, pool.chain)) as GqlToken[]
 
   const weeklyRewards = sumBy(currentRewardsPerWeek, reward =>
@@ -31,7 +33,9 @@ export function useGetPoolRewards(pool: Pool) {
   const weeklyRewardsByToken = Object.fromEntries(
     currentRewards.map(reward => [
       reward.tokenAddress,
-      reward.rewardPerSecond ? bn(reward.rewardPerSecond).times(oneWeekInSecs).toString() : '0',
+      isValidNumber(reward.rewardPerSecond)
+        ? bn(reward.rewardPerSecond).times(oneWeekInSecs).toString()
+        : '0',
     ])
   )
 

--- a/packages/lib/modules/pool/useGetUserPoolRewards.tsx
+++ b/packages/lib/modules/pool/useGetUserPoolRewards.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react'
 import { sumBy } from 'lodash'
 import { Pool } from './pool.types'
-import { safeTokenFormat } from '@repo/lib/shared/utils/numbers'
+import { formatUnits } from 'viem'
 import { useGetPoolRewards } from './useGetPoolRewards'
 import { BalTokenReward } from '../portfolio/PortfolioClaim/useBalRewards'
 import { ClaimableReward } from '../portfolio/PortfolioClaim/useClaimableBalances'
@@ -41,7 +41,7 @@ export function useGetUserPoolRewards({
         const token = tokens.find(t => t?.address === reward.tokenAddress)
         const decimals = token?.decimals || 18
 
-        balanceMap[reward.tokenAddress] = safeTokenFormat(reward.balance, decimals)
+        balanceMap[reward.tokenAddress] = formatUnits(reward.balance, decimals)
       }
     })
 

--- a/packages/lib/modules/pool/user-balance.helpers.spec.ts
+++ b/packages/lib/modules/pool/user-balance.helpers.spec.ts
@@ -81,3 +81,60 @@ test('has tiny balance', () => {
   pool.userBalance = userBalanceMock
   expect(hasTinyBalance(pool)).toBeTruthy()
 })
+
+describe('invalid balance fallbacks', () => {
+  test('getUserTotalBalance returns 0 when totalBalance is invalid', () => {
+    const pool = aWjAuraWethPoolElementMock()
+    pool.userBalance = {
+      __typename: 'GqlPoolUserBalance',
+      walletBalance: '100',
+      walletBalanceUsd: 200,
+      totalBalance: '',
+      totalBalanceUsd: 300,
+      stakedBalances: [],
+    }
+    expect(getUserTotalBalance(pool)).toBe('0')
+  })
+
+  test('getUserTotalBalanceInt returns 0n when totalBalance is invalid', () => {
+    const pool = aWjAuraWethPoolElementMock()
+    pool.userBalance = {
+      __typename: 'GqlPoolUserBalance',
+      walletBalance: '100',
+      walletBalanceUsd: 200,
+      totalBalance: null as any,
+      totalBalanceUsd: 300,
+      stakedBalances: [],
+    }
+    expect(getUserTotalBalanceInt(pool)).toBe(0n)
+  })
+
+  test('calcStakedBalance handles invalid staked balances', () => {
+    const pool = aWjAuraWethPoolElementMock()
+    pool.userBalance = {
+      __typename: 'GqlPoolUserBalance',
+      walletBalance: '100',
+      walletBalanceUsd: 200,
+      totalBalance: '175',
+      totalBalanceUsd: 300,
+      stakedBalances: [
+        {
+          balance: '',
+          balanceUsd: 0,
+          stakingType: GqlPoolStakingType.Gauge,
+          stakingId: '0x1',
+          __typename: 'GqlUserStakedBalance',
+        },
+        {
+          balance: '52.123',
+          balanceUsd: 7.9,
+          stakingType: GqlPoolStakingType.Gauge,
+          stakingId: '0x2',
+          __typename: 'GqlUserStakedBalance',
+        },
+      ],
+    }
+    expect(calcTotalStakedBalance(pool)).toBe('52.123')
+    expect(calcTotalStakedBalanceUsd(pool)).toBe(7.9)
+  })
+})

--- a/packages/lib/modules/pool/user-balance.helpers.ts
+++ b/packages/lib/modules/pool/user-balance.helpers.ts
@@ -1,4 +1,4 @@
-import { bn, safeSum } from '@repo/lib/shared/utils/numbers'
+import { bn, safeSum, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { Pool } from './pool.types'
 import { PoolListItem } from './pool.types'
 import { parseUnits } from 'viem'
@@ -18,7 +18,11 @@ export function calcStakedBalance(
     ? userBalance.stakedBalances.filter(stakedBalance => stakedBalance.stakingType === stakingType)
     : userBalance.stakedBalances
 
-  return safeSum(filteredBalances.map(stakedBalance => bn(stakedBalance.balance))) as HumanAmount
+  return safeSum(
+    filteredBalances.map(stakedBalance =>
+      isValidNumber(stakedBalance.balance) ? bn(stakedBalance.balance) : bn(0)
+    )
+  ) as HumanAmount
 }
 
 export function calcTotalStakedBalance(pool: Pool | PoolListItem): HumanAmount {
@@ -34,7 +38,11 @@ export function calcTotalStakedBalanceUsd(pool: Pool): number {
   if (!userBalance) return 0
 
   return Number(
-    safeSum(userBalance.stakedBalances.map(stakedBalance => bn(stakedBalance.balanceUsd)))
+    safeSum(
+      userBalance.stakedBalances.map(stakedBalance =>
+        isValidNumber(stakedBalance.balanceUsd) ? bn(stakedBalance.balanceUsd) : bn(0)
+      )
+    )
   )
 }
 
@@ -46,7 +54,9 @@ export function getUserTotalBalance(pool: Pool | PoolListItem): HumanAmount {
   const userBalance = pool.userBalance
   if (!userBalance) return '0'
 
-  return bn(userBalance.totalBalance).toFixed(18) as HumanAmount
+  return isValidNumber(userBalance.totalBalance)
+    ? (bn(userBalance.totalBalance).toFixed(18) as HumanAmount)
+    : '0'
 }
 
 export function getUserWalletBalance(pool: Pool): HumanAmount {
@@ -79,7 +89,10 @@ export function getUserTotalBalanceInt(pool: Pool): bigint {
   // totalBalance (human amount) returned from the API doesn't seem to be limited to 18
   // decimals and so it borked the whole pool page. toFixed(18) ensures the
   // value cannot be more than 18 decimals when passed into parseUnits.
-  const totalBalance = bn(getUserTotalBalance(pool)).toFixed(BPT_DECIMALS)
+  const totalBalanceStr = getUserTotalBalance(pool)
+  const totalBalance = isValidNumber(totalBalanceStr)
+    ? bn(totalBalanceStr).toFixed(BPT_DECIMALS)
+    : '0'
   return parseUnits(totalBalance, BPT_DECIMALS)
 }
 
@@ -135,7 +148,8 @@ export function calcStakedBalanceInt(pool: Pool, stakingType: GqlPoolStakingType
 }
 
 export function calcStakedBalanceUsd(pool: Pool, stakingType: GqlPoolStakingType): number {
-  return Number(bn(getStakedBalance(pool, stakingType).balanceUsd))
+  const balanceUsd = getStakedBalance(pool, stakingType).balanceUsd
+  return isValidNumber(balanceUsd) ? Number(bn(balanceUsd)) : 0
 }
 
 export function calcGaugeStakedBalanceUsd(pool: Pool): number {
@@ -143,7 +157,8 @@ export function calcGaugeStakedBalanceUsd(pool: Pool): number {
 }
 
 export function hasTotalBalance(pool: Pool) {
-  return bn(getUserTotalBalance(pool)).gt(0)
+  const totalBalance = getUserTotalBalance(pool)
+  return isValidNumber(totalBalance) && bn(totalBalance).gt(0)
 }
 
 export function hasBalancerStakedBalance(pool: Pool | PoolListItem): boolean {
@@ -162,7 +177,10 @@ export function hasStakedBalanceFor(
   if (!userBalance) return false
 
   return userBalance.stakedBalances.some(
-    balance => balance.stakingType === stakingType && bn(balance.balance).gt(0)
+    balance =>
+      balance.stakingType === stakingType &&
+      isValidNumber(balance.balance) &&
+      bn(balance.balance).gt(0)
   )
 }
 

--- a/packages/lib/modules/portfolio/PortfolioClaim/useGetHiddenHandRewards.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/useGetHiddenHandRewards.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { useUserAccount } from '../../web3/UserAccountProvider'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 
@@ -78,11 +78,15 @@ export function useGetHiddenHandRewards() {
     staleTime: 60000,
     refetchInterval: 300000,
     select: data => {
-      const filteredRewards = data.data.filter(reward => bn(reward.claimable).gt(0))
+      const filteredRewards = data.data.filter(
+        reward => isValidNumber(reward.claimable) && bn(reward.claimable).gt(0)
+      )
 
       const aggregatedRewards = filteredRewards.reduce(
         (acc, reward) => {
           const tokenAddress = reward.token
+          if (!isValidNumber(reward.claimable)) return acc
+
           const rewardTokenUsdValue = usdValueForTokenAddress(
             tokenAddress,
             PROJECT_CONFIG.defaultNetwork,

--- a/packages/lib/modules/tokens/TokenRow/TokenRowGroup.tsx
+++ b/packages/lib/modules/tokens/TokenRow/TokenRowGroup.tsx
@@ -8,7 +8,7 @@ import TokenRow from './TokenRow'
 import { ReactNode, useMemo } from 'react'
 import { HumanAmount } from '@balancer/sdk'
 import { Pool } from '@repo/lib/modules/pool/pool.types'
-import { bn, formatFalsyValueAsDash } from '@repo/lib/shared/utils/numbers'
+import { bn, formatFalsyValueAsDash, isValidNumber } from '@repo/lib/shared/utils/numbers'
 
 type HumanTokenAmountWithSymbol = HumanTokenAmount & { symbol?: string }
 
@@ -49,11 +49,13 @@ export function TokenRowGroup({
       const key = amount.tokenAddress
 
       if (amountMap[key]) {
+        const existingAmount = isValidNumber(amountMap[key].humanAmount)
+          ? bn(amountMap[key].humanAmount)
+          : bn(0)
+        const newAmount = isValidNumber(amount.humanAmount) ? bn(amount.humanAmount) : bn(0)
         amountMap[key] = {
           ...amountMap[key],
-          humanAmount: bn(amountMap[key].humanAmount)
-            .plus(bn(amount.humanAmount))
-            .toString() as HumanAmount,
+          humanAmount: existingAmount.plus(newAmount).toString() as HumanAmount,
           symbol: symbol || amount.symbol,
         }
       } else {

--- a/packages/lib/modules/tokens/TokensProvider.tsx
+++ b/packages/lib/modules/tokens/TokensProvider.tsx
@@ -8,7 +8,7 @@ import {
 } from '@repo/lib/shared/services/api/generated/graphql'
 import { isSameAddress } from '@repo/lib/shared/utils/addresses'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
-import { bn, Numberish } from '@repo/lib/shared/utils/numbers'
+import { bn, Numberish, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { useQuery } from '@apollo/client/react'
 import { createContext, PropsWithChildren, useCallback } from 'react'
 import { Address } from 'viem'
@@ -87,6 +87,7 @@ export function useTokensLogic() {
   function usdValueForToken(token: ApiOrCustomToken | undefined, amount: Numberish) {
     if (!token) return '0'
     if (amount === '') return '0'
+    if (typeof amount === 'string' && !isValidNumber(amount)) return '0'
     return bn(amount)
       .times(priceFor(token.address as Address, token.chain))
       .toFixed()
@@ -99,6 +100,7 @@ export function useTokensLogic() {
     customUsdPrice?: string
   ) {
     if (amount === '') return '0'
+    if (typeof amount === 'string' && !isValidNumber(amount)) return '0'
     return bn(amount)
       .times(customUsdPrice || priceFor(address, chain))
       .toFixed()
@@ -121,7 +123,7 @@ export function useTokensLogic() {
     const tokenPrice = priceFor(tokenAddress, chain)
     const totalLiquidityBn = bn(totalLiquidity || 0)
 
-    if (totalLiquidityBn.isZero()) return '0'
+    if (totalLiquidityBn.isZero() || !isValidNumber(tokenBalance)) return '0'
 
     return bn(tokenPrice).times(tokenBalance).div(totalLiquidityBn).toString()
   }
@@ -130,6 +132,7 @@ export function useTokensLogic() {
     (poolTokens: PoolToken[], chain: GqlChain) => {
       return poolTokens
         .reduce((total, token) => {
+          if (!isValidNumber(token.balance)) return total
           return total.plus(bn(priceFor(token.address, chain)).times(token.balance))
         }, bn(0))
         .toString()

--- a/packages/lib/shared/utils/numbers.spec.ts
+++ b/packages/lib/shared/utils/numbers.spec.ts
@@ -2,7 +2,6 @@ import BigNumber from 'bignumber.js'
 import {
   bn,
   fNum,
-  safeTokenFormat,
   BN_LOWER_THRESHOLD,
   sum,
   formatFalsyValueAsDash,
@@ -139,20 +138,6 @@ describe('slippage', () => {
     expect(fNum('slippage', '0.0001')).toBe('<0.01%')
     expect(fNum('slippage', '0.00009')).toBe('<0.01%')
     expect(fNum('slippage', '0.000007595846919227514')).toBe('<0.01%')
-  })
-})
-
-describe('safeTokenFormat', () => {
-  test('for a bigint amount', () => {
-    expect(safeTokenFormat(251359380787607529n, 18)).toBe('0.2514')
-    expect(safeTokenFormat(null, 18)).toBe('-')
-  })
-})
-
-describe('safeTokenFormat', () => {
-  test('for a bigint amount', () => {
-    expect(safeTokenFormat(251359380787607529n, 18)).toBe('0.2514')
-    expect(safeTokenFormat(null, 18)).toBe('-')
   })
 })
 

--- a/packages/lib/shared/utils/numbers.spec.ts
+++ b/packages/lib/shared/utils/numbers.spec.ts
@@ -6,6 +6,7 @@ import {
   sum,
   formatFalsyValueAsDash,
   ZERO_VALUE_DASH,
+  isValidNumber,
 } from './numbers'
 
 test('Stringifies bigints', () => {
@@ -239,5 +240,24 @@ describe('formatFalsyValueAsDash', () => {
     expect(formatFalsyValueAsDash('-100')).toBe('-100')
     expect(formatFalsyValueAsDash('0.123456')).toBe('0.123456')
     expect(formatFalsyValueAsDash('1000000000')).toBe('1000000000')
+  })
+})
+
+describe('isValidNumber', () => {
+  test('returns false for nullish and invalid values', () => {
+    expect(isValidNumber(null)).toBe(false)
+    expect(isValidNumber(undefined)).toBe(false)
+    expect(isValidNumber('')).toBe(false)
+    expect(isValidNumber('abc')).toBe(false)
+  })
+
+  test('returns true for valid numbers and numeric strings', () => {
+    expect(isValidNumber(0)).toBe(true)
+    expect(isValidNumber(1.5)).toBe(true)
+    expect(isValidNumber(-10)).toBe(true)
+    expect(isValidNumber('0')).toBe(true)
+    expect(isValidNumber('1.5')).toBe(true)
+    expect(isValidNumber('100')).toBe(true)
+    expect(isValidNumber('0.0000000000000035')).toBe(true)
   })
 })

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -4,7 +4,7 @@ import { MAX_UINT256 } from '@balancer/sdk'
 import BigNumber from 'bignumber.js'
 import numeral from 'numeral'
 import { KeyboardEvent } from 'react'
-import { formatUnits, parseUnits } from 'viem'
+import { parseUnits } from 'viem'
 import { isNumber, toNumber } from 'lodash'
 
 // Allows calling JSON.stringify with bigints
@@ -288,17 +288,6 @@ function isSmallPercentage(
 
 export function isSuperSmallAmount(value: Numberish): boolean {
   return bn(value).lte(BN_LOWER_THRESHOLD)
-}
-
-// Returns dash if token amount is null, otherwise returns humanized token amount in token display format.
-export function safeTokenFormat(
-  amount: bigint | null | undefined,
-  decimals: number,
-  opts?: FormatOpts
-): string {
-  if (!amount) return '-'
-
-  return fNum('token', formatUnits(amount, decimals), opts)
 }
 
 export function isZero(amount: Numberish): boolean {

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -312,7 +312,7 @@ export function isTooSmallToRemoveUsd(value: Numberish): boolean {
 }
 
 export const isValidNumber = (value: string | number | undefined | null): boolean =>
-  value !== '' && isNumber(toNumber(value)) && !isNaN(toNumber(value))
+  value != null && value !== '' && isNumber(toNumber(value)) && !isNaN(toNumber(value))
 
 // Parses a fixed-point decimal string into a bigint
 // If we do not have enough decimals to express the number, we truncate it


### PR DESCRIPTION
## Fix potential `bn()` crashes from invalid string inputs

The `bn()` wrapper (`packages/lib/shared/utils/numbers.ts`) converts values via `new BigNumber(val.toString())`, which throws `[BigNumber Error] Not a number` when the string is non-numeric (e.g. `< 0.00001` from `tokenFormat`, or malformed API data). This PR adds `isValidNumber()` guards before all unvalidated `bn()` calls on string inputs that originate from GraphQL responses or external APIs.

### What's changed

**Pool / APR**
- `pool.utils.ts` — validates `item.apr` before every `bn(item.apr)` in `getTotalApr`
- `useGetPoolRewards.tsx` — validates `rewardPerSecond` when calculating weekly rewards and token lists

**Pool composition & liquidity**
- `PoolComposition.tsx` — validates `poolToken.balance`, `nestedPoolToken.balanceUSD`, `nestedPoolToken.weight`, `pool.reserveTokenVirtualBalance`
- `LbpPoolChartsProvider.tsx` — validates `projectToken.balance`
- `useIsMinimumDepositMet.ts` — validates `token.balance` and `token.priceRate`

**User balances**
- `user-balance.helpers.ts` — validates `stakedBalance.balance`, `stakedBalance.balanceUsd`, `userBalance.totalBalance`, and `balance.balance` across all helper functions

**Tokens**
- `TokensProvider.tsx` — validates `amount` in `usdValueForToken`/`usdValueForTokenAddress`, `tokenBalance` in `calcWeightForBalance`, and `token.balance` in `calcTotalUsdValue`

**Portfolio / Claims**
- `useGetHiddenHandRewards.tsx` — validates `reward.claimable` from HiddenHand API

**Beets Reliquary**
- `RelicCard.tsx` — validates `relic.amount`, `relicApr`, `item.apr`
- `LandingBeetsData.tsx` — validates `rewardsClaimed24h`, `swapFee24h`, `yieldCapture24h`
- `ReliquaryRemoveLiquiditySummary.tsx` — validates `amount.humanAmount`
- `MaBeetsNumbers.tsx`, `YourMaBeetsStats.tsx` — validates `balance.level`, `balance.balance`, `relic.amount`
- `ReliquaryMaBEETSLevelChart.tsx`, `ReliquaryRelicsCountChart.tsx` — validates chart data values
- `useRelicAddLiquidityBalance.tsx`, `useGetPendingRewards.tsx`, `ReliquaryProvider.tsx` — validates relic/level/reward amounts

**veBAL**
- `useVebalLocksChart.tsx` — validates `snapshot.bias` and `snapshot.slope"