### PR TITLE
fix: sanitize persisted swap state at load and guard bn() calls with isBnParseable

### DIFF
--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -14,7 +14,7 @@ import { GqlSorSwapTypeValues } from '@repo/lib/shared/services/api/graphql-enum
 import { isSameAddress, selectByAddress } from '@repo/lib/shared/utils/addresses'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { isDisabledWithReason } from '@repo/lib/shared/utils/functions/isDisabledWithReason'
-import { bn, isValidNumber } from '@repo/lib/shared/utils/numbers'
+import { bn, isBnParseable } from '@repo/lib/shared/utils/numbers'
 import { invert } from 'lodash'
 import { PropsWithChildren, createContext, useEffect, useMemo, useRef, useState } from 'react'
 import { Address, Hash, isAddress, parseUnits } from 'viem'
@@ -33,7 +33,7 @@ import { DefaultSwapHandler } from './handlers/DefaultSwap.handler'
 import { NativeWrapHandler } from './handlers/NativeWrap.handler'
 import { SwapHandler } from './handlers/Swap.handler'
 import { useSimulateSwapQuery } from './queries/useSimulateSwapQuery'
-import { isAuraBalSwap } from './swap.helpers'
+import { isAuraBalSwap, sanitizeSwapState } from './swap.helpers'
 import {
   OSwapAction,
   SdkSimulateSwapResponse,
@@ -123,7 +123,8 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
       selectedChain: isPoolSwap ? pool.chain : PROJECT_CONFIG.defaultNetwork,
     },
     isLbpSwap ? 'lbpSwapState' : 'swapState',
-    shouldDiscardOldPersistedValue
+    shouldDiscardOldPersistedValue,
+    sanitizeSwapState
   )
 
   const swapState = useReactiveVar(swapStateVar)
@@ -196,7 +197,7 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
       isAddress(state.tokenIn.address) &&
       isAddress(state.tokenOut.address) &&
       !!state.swapType &&
-      isValidNumber(swapAmount) &&
+      isBnParseable(swapAmount) &&
       bn(swapAmount).gt(0)
     )
   }
@@ -489,7 +490,7 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
     isSameAddress(swapState.tokenIn.address, networkConfig.tokens.nativeAsset.address) ||
     isSameAddress(swapState.tokenOut.address, networkConfig.tokens.nativeAsset.address)
   const validAmountOut =
-    isValidNumber(swapState.tokenOut.amount) && bn(swapState.tokenOut.amount).gt(0)
+    isBnParseable(swapState.tokenOut.amount) && bn(swapState.tokenOut.amount).gt(0)
 
   const protocolVersion =
     ((simulationQuery.data as SdkSimulateSwapResponse)?.protocolVersion as ProtocolVersion) || 2
@@ -566,9 +567,9 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
   }
 
   function setInitialAmounts(slugAmountIn?: string, slugAmountOut?: string) {
-    if (slugAmountIn && !slugAmountOut && isValidNumber(slugAmountIn) && bn(slugAmountIn).gt(0)) {
+    if (slugAmountIn && !slugAmountOut && isBnParseable(slugAmountIn) && bn(slugAmountIn).gt(0)) {
       setTokenInAmount(slugAmountIn as HumanAmount)
-    } else if (slugAmountOut && isValidNumber(slugAmountOut) && bn(slugAmountOut).gt(0)) {
+    } else if (slugAmountOut && isBnParseable(slugAmountOut) && bn(slugAmountOut).gt(0)) {
       setTokenOutAmount(slugAmountOut as HumanAmount)
     } else resetSwapAmounts()
   }
@@ -604,25 +605,6 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
     const swapState = swapStateVar()
     return getNetworkConfig(swapState.selectedChain)
   }
