### PR TITLE
fix: prevent swap page crash on invalid amount input like '.'

### DIFF
--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -14,7 +14,7 @@ import { GqlSorSwapTypeValues } from '@repo/lib/shared/services/api/graphql-enum
 import { isSameAddress, selectByAddress } from '@repo/lib/shared/utils/addresses'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { isDisabledWithReason } from '@repo/lib/shared/utils/functions/isDisabledWithReason'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { invert } from 'lodash'
 import { PropsWithChildren, createContext, useEffect, useMemo, useRef, useState } from 'react'
 import { Address, Hash, isAddress, parseUnits } from 'viem'
@@ -191,11 +191,13 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
 
   const shouldFetchSwap = (state: SwapState, urlTxHash?: Hash) => {
     if (urlTxHash) return false
+    const swapAmount = getSwapAmount()
     return (
       isAddress(state.tokenIn.address) &&
       isAddress(state.tokenOut.address) &&
       !!state.swapType &&
-      bn(getSwapAmount()).gt(0)
+      isValidNumber(swapAmount) &&
+      bn(swapAmount).gt(0)
     )
   }
 
@@ -486,7 +488,8 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
   const wethIsEth =
     isSameAddress(swapState.tokenIn.address, networkConfig.tokens.nativeAsset.address) ||
     isSameAddress(swapState.tokenOut.address, networkConfig.tokens.nativeAsset.address)
-  const validAmountOut = swapState.tokenOut.amount !== '' && bn(swapState.tokenOut.amount).gt(0)
+  const validAmountOut =
+    isValidNumber(swapState.tokenOut.amount) && bn(swapState.tokenOut.amount).gt(0)
 
   const protocolVersion =
     ((simulationQuery.data as SdkSimulateSwapResponse)?.protocolVersion as ProtocolVersion) || 2
@@ -563,9 +566,9 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
   }
 
   function setInitialAmounts(slugAmountIn?: string, slugAmountOut?: string) {
-    if (slugAmountIn && !slugAmountOut && bn(slugAmountIn).gt(0)) {
+    if (slugAmountIn && !slugAmountOut && isValidNumber(slugAmountIn) && bn(slugAmountIn).gt(0)) {
       setTokenInAmount(slugAmountIn as HumanAmount)
-    } else if (slugAmountOut && bn(slugAmountOut).gt(0)) {
+    } else if (slugAmountOut && isValidNumber(slugAmountOut) && bn(slugAmountOut).gt(0)) {
       setTokenOutAmount(slugAmountOut as HumanAmount)
     } else resetSwapAmounts()
   }
@@ -601,6 +604,25 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
     const swapState = swapStateVar()
     return getNetworkConfig(swapState.selectedChain)
   }
