### PR TITLE
refactor(pool-list): remove effect-based URL query param cleanup from filters

### DIFF
--- a/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
+++ b/packages/lib/modules/pool/PoolList/PoolListFilters.tsx
@@ -33,7 +33,7 @@ import {
   poolTypeFilters,
 } from '../pool.types'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Filter, Info, Plus } from 'react-feather'
 import { useBreakpoints } from '@repo/lib/shared/hooks/useBreakpoints'
 import { useCurrency } from '@repo/lib/shared/hooks/useCurrency'
@@ -127,15 +127,8 @@ function UserLiquidityFilters() {
 
 function PoolCategoryFilters({ hidePoolTags }: { hidePoolTags: string[] }) {
   const {
-    queryState: { togglePoolTag, poolTags, setPoolTags, poolTagLabel },
+    queryState: { togglePoolTag, poolTags, poolTagLabel },
   } = usePoolList()
-
-  // remove query param when empty
-  useEffect(() => {
-    if (!poolTags.length) {
-      setPoolTags(null)
-    }
-  }, [poolTags])
 
   return (
     <Box animate="show" as={motion.div} exit="exit" initial="hidden" variants={staggeredFadeInUp}>
@@ -157,20 +150,13 @@ function PoolCategoryFilters({ hidePoolTags }: { hidePoolTags: string[] }) {
 
 function PoolHookFilters() {
   const {
-    queryState: { togglePoolHookTag, poolHookTags, setPoolHookTags, poolHookTagLabel },
+    queryState: { togglePoolHookTag, poolHookTags, poolHookTagLabel },
   } = usePoolList()
 
   // Exclude hooks that are not live
   const livePoolHookTagFilters = poolHookTagFilters.filter(
     tag => tag !== 'HOOKS_FEETAKING' && tag !== 'HOOKS_EXITFEE'
   )
-
-  // remove query param when empty
-  useEffect(() => {
-    if (!poolHookTags.length) {
-      setPoolHookTags(null)
-    }
-  }, [poolHookTags])
 
   return (
     <Box animate="show" as={motion.div} exit="exit" initial="hidden" variants={staggeredFadeInUp}>
@@ -191,7 +177,6 @@ function PoolHookFilters() {
 export interface PoolTypeFiltersArgs {
   poolTypes: PoolFilterType[]
   poolTypeLabel: (poolType: PoolFilterType) => string
-  setPoolTypes: (value: PoolFilterType[] | null) => void
   togglePoolType: (checked: boolean, value: PoolFilterType) => void
   hidePoolTypes?: PoolFilterType[]
 }
@@ -200,16 +185,8 @@ export function PoolTypeFilters({
   togglePoolType,
   poolTypes,
   poolTypeLabel,
-  setPoolTypes,
   hidePoolTypes,
 }: PoolTypeFiltersArgs) {
-  // remove query param when empty
-  useEffect(() => {
-    if (!poolTypes.length) {
-      setPoolTypes(null)
-    }
-  }, [poolTypes])
-
   const _poolTypeFilters = poolTypeFilters.filter(
     poolType => !(hidePoolTypes ?? []).includes(poolType)
   )
@@ -460,8 +437,6 @@ export interface ProtocolVersionFilterProps {
   setProtocolVersion: (version: number | null) => any
   protocolVersion: number | null
   poolTypes: PoolFilterType[]
-  activeProtocolVersionTab: ButtonGroupOption
-  setActiveProtocolVersionTab: React.Dispatch<React.SetStateAction<ButtonGroupOption>>
   hideProtocolVersion?: string[]
 }
 
@@ -469,39 +444,30 @@ export function ProtocolVersionFilter({
   setProtocolVersion,
   protocolVersion,
   poolTypes,
-  activeProtocolVersionTab,
-  setActiveProtocolVersionTab,
   hideProtocolVersion,
 }: ProtocolVersionFilterProps) {
   const tabs = PROTOCOL_VERSION_TABS
 
+  const activeProtocolVersionTab =
+    protocolVersion === 3
+      ? PROTOCOL_VERSION_TABS[2]
+      : protocolVersion === 2
+        ? PROTOCOL_VERSION_TABS[1]
+        : poolTypes.includes(GqlPoolTypeValues.CowAmm) || protocolVersion === 1
+          ? PROTOCOL_VERSION_TABS[3]
+          : PROTOCOL_VERSION_TABS[0]
+
   function toggleTab(option: ButtonGroupOption) {
-    setActiveProtocolVersionTab(option)
-  }
-
-  useEffect(() => {
-    if (protocolVersion === 3) {
-      setActiveProtocolVersionTab(PROTOCOL_VERSION_TABS[2])
-    } else if (protocolVersion === 2) {
-      setActiveProtocolVersionTab(PROTOCOL_VERSION_TABS[1])
-    } else if (poolTypes.includes(GqlPoolTypeValues.CowAmm) || protocolVersion === 1) {
-      setActiveProtocolVersionTab(PROTOCOL_VERSION_TABS[3])
-    } else {
-      setActiveProtocolVersionTab(PROTOCOL_VERSION_TABS[0])
-    }
-  }, [])
-
-  useEffect(() => {
-    if (activeProtocolVersionTab.value === 'v3') {
+    if (option.value === 'v3') {
       setProtocolVersion(3)
-    } else if (activeProtocolVersionTab.value === 'v2') {
+    } else if (option.value === 'v2') {
       setProtocolVersion(2)
-    } else if (activeProtocolVersionTab.value === 'cow') {
+    } else if (option.value === 'cow') {
       setProtocolVersion(1)
     } else {
       setProtocolVersion(null)
     }
-  }, [activeProtocolVersionTab])
+  }
 
   return (
     <ButtonGroup
@@ -522,16 +488,13 @@ export function PoolListFilters() {
     queryState: {
       resetFilters,
       totalFilterCount,
-      setActiveProtocolVersionTab,
       networks: toggledNetworks,
       toggleNetwork,
       setNetworks,
       togglePoolType,
       poolTypes,
-      setPoolTypes,
       setProtocolVersion,
       protocolVersion,
-      activeProtocolVersionTab,
     },
   } = usePoolList()
   const { isCowPath } = useCow()
@@ -539,7 +502,6 @@ export function PoolListFilters() {
 
   function _resetFilters() {
     resetFilters()
-    setActiveProtocolVersionTab(PROTOCOL_VERSION_TABS[0])
   }
 
   const { options, supportedNetworks } = PROJECT_CONFIG
@@ -626,11 +588,9 @@ export function PoolListFilters() {
                             Protocol version
                           </Heading>
                           <ProtocolVersionFilter
-                            activeProtocolVersionTab={activeProtocolVersionTab}
                             hideProtocolVersion={PROJECT_CONFIG.options.hideProtocolVersion}
                             poolTypes={poolTypes}
                             protocolVersion={protocolVersion}
-                            setActiveProtocolVersionTab={setActiveProtocolVersionTab}
                             setProtocolVersion={setProtocolVersion}
                           />
                         </Box>
@@ -644,7 +604,6 @@ export function PoolListFilters() {
                             hidePoolTypes={PROJECT_CONFIG.options.hidePoolTypes}
                             poolTypeLabel={poolTypeLabel}
                             poolTypes={poolTypes}
-                            setPoolTypes={setPoolTypes}
                             togglePoolType={togglePoolType}
                           />
                         </Box>

--- a/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
+++ b/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
@@ -32,7 +32,7 @@ import {
   SortingState,
 } from '../pool.types'
 import { PaginationState } from '@repo/lib/shared/components/pagination/pagination.types'
-import { useEffect, useRef, useState } from 'react'
+
 import { ButtonGroupOption } from '@repo/lib/shared/components/btns/button-group/ButtonGroup'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
@@ -89,7 +89,6 @@ export function usePoolListQueryState() {
   const [first, setFirst] = useQueryState('first', poolListQueryStateParsers.first)
   const [skip, setSkip] = useQueryState('skip', poolListQueryStateParsers.skip)
   const [orderBy, setOrderBy] = useQueryState('orderBy', poolListQueryStateParsers.orderBy)
-  const [activeProtocolVersionTab, setActiveProtocolVersionTab] = useState(PROTOCOL_VERSION_TABS[0])
   const [poolTypes, setPoolTypes] = useQueryState('poolTypes', poolListQueryStateParsers.poolTypes)
   const [networks, setNetworks] = useQueryState('networks', poolListQueryStateParsers.networks)
   const [minTvl, setMinTvl] = useQueryState('minTvl', poolListQueryStateParsers.minTvl)
@@ -124,18 +123,9 @@ export function usePoolListQueryState() {
   )
   const joinablePools = joinablePoolsValue === 'true'
 
-  const isFirstRender = useRef(true)
-  // on toggle always start at the beginning of the list
-  useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false
-      return
-    }
-    if (skip) setSkip(0)
-  }, [poolTypes, networks, minTvl, poolTags, joinablePools, userAddress])
-
   // Set internal checked state
   function toggleUserAddress(checked: boolean, address: string) {
+    if (skip) setSkip(0)
     if (checked) {
       setUserAddress(address)
     } else {
@@ -158,24 +148,33 @@ export function usePoolListQueryState() {
 
   // Set internal checked state
   function togglePoolTag(checked: boolean, poolTag: PoolTagType) {
+    if (skip) setSkip(0)
     if (checked) {
       setPoolTags(current => uniq([...current, poolTag]))
     } else {
-      setPoolTags(current => current.filter(item => item !== poolTag))
+      setPoolTags(current => {
+        const next = current.filter(item => item !== poolTag)
+        return next.length ? next : null
+      })
     }
   }
 
   // Set internal checked state
   function togglePoolHookTag(checked: boolean, poolHookTag: PoolHookTagType) {
+    if (skip) setSkip(0)
     if (checked) {
       setPoolHookTags(current => uniq([...current, poolHookTag]))
     } else {
-      setPoolHookTags(current => current.filter(item => item !== poolHookTag))
+      setPoolHookTags(current => {
+        const next = current.filter(item => item !== poolHookTag)
+        return next.length ? next : null
+      })
     }
   }
 
   // Set internal checked state
   function toggleNetwork(checked: boolean, network: GqlChain) {
+    if (skip) setSkip(0)
     if (checked) {
       setNetworks(current => uniq([...current, network]))
     } else {
@@ -185,10 +184,14 @@ export function usePoolListQueryState() {
 
   // Set internal checked state
   function togglePoolType(checked: boolean, poolType: PoolFilterType) {
+    if (skip) setSkip(0)
     if (checked) {
       setPoolTypes(current => uniq([...current, poolType]))
     } else {
-      setPoolTypes(current => current.filter(type => type !== poolType))
+      setPoolTypes(current => {
+        const next = current.filter(type => type !== poolType)
+        return next.length ? next : null
+      })
     }
   }
 
@@ -348,8 +351,6 @@ export function usePoolListQueryState() {
     poolHookTagLabel,
     setNetworks,
     setProtocolVersion,
-    setActiveProtocolVersionTab,
-    activeProtocolVersionTab,
     poolTags,
     protocolVersion,
     minTvl,

--- a/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
+++ b/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
@@ -322,6 +322,11 @@ export function usePoolListQueryState() {
     textSearch,
   }
 
+  function _setMinTvl(value: number | null) {
+    if (skip) setSkip(0)
+    setMinTvl(value)
+  }
+
   return {
     state: {
       first,
@@ -342,7 +347,7 @@ export function usePoolListQueryState() {
     setSorting,
     setPagination,
     setSearch,
-    setMinTvl,
+    setMinTvl: _setMinTvl,
     setPoolTypes,
     setPoolTags,
     setPoolHookTags,

--- a/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
+++ b/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
@@ -178,7 +178,10 @@ export function usePoolListQueryState() {
     if (checked) {
       setNetworks(current => uniq([...current, network]))
     } else {
-      setNetworks(current => current.filter(chain => chain !== network))
+      setNetworks(current => {
+        const next = current.filter(chain => chain !== network)
+        return next.length ? next : null
+      })
     }
   }
 

--- a/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
+++ b/packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx
@@ -129,7 +129,7 @@ export function usePoolListQueryState() {
     if (checked) {
       setUserAddress(address)
     } else {
-      setUserAddress('')
+      setUserAddress(null)
     }
   }
 


### PR DESCRIPTION
Part of #2076 — split from #2537

## Summary

Remove `useEffect` blocks that mirror empty filter arrays to URL query params (`setPoolTags(null)`, `setPoolHookTags(null)`, `setPoolTypes(null)`) and the local `activeProtocolVersionTab` state that mirrored `protocolVersion`.

Empty-param cleanup is now handled in `usePoolListQueryState` instead of being synchronized via effects from render-derived values.

## Files

- `packages/lib/modules/pool/PoolList/PoolListFilters.tsx` — remove 3 `useEffect` cleanup blocks, remove `activeProtocolVersionTab` local state + `setPoolTypes`/`setPoolTags`/`setPoolHookTags` props
- `packages/lib/modules/pool/PoolList/usePoolListQueryState.tsx` — handle empty-param cleanup in query state setters

## Test plan

- [x] Go to the pools list page
- [x] Apply a pool type filter, pool tag filter, and hook tag filter — verify the list updates and URL params appear
- [x] Clear each filter — verify the list updates and URL params are removed
- [x] Toggle protocol version tabs — verify the list updates and URL param updates
- [x] Refresh the page with active filters — verify state is restored from URL
- [x] Reset all filters — verify the list returns to default state