### PR TITLE
refactor(pool-creation): derive Gyro E-CLP c/s from peakPrice instead of form state

### DIFF
--- a/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
+++ b/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
@@ -119,7 +119,7 @@ describe('usePoolFormLogic', () => {
   })
 
   describe('invertGyroEclpPriceParams', () => {
-    it('inverts alpha/beta/peakPrice, swaps s<->c, preserves lambda, and reverses poolTokens', async () => {
+    it('inverts alpha/beta/peakPrice, preserves lambda, and reverses poolTokens', async () => {
       const { result } = await renderPoolForm()
 
       const tokenA = { ...INITIAL_POOL_CREATION_FORM.poolTokens[0], weight: '50' }
@@ -130,8 +130,6 @@ describe('usePoolFormLogic', () => {
         result.current.eclpConfigForm.setValue('alpha', '2')
         result.current.eclpConfigForm.setValue('beta', '4')
         result.current.eclpConfigForm.setValue('peakPrice', '5')
-        result.current.eclpConfigForm.setValue('s', '0.1')
-        result.current.eclpConfigForm.setValue('c', '0.9')
         result.current.eclpConfigForm.setValue('lambda', '100')
       })
 
@@ -144,9 +142,6 @@ describe('usePoolFormLogic', () => {
       expect(Number(eclp.alpha)).toBeCloseTo(0.25)
       expect(Number(eclp.beta)).toBeCloseTo(0.5)
       expect(Number(eclp.peakPrice)).toBeCloseTo(0.2)
-      // s and c are swapped as-is (no inversion, no reformat)
-      expect(eclp.s).toBe('0.9')
-      expect(eclp.c).toBe('0.1')
       // lambda is preserved
       expect(eclp.lambda).toBe('100')
       expect(result.current.poolCreationForm.getValues('poolTokens')).toEqual([tokenB, tokenA])

--- a/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.tsx
+++ b/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.tsx
@@ -75,13 +75,11 @@ export function usePoolFormLogic() {
   }
 
   const invertGyroEclpPriceParams = () => {
-    const { alpha, beta, peakPrice, s, c, lambda } = eclpConfigForm.getValues()
+    const { alpha, beta, peakPrice, lambda } = eclpConfigForm.getValues()
     eclpConfigForm.reset({
       alpha: fNumCustom(invertNumber(beta), NUM_FORMAT),
       beta: fNumCustom(invertNumber(alpha), NUM_FORMAT),
       peakPrice: fNumCustom(invertNumber(peakPrice), NUM_FORMAT),
-      s: c,
-      c: s,
       lambda: lambda,
     })
 

--- a/packages/lib/modules/pool/actions/create/constants.ts
+++ b/packages/lib/modules/pool/actions/create/constants.ts
@@ -181,8 +181,6 @@ export const INITIAL_AUTORANGE_CONFIG: AutoRangeConfig = {
 export const INITIAL_ECLP_CONFIG: EclpConfigForm = {
   alpha: '',
   beta: '',
-  c: '',
-  s: '',
   lambda: '',
   peakPrice: '',
 }

--- a/packages/lib/modules/pool/actions/create/modal/useCreatePoolInput.ts
+++ b/packages/lib/modules/pool/actions/create/modal/useCreatePoolInput.ts
@@ -5,6 +5,7 @@ import { PERCENTAGE_DECIMALS, DEFAULT_DECIMALS } from '../constants'
 import { getNetworkConfig, getGqlChain } from '@repo/lib/config/app.config'
 import { invertNumber } from '@repo/lib/shared/utils/numbers'
 import { CreatePoolInput } from '../types'
+import { calculateRotationComponents } from '../steps/details/gyro.helpers'
 
 export function useCreatePoolInput(chainId: number): CreatePoolInput {
   const { poolCreationForm, autoRangeConfigForm, eclpConfigForm } = usePoolCreationForm()
@@ -113,7 +114,8 @@ export function useCreatePoolInput(chainId: number): CreatePoolInput {
   }
 
   if (poolType === PoolType.GyroE) {
-    const { alpha, beta, s, c, lambda } = eclpConfigForm.getValues()
+    const { alpha, beta, peakPrice, lambda } = eclpConfigForm.getValues()
+    const { c, s } = calculateRotationComponents(peakPrice || '')
 
     // The SDK's normalizeEclpParamsAndTokens handles token sorting and param inversion
     const eclpParams = {

--- a/packages/lib/modules/pool/actions/create/preview/usePreviewEclpLiquidityProfile.ts
+++ b/packages/lib/modules/pool/actions/create/preview/usePreviewEclpLiquidityProfile.ts
@@ -5,6 +5,7 @@ import { bn } from '@repo/lib/shared/utils/numbers'
 import { usePoolSpotPriceWithoutRate } from '../steps/details/usePoolSpotPriceWithoutRate'
 import { isGyroEllipticPool } from '../helpers'
 import { useWatch } from 'react-hook-form'
+import { calculateRotationComponents } from '../steps/details/gyro.helpers'
 
 export function usePreviewEclpLiquidityProfile(): ECLPLiquidityProfile {
   const { eclpConfigForm, poolCreationForm } = usePoolCreationForm()
@@ -20,10 +21,12 @@ export function usePreviewEclpLiquidityProfile(): ECLPLiquidityProfile {
 
   const priceRateRatio = bn(rateTokenA).div(bn(rateTokenB))
 
-  const [alpha, beta, s, c, lambda] = useWatch({
+  const [alpha, beta, peakPrice, lambda] = useWatch({
     control: eclpConfigForm.control,
-    name: ['alpha', 'beta', 's', 'c', 'lambda'],
+    name: ['alpha', 'beta', 'peakPrice', 'lambda'],
   })
+
+  const { c, s } = calculateRotationComponents(peakPrice || '')
 
   const tokenRateScalingFactorString = '1'
 

--- a/packages/lib/modules/pool/actions/create/steps/details/GyroEclpConfiguration.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/GyroEclpConfiguration.tsx
@@ -51,9 +51,9 @@ function EclpParamInputs() {
   const suggestedEclpConfig = useSuggestedGyroEclpConfig()
   const { eclpConfigForm, poolCreationForm } = usePoolCreationForm()
   const poolTokens = useWatch({ control: poolCreationForm.control, name: 'poolTokens' })
-  const [alpha, beta, peakPrice, lambda, c, s] = useWatch({
+  const [alpha, beta, peakPrice, lambda] = useWatch({
     control: eclpConfigForm.control,
-    name: ['alpha', 'beta', 'peakPrice', 'lambda', 'c', 's'],
+    name: ['alpha', 'beta', 'peakPrice', 'lambda'],
   })
 
   const tokenPricePair = poolTokens
@@ -61,12 +61,8 @@ function EclpParamInputs() {
     .filter(Boolean)
     .join(' / ')
 
-  // peak price is used to calculate c and s
-  useEffect(() => {
-    const { c, s } = calculateRotationComponents(peakPrice || '')
-    eclpConfigForm.setValue('c', c, { shouldValidate: true })
-    eclpConfigForm.setValue('s', s, { shouldValidate: true })
-  }, [peakPrice])
+  // c and s are derived from peakPrice, computed directly to avoid effect-based mirroring
+  const { c, s } = calculateRotationComponents(peakPrice || '')
 
   // reset init amounts when eclp params change
   useEffect(() => {

--- a/packages/lib/modules/pool/actions/create/steps/details/useSuggestedGyroEclpConfig.ts
+++ b/packages/lib/modules/pool/actions/create/steps/details/useSuggestedGyroEclpConfig.ts
@@ -1,7 +1,6 @@
 import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { usePoolSpotPriceWithoutRate } from './usePoolSpotPriceWithoutRate'
 import { useEffect } from 'react'
-import { calculateRotationComponents } from './gyro.helpers'
 import { fNumCustom } from '@repo/lib/shared/utils/numbers'
 import { NUM_FORMAT } from '../../constants'
 import { useWatch } from 'react-hook-form'
@@ -14,15 +13,12 @@ export function useSuggestedGyroEclpConfig() {
   const formValues = useWatch({ control: eclpConfigForm.control })
   const isEmptyEclpConfig = Object.values(formValues).every(value => value === '')
 
-  const { c, s } = calculateRotationComponents(spotPriceWithoutRate.toString())
   const alpha = fNumCustom(spotPriceWithoutRate.times(1 - BOUNDARY_FACTOR), NUM_FORMAT)
   const beta = fNumCustom(spotPriceWithoutRate.times(1 + BOUNDARY_FACTOR), NUM_FORMAT)
 
   const suggestedEclpConfig = {
     alpha,
     beta,
-    c,
-    s,
     lambda: '100',
     peakPrice: fNumCustom(spotPriceWithoutRate, NUM_FORMAT),
   }

--- a/packages/lib/modules/pool/actions/create/steps/details/useValidateEclpParams.ts
+++ b/packages/lib/modules/pool/actions/create/steps/details/useValidateEclpParams.ts
@@ -5,14 +5,17 @@ import { parseUnits } from 'viem'
 import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { DEFAULT_DECIMALS } from '../../constants'
 import { useWatch } from 'react-hook-form'
+import { calculateRotationComponents } from './gyro.helpers'
 
 export function useValidateEclpParams() {
   const { eclpConfigForm, poolCreationForm } = usePoolCreationForm()
   const poolType = useWatch({ control: poolCreationForm.control, name: 'poolType' })
-  const [alpha, beta, c, s, lambda] = useWatch({
+  const [alpha, beta, peakPrice, lambda] = useWatch({
     control: eclpConfigForm.control,
-    name: ['alpha', 'beta', 'c', 's', 'lambda'],
+    name: ['alpha', 'beta', 'peakPrice', 'lambda'],
   })
+
+  const { c, s } = calculateRotationComponents(peakPrice || '')
 
   const errorMessage = useMemo(() => {
     if (poolType !== PoolType.GyroE) return null

--- a/packages/lib/modules/pool/actions/create/steps/fund/useGyroEclpInitAmountsRatio.ts
+++ b/packages/lib/modules/pool/actions/create/steps/fund/useGyroEclpInitAmountsRatio.ts
@@ -2,6 +2,7 @@ import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { usePoolSpotPriceWithoutRate } from '../details/usePoolSpotPriceWithoutRate'
 import { isGyroEllipticPool } from '../../helpers'
 import { useWatch } from 'react-hook-form'
+import { calculateRotationComponents } from '../details/gyro.helpers'
 
 export function useGyroEclpInitAmountsRatio() {
   const { spotPriceWithoutRate, rateTokenA, rateTokenB, isRateLoading } =
@@ -12,8 +13,9 @@ export function useGyroEclpInitAmountsRatio() {
 
   const alpha = Number(eclpParams.alpha)
   const beta = Number(eclpParams.beta)
-  const c = Number(eclpParams.c)
-  const s = Number(eclpParams.s)
+  const { c: cStr, s: sStr } = calculateRotationComponents(eclpParams.peakPrice || '')
+  const c = Number(cStr)
+  const s = Number(sStr)
   const lambda = Number(eclpParams.lambda)
   const rateA = Number(rateTokenA)
   const rateB = Number(rateTokenB)

--- a/packages/lib/modules/pool/actions/create/types.ts
+++ b/packages/lib/modules/pool/actions/create/types.ts
@@ -79,8 +79,6 @@ export type AutoRangeConfig = {
 export type EclpConfigForm = {
   alpha: string
   beta: string
-  c: string
-  s: string
   lambda: string
   peakPrice: string
 }

--- a/packages/lib/modules/pool/actions/create/useUninitializedPool.ts
+++ b/packages/lib/modules/pool/actions/create/useUninitializedPool.ts
@@ -329,8 +329,6 @@ export function useUninitializedPool() {
     return {
       alpha,
       beta,
-      c,
-      s,
       lambda,
       peakPrice: calculatePeakPrice({ c, s }),
     }


### PR DESCRIPTION
Part of #2076 — split from #2537

## Summary

Remove `c` and `s` from `EclpConfigForm` type and `INITIAL_ECLP_CONFIG`. These rotation components are now derived from `peakPrice` via `calculateRotationComponents` at each call site (payload creation, liquidity profile preview, validation, init amounts ratio, suggested config).

This eliminates the `useEffect` in `GyroEclpConfiguration` that mirrored `peakPrice`-derived `c`/`s` values back into form state — a state-mirroring violation per React's set-state-in-effect lint rule.

## Files

- `types.ts` — remove `c`, `s` from `EclpConfigForm`
- `constants.ts` — remove `c`, `s` from `INITIAL_ECLP_CONFIG`
- `PoolCreationFormProvider.tsx` — stop swapping `s`/`c` in `invertGyroEclpPriceParams`
- `PoolCreationFormProvider.integration.spec.tsx` — update test expectations
- `GyroEclpConfiguration.tsx` — derive `c`/`s` inline instead of `useEffect` mirroring
- `useValidateEclpParams.ts` — derive `c`/`s` via `useMemo`
- `useSuggestedGyroEclpConfig.ts` — stop setting `c`/`s` in suggested config
- `useCreatePoolInput.ts` — derive `c`/`s` at payload creation
- `usePreviewEclpLiquidityProfile.ts` — derive `c`/`s` from `peakPrice`
- `useGyroEclpInitAmountsRatio.ts` — derive `c`/`s` from `peakPrice`
- `useUninitializedPool.ts` — stop returning `c`/`s` from on-chain params

## Test plan

This is a refactor — behavior should be unchanged. Verify no regression:

- [x] Start creating a v3 Gyro E-CLP pool
- [x] On the details step, confirm Lower bound price, Upper bound price, Peak price, and Stretching factor are prefilled with suggested values
- [x] Verify the liquidity profile chart renders correctly
- [x] Clear Peak price and confirm the chart/validation handle empty c/s gracefully (no crash, no false error)
- [x] Invert the price params (token order swap) and verify Lower bound price, Upper bound price, and Peak price invert correctly
- [ ] Proceed to the fund step and verify init amounts ratio calculates correctly
- [ ] Submit pool creation and verify the payload includes correct `c` and `s` values derived from `peakPrice`
- [ ] Load an uninitialized Gyro E-CLP pool and verify on-chain params populate the form correctly (without `c`/`s` fields)