+
+  // Heal invalid persisted amounts (e.g. '.') that older versions could write
+  // to localStorage, so affected users recover without clearing storage manually
+  useEffect(() => {
+    const state = swapStateVar()
+    const invalidTokenIn = state.tokenIn.amount !== '' && !isValidNumber(state.tokenIn.amount)
+    const invalidTokenOut = state.tokenOut.amount !== '' && !isValidNumber(state.tokenOut.amount)
+    if (invalidTokenIn || invalidTokenOut) {
+      swapStateVar({
+        ...state,
+        tokenIn: invalidTokenIn
+          ? { ...state.tokenIn, amount: '', scaledAmount: BigInt(0) }
+          : state.tokenIn,
+        tokenOut: invalidTokenOut
+          ? { ...state.tokenOut, amount: '', scaledAmount: BigInt(0) }
+          : state.tokenOut,
+      })
+    }
+  }, [])
 
   // Set state on initial load
   useEffect(() => {

--- a/packages/lib/modules/tokens/TokenInput/useTokenInput.spec.ts
+++ b/packages/lib/modules/tokens/TokenInput/useTokenInput.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest'
+import { cleanAmountInput } from './useTokenInput'
+import { bn } from '@repo/lib/shared/utils/numbers'
+
+describe('cleanAmountInput', () => {
+  test('prefixes a leading decimal separator with zero', () => {
+    // Regression: a bare '.' (from typing '.' or ',' as first char) was stored in
+    // swapState and crashed the app with '[BigNumber Error] Not a number: .'
+    expect(cleanAmountInput('.')).toBe('0.')
+    expect(cleanAmountInput(',')).toBe('0.')
+    expect(cleanAmountInput('.5')).toBe('0.5')
+    expect(cleanAmountInput(',5')).toBe('0.5')
+  })
+
+  test('normalizes a comma decimal separator to a dot', () => {
+    expect(cleanAmountInput('1,5')).toBe('1.5')
+    expect(cleanAmountInput('0,001')).toBe('0.001')
+  })
+
+  test('strips non numeric characters', () => {
+    expect(cleanAmountInput('abc')).toBe('')
+    expect(cleanAmountInput('1a2b3')).toBe('123')
+    expect(cleanAmountInput('1e5')).toBe('15')
+  })
+
+  test('keeps valid amounts untouched', () => {
+    expect(cleanAmountInput('')).toBe('')
+    expect(cleanAmountInput('0')).toBe('0')
+    expect(cleanAmountInput('0.5')).toBe('0.5')
+    expect(cleanAmountInput('1234.5678')).toBe('1234.5678')
+  })
+
+  test('every non-empty result is parseable by BigNumber', () => {
+    const inputs = ['.', ',', '.5', ',5', '1,5', '0.', '123', 'abc1.2']
+    for (const input of inputs) {
+      const cleaned = cleanAmountInput(input)
+      if (cleaned !== '') expect(bn(cleaned).isNaN()).toBe(false)
+    }
+  })
+})

--- a/packages/lib/modules/tokens/TokenInput/useTokenInput.ts
+++ b/packages/lib/modules/tokens/TokenInput/useTokenInput.ts
@@ -1,4 +1,4 @@
-import { Numberish, bn } from '@repo/lib/shared/utils/numbers'
+import { Numberish, bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
 import { ChangeEvent } from 'react'
 import { useTokenBalances } from '../TokenBalancesProvider'
 import { useTokenInputsValidation } from '../TokenInputsValidationProvider'
@@ -13,6 +13,17 @@ export function overflowProtected(value: Numberish, decimalLimit: number): strin
     const maxLength = numberSegment.length + decimalLimit + 1
     return stringValue.slice(0, maxLength)
   } else return stringValue
+}
+
+export function cleanAmountInput(newValue: string): string {
+  let cleanValue = newValue.replace(',', '.')
+  cleanValue = cleanValue.replace(/[^\d.]/g, '')
+  let separators = 0 // Remove all non decimal chars except the first decimal separator
+  cleanValue = cleanValue.replace('.', () => (separators++ === 0 ? '.' : ''))
+  // A bare leading separator ('.') is not parseable by BigNumber and would crash downstream
+  if (cleanValue.startsWith('.')) cleanValue = '0' + cleanValue
+
+  return cleanValue
 }
 
 type Params = {
@@ -44,7 +55,7 @@ export function useTokenInput({
     const userBalance = balanceFor(tokenAddress)
 
     removeValidationErrors(tokenAddress, [EXCEEDS_BALANCE_ERROR])
-    if (value && userBalance !== undefined && !disableBalanceValidation) {
+    if (value && isValidNumber(value) && userBalance !== undefined && !disableBalanceValidation) {
       if (bn(value).gt(bn(userBalance.formatted))) {
         return setValidationError(tokenAddress, EXCEEDS_BALANCE_ERROR)
       }
@@ -52,14 +63,7 @@ export function useTokenInput({
   }
 
   const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.currentTarget.value
-
-    let cleanValue = newValue.replace(',', '.')
-    cleanValue = cleanValue.replace(/[^\d.]/g, '')
-    let separators = 0 // Remove all non decimal chars except the first decimal separator
-    cleanValue = cleanValue.replace('.', () => (separators++ === 0 ? '.' : ''))
-
-    updateValue(cleanValue)
+    updateValue(cleanAmountInput(event.currentTarget.value))
   }
 
   return {

--- a/packages/lib/shared/utils/numbers.spec.ts
+++ b/packages/lib/shared/utils/numbers.spec.ts
@@ -249,6 +249,9 @@ describe('isValidNumber', () => {
     expect(isValidNumber(undefined)).toBe(false)
     expect(isValidNumber('')).toBe(false)
     expect(isValidNumber('abc')).toBe(false)
+    expect(isValidNumber('.')).toBe(false)
+    expect(isValidNumber(',')).toBe(false)
+    expect(isValidNumber('1,5')).toBe(false)
   })
 
   test('returns true for valid numbers and numeric strings', () => {
@@ -259,5 +262,7 @@ describe('isValidNumber', () => {
     expect(isValidNumber('1.5')).toBe(true)
     expect(isValidNumber('100')).toBe(true)
     expect(isValidNumber('0.0000000000000035')).toBe(true)
+    expect(isValidNumber('0.')).toBe(true)
+    expect(isValidNumber('.5')).toBe(true)
   })
 })


### PR DESCRIPTION
Typing '.' or ',' as the first character of a swap amount (common on comma-decimal keyboard layouts, where ',' is normalized to '.') stored a bare '.' in the persisted swapState. The next render then crashed with '[BigNumber Error] Not a number: .' via bn() in shouldFetchSwap, and since the value was persisted to localStorage the crash survived reloads until the user manually cleared the swapState key.

- normalize a leading decimal separator to '0.' in the token input
- guard render-time bn() calls in SwapProvider with isValidNumber (shouldFetchSwap, validAmountOut, setInitialAmounts slug params)
- heal invalid persisted amounts on mount so already-affected users recover without clearing localStorage