-
-  // Heal invalid persisted amounts (e.g. '.') that older versions could write
-  // to localStorage, so affected users recover without clearing storage manually
-  useEffect(() => {
-    const state = swapStateVar()
-    const invalidTokenIn = state.tokenIn.amount !== '' && !isValidNumber(state.tokenIn.amount)
-    const invalidTokenOut = state.tokenOut.amount !== '' && !isValidNumber(state.tokenOut.amount)
-    if (invalidTokenIn || invalidTokenOut) {
-      swapStateVar({
-        ...state,
-        tokenIn: invalidTokenIn
-          ? { ...state.tokenIn, amount: '', scaledAmount: BigInt(0) }
-          : state.tokenIn,
-        tokenOut: invalidTokenOut
-          ? { ...state.tokenOut, amount: '', scaledAmount: BigInt(0) }
-          : state.tokenOut,
-      })
-    }
-  }, [])
 
   // Set state on initial load
   useEffect(() => {

--- a/packages/lib/modules/swap/swap.helpers.ts
+++ b/packages/lib/modules/swap/swap.helpers.ts
@@ -1,5 +1,5 @@
 import { Address } from 'viem'
-import { OSwapAction, SdkSimulateSwapResponse, SwapAction } from './swap.types'
+import { OSwapAction, SdkSimulateSwapResponse, SwapAction, SwapState } from './swap.types'
 import type { GqlChain, GqlSorSwapType } from '@repo/lib/shared/services/api/generated/graphql'
 import { GqlSorSwapTypeValues } from '@repo/lib/shared/services/api/graphql-enums'
 import {
@@ -10,6 +10,7 @@ import {
 import { isSameAddress } from '@repo/lib/shared/utils/addresses'
 import { isMainnet } from '../chains/chain.utils'
 import { SwapSimulationQueryResult } from './queries/useSimulateSwapQuery'
+import { isBnParseable } from '@repo/lib/shared/utils/numbers'
 
 export function swapActionPastTense(action: SwapAction): string {
   switch (action) {
@@ -77,4 +78,18 @@ export function orderRouteVersion(simulationQuery: SwapSimulationQueryResult): n
   const queryData = simulationQuery.data as SdkSimulateSwapResponse
   const orderRouteVersion = queryData ? queryData.protocolVersion : 2
   return orderRouteVersion
+}
+// Heals invalid persisted amounts (e.g. '.') that older versions could write
+// to localStorage, so affected users recover without clearing storage manually
+export function sanitizeSwapState(state: SwapState): SwapState {
+  const sanitizeToken = (token: SwapState['tokenIn']) =>
+    token.amount !== '' && !isBnParseable(token.amount)
+      ? { ...token, amount: '', scaledAmount: BigInt(0) }
+      : token
+
+  return {
+    ...state,
+    tokenIn: sanitizeToken(state.tokenIn),
+    tokenOut: sanitizeToken(state.tokenOut),
+  }
 }

--- a/packages/lib/shared/hooks/useMakeVarPersisted.ts
+++ b/packages/lib/shared/hooks/useMakeVarPersisted.ts
@@ -9,7 +9,9 @@ import { useLocalStorage } from 'usehooks-ts'
 export function useMakeVarPersisted<T>(
   initialValue: T,
   storageName: string,
-  shouldDiscardPersistedValue = false
+  shouldDiscardPersistedValue = false,
+  // Heals a corrupted persisted value before the first render
+  sanitize?: (value: T) => T
 ) {
   const [value, setValue] = useLocalStorage(storageName, initialValue)
 
@@ -22,7 +24,9 @@ export function useMakeVarPersisted<T>(
     Create a reactive var with stored/initial value
     If shouldDiscardPersistedValue is true, discard the persisted value on first render
   */
-  const rv = shouldLoadInitialValue ? makeVar(initialValue) : makeVar(value)
+  const rv = shouldLoadInitialValue
+    ? makeVar(initialValue)
+    : makeVar(sanitize ? sanitize(value) : value)
 
   const onNextChange = (newValue: T | undefined) => {
     try {

--- a/packages/lib/shared/utils/numbers.spec.ts
+++ b/packages/lib/shared/utils/numbers.spec.ts
@@ -1,12 +1,13 @@
 import BigNumber from 'bignumber.js'
 import {
   bn,
-  fNum,
   BN_LOWER_THRESHOLD,
-  sum,
+  fNum,
   formatFalsyValueAsDash,
-  ZERO_VALUE_DASH,
+  isBnParseable,
   isValidNumber,
+  sum,
+  ZERO_VALUE_DASH,
 } from './numbers'
 
 test('Stringifies bigints', () => {
@@ -264,5 +265,30 @@ describe('isValidNumber', () => {
     expect(isValidNumber('0.0000000000000035')).toBe(true)
     expect(isValidNumber('0.')).toBe(true)
     expect(isValidNumber('.5')).toBe(true)
+  })
+})
+describe('isBnParseable', () => {
+  test('returns false for nullish and values bn() cannot parse', () => {
+    expect(isBnParseable(null)).toBe(false)
+    expect(isBnParseable(undefined)).toBe(false)
+    expect(isBnParseable('')).toBe(false)
+    expect(isBnParseable('.')).toBe(false)
+    expect(isBnParseable(',')).toBe(false)
+    expect(isBnParseable('1,5')).toBe(false)
+    expect(isBnParseable('1.2.3')).toBe(false)
+    // Passes isValidNumber (lodash toNumber) but throws in bn() — the reason this guard exists
+    expect(isBnParseable('  ')).toBe(false)
+  })
+
+  test('returns true for values bn() can parse', () => {
+    expect(isBnParseable(0)).toBe(true)
+    expect(isBnParseable(1.5)).toBe(true)
+    expect(isBnParseable(12345678901234567890n)).toBe(true)
+    expect(isBnParseable(bn('1.5'))).toBe(true)
+    expect(isBnParseable('0')).toBe(true)
+    expect(isBnParseable('1.5')).toBe(true)
+    expect(isBnParseable('0.')).toBe(true)
+    expect(isBnParseable('.5')).toBe(true)
+    expect(isBnParseable('0.0000000000000035')).toBe(true)
   })
 })

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -392,3 +392,18 @@ export function formatFalsyValueAsDash(
   // Otherwise return the string representation of the value
   return stringValue
 }
+/**
+ * True when `bn()` can parse the value without throwing.
+ * Prefer this over `isValidNumber` when guarding a `bn()` call: `isValidNumber`
+ * uses lodash `toNumber`, whose grammar differs from BigNumber's
+ * (e.g. 'Infinity' and whitespace-only strings pass `isValidNumber` but throw in `bn()`).
+ */
+export function isBnParseable(value: Numberish | undefined | null): boolean {
+  if (value == null) return false
+  try {
+    bn(value)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2566, which fixed the swap page crash on invalid amounts like a bare dot. This PR closes two gaps left by that fix.

## Problem 1: guard/parser mismatch

isValidNumber (lodash toNumber) and bn() (BigNumber) accept different grammars, so a value can pass the guard and still throw in the bn() call it protects. A whitespace-only persisted amount passes isValidNumber but throws in bn().

Fix: new isBnParseable() util validates with the same parser it protects (try/catch around bn()), and replaces isValidNumber in SwapProvider render-time guards (shouldFetchSwap, validAmountOut, setInitialAmounts).

## Problem 2: heal effect runs one render too late

The #2566 useEffect that heals corrupted persisted amounts runs after the first render, so the crashed-render path still executes once with the bad value. It survives today only because all current render-time bn() calls on the amount happen to be guarded.

Fix: useMakeVarPersisted now accepts an optional sanitize fn applied when the reactive var is created, so corrupted localStorage state is healed before the first render. SwapProvider passes the new pure sanitizeSwapState() (in swap.helpers.ts), and the post-mount heal effect is removed.

The LBP path goes through the same useMakeVarPersisted call; its persisted value was already discarded at load, and now shares the isBnParseable guards.

## Test plan

- [x] isBnParseable unit tests, incl. the whitespace regression case
- [x] Existing numbers.spec.ts, useTokenInput.spec.ts, swap.helpers.spec.ts pass
- [x] Manual: seed localStorage swapState with a whitespace amount and tokens set, reload /swap/ethereum/<tokenIn>/<tokenOut> - page renders, amount cleared (crashes on main)
- [x] Manual: seed with a bare dot amount - breakpoint at useReactiveVar shows empty string on first render (shows the dot on main)
- [x] Regression: type .5 / ,5 in sell input - shows 0.5, quote fetches
