### PR TITLE
fix: renovate bot oom

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "vitest": "3.2.6",
     "vitest-mock-extended": "3.1.1"
   },
-  "packageManager": "pnpm@11.7.0+sha512.19cc852c120c7125760f2443ee6be0ca5b40f9f50598de1a09a1f177503e010e57c23c77646e01e761de59bf874fb22a3398c33ab9691fc13eb946b6f0f4d620",
+  "packageManager": "pnpm@11.17.0",
   "engines": {
     "node": "24.x",
     "pnpm": ">=8"


### PR DESCRIPTION
pnpm install is using more mem than mend.io's clound env supplies to renovatebot (3GB)

latest pnpm version should use a lot less mem when installing