### PR TITLE
refactor(price-impact): lift PriceImpactProvider above liquidity providers, remove setNeedsToAcceptHighPI mirroring

### DIFF
--- a/apps/beets-frontend-v3/app/(app)/mabeets/add-liquidity/[relicId]/[[...txHash]]/layout.tsx
+++ b/apps/beets-frontend-v3/app/(app)/mabeets/add-liquidity/[relicId]/[[...txHash]]/layout.tsx
@@ -3,6 +3,7 @@
 import { PropsWithChildren, use } from 'react'
 import { RelicAddLiquidityProvider } from '@/lib/modules/reliquary/RelicAddLiquidityProvider'
 import { DefaultPageContainer } from '@repo/lib/shared/components/containers/DefaultPageContainer'
+import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { isHash, Hash } from 'viem'
 
 type Props = PropsWithChildren<{
@@ -16,9 +17,11 @@ export default function RelicAddLiquidityLayoutWrapper({ params, children }: Pro
 
   return (
     <DefaultPageContainer>
-      <RelicAddLiquidityProvider relicId={relicId} urlTxHash={urlTxHash}>
-        {children}
-      </RelicAddLiquidityProvider>
+      <PriceImpactProvider>
+        <RelicAddLiquidityProvider relicId={relicId} urlTxHash={urlTxHash}>
+          {children}
+        </RelicAddLiquidityProvider>
+      </PriceImpactProvider>
     </DefaultPageContainer>
   )
 }

--- a/apps/beets-frontend-v3/app/(app)/mabeets/add-liquidity/new/[[...txHash]]/layout.tsx
+++ b/apps/beets-frontend-v3/app/(app)/mabeets/add-liquidity/new/[[...txHash]]/layout.tsx
@@ -3,6 +3,7 @@
 import { PropsWithChildren } from 'react'
 import { RelicAddLiquidityProvider } from '@/lib/modules/reliquary/RelicAddLiquidityProvider'
 import { DefaultPageContainer } from '@repo/lib/shared/components/containers/DefaultPageContainer'
+import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { isHash, Hash } from 'viem'
 
 type Props = PropsWithChildren<{
@@ -15,7 +16,9 @@ export default function RelicAddLiquidityLayoutWrapper({ params: { txHash }, chi
 
   return (
     <DefaultPageContainer>
-      <RelicAddLiquidityProvider urlTxHash={urlTxHash}>{children}</RelicAddLiquidityProvider>
+      <PriceImpactProvider>
+        <RelicAddLiquidityProvider urlTxHash={urlTxHash}>{children}</RelicAddLiquidityProvider>
+      </PriceImpactProvider>
     </DefaultPageContainer>
   )
 }

--- a/apps/beets-frontend-v3/app/(app)/mabeets/remove-liquidity/[relicId]/[[...txHash]]/layout.tsx
+++ b/apps/beets-frontend-v3/app/(app)/mabeets/remove-liquidity/[relicId]/[[...txHash]]/layout.tsx
@@ -5,6 +5,7 @@ import { DefaultPageContainer } from '@repo/lib/shared/components/containers/Def
 import { isHash, Hash } from 'viem'
 import { RelicRemoveLiquidityProvider } from '@/lib/modules/reliquary/RelicRemoveLiquidityProvider'
 import { PermitSignatureProvider } from '@repo/lib/modules/tokens/approvals/permit2/PermitSignatureProvider'
+import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 
 type Props = PropsWithChildren<{
   params: Promise<{ relicId: string; txHash?: string[] }>
@@ -18,9 +19,11 @@ export default function RelicRemoveLiquidityLayoutWrapper({ params, children }: 
   return (
     <DefaultPageContainer>
       <PermitSignatureProvider>
-        <RelicRemoveLiquidityProvider relicId={relicId} urlTxHash={urlTxHash}>
-          {children}
-        </RelicRemoveLiquidityProvider>
+        <PriceImpactProvider>
+          <RelicRemoveLiquidityProvider relicId={relicId} urlTxHash={urlTxHash}>
+            {children}
+          </RelicRemoveLiquidityProvider>
+        </PriceImpactProvider>
       </PermitSignatureProvider>
     </DefaultPageContainer>
   )

--- a/apps/beets-frontend-v3/lib/modules/reliquary/pages/ReliquaryAddLiquidityPage.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/pages/ReliquaryAddLiquidityPage.tsx
@@ -72,7 +72,6 @@ function ReliquaryAddLiquidityForm({ relicId }: { relicId?: string }) {
     showAcceptPoolRisks,
     totalUSDValue,
     addLiquidityTxHash,
-    setNeedsToAcceptHighPI,
     refetchQuote,
     previewModalDisclosure,
     slippage,
@@ -198,7 +197,6 @@ function ReliquaryAddLiquidityForm({ relicId }: { relicId?: string }) {
                 action="add"
                 cannotCalculatePriceImpact={cannotCalculatePriceImpactError(priceImpactQuery.error)}
                 isDisabled={!wantsProportional && !priceImpactQuery.data}
-                setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
               />
             )}
           </VStack>

--- a/apps/beets-frontend-v3/lib/modules/reliquary/pages/ReliquaryRemoveLiquidityPage.tsx
+++ b/apps/beets-frontend-v3/lib/modules/reliquary/pages/ReliquaryRemoveLiquidityPage.tsx
@@ -77,7 +77,6 @@ function ReliquaryRemoveLiquidityForm({ relicId }: { relicId: string }) {
     removeLiquidityTxHash,
     setProportionalType,
     setSingleTokenType,
-    setNeedsToAcceptHighPI,
     tokens,
     humanBptInPercent,
     setHumanBptInPercent,
@@ -223,7 +222,6 @@ function ReliquaryRemoveLiquidityForm({ relicId }: { relicId: string }) {
                 }
                 action="remove"
                 isDisabled={!isProportionalTabSelected && !priceImpactQuery.data}
-                setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
               />
             )}
           </VStack>

--- a/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/AddLiquidityProvider.tsx
@@ -31,6 +31,7 @@ import { useTransactionSteps } from '@repo/lib/modules/transactions/transaction-
 import { useTotalUsdValue } from '@repo/lib/modules/tokens/useTotalUsdValue'
 import { HumanTokenAmountWithSymbol } from '@repo/lib/modules/tokens/token.types'
 import { isUnhandledAddPriceImpactError } from '@repo/lib/modules/price-impact/price-impact.utils'
+import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { useModalWithPoolRedirect } from '../../useModalWithPoolRedirect'
 import { supportsWethIsEth } from '../../pool.helpers'
 import { Pool } from '../../pool.types'
@@ -81,7 +82,6 @@ export function useAddLiquidityLogic(
   )
   // only used by Proportional handlers that require a referenceAmount
   const [referenceAmountAddress, setReferenceAmountAddress] = useState<Address | undefined>()
-  const [needsToAcceptHighPI, setNeedsToAcceptHighPI] = useState(false)
   const [acceptPoolRisks, setAcceptPoolRisks] = useState(false)
   const [wethIsEth, setWethIsEth] = useState(false)
 
@@ -117,6 +117,7 @@ export function useAddLiquidityLogic(
   ]
 
   const { usdValueFor } = useTotalUsdValue(validTokens)
+  const { acceptPriceImpactRisk, hasToAcceptHighPriceImpact, resetPriceImpact } = usePriceImpact()
 
   function setInitialHumanAmountsIn() {
     setHumanAmountsIn(mapTokensToEmptyHumanAmounts(tokens))
@@ -133,6 +134,7 @@ export function useAddLiquidityLogic(
         symbol: token.symbol,
       },
     ])
+    resetPriceImpact()
   }
 
   function clearAmountsIn(changedAmount?: HumanTokenAmountWithSymbol) {
@@ -172,6 +174,8 @@ export function useAddLiquidityLogic(
     humanAmountsIn,
     enabled,
   })
+
+  const needsToAcceptHighPI = hasToAcceptHighPriceImpact && !acceptPriceImpactRisk
 
   const { steps, isLoadingSteps } = useAddLiquiditySteps({
     helpers,
@@ -272,7 +276,6 @@ export function useAddLiquidityLogic(
     setHumanAmountsIn,
     clearAmountsIn,
     setReferenceAmountAddress,
-    setNeedsToAcceptHighPI,
     setAcceptPoolRisks,
     setWethIsEth,
     setWrapUnderlyingByIndex,

--- a/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/form/AddLiquidityForm.tsx
@@ -82,7 +82,6 @@ function AddLiquidityMainForm() {
     showAcceptPoolRisks,
     totalUSDValue,
     addLiquidityTxHash,
-    setNeedsToAcceptHighPI,
     refetchQuote,
     setWethIsEth,
     nativeAsset,
@@ -265,7 +264,6 @@ function AddLiquidityMainForm() {
                 avoidPriceImpactAlert={shouldShowUnbalancedError}
                 cannotCalculatePriceImpact={cannotCalculatePriceImpactError(priceImpactQuery.error)}
                 isDisabled={!wantsProportional && !priceImpactQuery.data}
-                setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
               />
             )}
           </VStack>

--- a/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.spec.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.spec.tsx
@@ -4,7 +4,11 @@ import type { GqlPoolElement } from '@repo/lib/shared/services/api/graphql-deriv
 import { aBalWethPoolElementMock } from '@repo/lib/test/msw/builders/gqlPoolElement.builders'
 import { aUserPoolBalance } from '@repo/lib/test/msw/builders/gqlUserBalance.builders'
 import { mockTokenPricesList } from '@repo/lib/test/msw/handlers/Tokens.handlers'
-import { buildDefaultPoolTestProvider, testHook } from '@repo/lib/test/utils/custom-renderers'
+import {
+  buildDefaultPoolTestProvider,
+  testHook,
+  DefaultRemoveLiquidityTestProvider,
+} from '@repo/lib/test/utils/custom-renderers'
 import { waitFor } from '@testing-library/react'
 import { act } from 'react'
 import { mock } from 'vitest-mock-extended'
@@ -47,8 +51,9 @@ poolMock.dynamicData.totalShares = '100'
 
 async function testUseRemoveLiquidity(pool: GqlPoolElement = poolMock) {
   const { result } = testHook(() => useRemoveLiquidityLogic(), {
-    wrapper: buildDefaultPoolTestProvider(pool),
+    wrapper: buildDefaultPoolTestProvider(pool, DefaultRemoveLiquidityTestProvider),
   })
+
   return result
 }
 
@@ -121,7 +126,7 @@ test('uses custom remove liquidity handler selector and forwards handler to cust
         useRemoveLiquiditySteps
       ),
     {
-      wrapper: buildDefaultPoolTestProvider(poolMock),
+      wrapper: buildDefaultPoolTestProvider(poolMock, DefaultRemoveLiquidityTestProvider),
     }
   )
 

--- a/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/RemoveLiquidityProvider.tsx
@@ -19,6 +19,7 @@ import { emptyTokenAmounts, toHumanAmountWithAddress } from '../LiquidityActionH
 import { isCowAmmPool } from '../../pool.helpers'
 import { getActionableTokenAddresses, getPoolActionableTokens } from '../../pool-tokens.utils'
 import { isWrappedNativeAsset } from '@repo/lib/modules/tokens/token.helpers'
+import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { useRemoveLiquiditySimulationQuery } from './queries/useRemoveLiquiditySimulationQuery'
 import { useRemoveLiquiditySteps as useRemoveLiquidityStepsBase } from './useRemoveLiquiditySteps'
 import { useTransactionSteps } from '@repo/lib/modules/transactions/transaction-steps/useTransactionSteps'
@@ -51,7 +52,6 @@ export function useRemoveLiquidityLogic(
   const [singleTokenAddress, setSingleTokenAddress] = useState<Address | undefined>(undefined)
   const [humanBptInPercent, setHumanBptInPercent] = useState<number>(100)
   const [wethIsEth, setWethIsEth] = useState(false)
-  const [needsToAcceptHighPI, setNeedsToAcceptHighPI] = useState(false)
   const [removalType, setRemovalType] = useState<RemoveLiquidityType>(
     RemoveLiquidityType.Proportional
   )
@@ -60,6 +60,8 @@ export function useRemoveLiquidityLogic(
   const { getNativeAssetToken, getWrappedNativeAssetToken, usdValueForTokenAddress } = useTokens()
   const { isConnected } = useUserAccount()
   const { wrapUnderlying, setWrapUnderlyingByIndex } = useWrapUnderlying(pool)
+  const { acceptPriceImpactRisk, hasToAcceptHighPriceImpact, resetPriceImpact } = usePriceImpact()
+  const needsToAcceptHighPI = hasToAcceptHighPriceImpact && !acceptPriceImpactRisk
 
   const humanBptIn: HumanAmount = bn(maxHumanBptIn ?? getUserWalletBalance(pool))
     .times(humanBptInPercent / 100)
@@ -83,6 +85,17 @@ export function useRemoveLiquidityLogic(
 
   const setProportionalType = () => setRemovalType(RemoveLiquidityType.Proportional)
   const setSingleTokenType = () => setRemovalType(RemoveLiquidityType.SingleToken)
+
+  function setHumanBptInPercentWithReset(percent: number) {
+    setHumanBptInPercent(percent)
+    resetPriceImpact()
+  }
+
+  function setSingleTokenAddressWithReset(address: Address | undefined) {
+    setSingleTokenAddress(address)
+    resetPriceImpact()
+  }
+
   const isSingleToken = removalType === RemoveLiquidityType.SingleToken
   const isProportional = removalType === RemoveLiquidityType.Proportional
 
@@ -290,13 +303,12 @@ export function useRemoveLiquidityLogic(
     removeLiquidityTxSuccess,
     isSingleTokenBalanceMoreThat25Percent,
     setRemovalType,
-    setHumanBptInPercent,
+    setHumanBptInPercent: setHumanBptInPercentWithReset,
     setProportionalType,
     setSingleTokenType,
-    setSingleTokenAddress,
+    setSingleTokenAddress: setSingleTokenAddressWithReset,
     amountOutForToken,
     usdOutForToken,
-    setNeedsToAcceptHighPI,
     setWethIsEth,
     setWrapUnderlyingByIndex,
   }

--- a/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -94,7 +94,6 @@ export function RemoveLiquidityForm() {
     setProportionalType,
     setSingleTokenType,
     setHumanBptInPercent,
-    setNeedsToAcceptHighPI,
     amountsOut,
   } = useRemoveLiquidity()
   const { priceImpactColor, priceImpact, setPriceImpact } = usePriceImpact()
@@ -280,7 +279,6 @@ export function RemoveLiquidityForm() {
                   }
                   action="remove"
                   isDisabled={priceImpactQuery.isLoading && !priceImpactQuery.isSuccess}
-                  setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
                 />
               )}
               {isV3LBP(pool) && (

--- a/packages/lib/modules/price-impact/PriceImpactAccordion.tsx
+++ b/packages/lib/modules/price-impact/PriceImpactAccordion.tsx
@@ -21,13 +21,12 @@ import {
 } from '@chakra-ui/react'
 import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 import { fNum } from '@repo/lib/shared/utils/numbers'
-import { ReactNode, useEffect } from 'react'
+import { ReactNode } from 'react'
 import { PriceImpactAcceptModal } from './PriceImpactAcceptModal'
 import { getPriceImpactLevel } from './price-impact.utils'
 import { CheckIcon } from '@chakra-ui/icons'
 
 interface PriceImpactAccordionProps {
-  setNeedsToAcceptPIRisk: (value: boolean) => void
   accordionButtonComponent: ReactNode
   accordionPanelComponent: ReactNode
   isDisabled?: boolean
@@ -39,7 +38,6 @@ interface PriceImpactAccordionProps {
 }
 
 export function PriceImpactAccordion({
-  setNeedsToAcceptPIRisk,
   accordionButtonComponent,
   accordionPanelComponent,
   isDisabled,
@@ -53,7 +51,6 @@ export function PriceImpactAccordion({
     priceImpactLevel,
     priceImpactColor,
     acceptPriceImpactRisk,
-    hasToAcceptHighPriceImpact,
     setAcceptPriceImpactRisk,
     PriceImpactIcon,
     priceImpact,
@@ -67,14 +64,6 @@ export function PriceImpactAccordion({
     const extremely = level === 'max' ? 'extremely ' : ''
     return `Potential ‘${label}’ loss is ${extremely}high: ${priceImpact && fNum('priceImpact', priceImpact)}`
   }
-
-  useEffect(() => {
-    if ((hasToAcceptHighPriceImpact || isUnknownPriceImpact) && !acceptPriceImpactRisk) {
-      setNeedsToAcceptPIRisk(true)
-    } else {
-      setNeedsToAcceptPIRisk(false)
-    }
-  }, [acceptPriceImpactRisk, hasToAcceptHighPriceImpact, isUnknownPriceImpact])
 
   const handleClick = () => {
     if (priceImpactLevel === 'high') {

--- a/packages/lib/modules/swap/SwapForm.tsx
+++ b/packages/lib/modules/swap/SwapForm.tsx
@@ -94,7 +94,6 @@ export function SwapForm({
     setTokenIn,
     setTokenOut,
     switchTokens,
-    setNeedsToAcceptHighPI,
     resetSwapAmounts,
     replaceUrlPath,
   } = useSwap()
@@ -107,7 +106,7 @@ export function SwapForm({
   const isMounted = useIsMounted()
   const { isConnected } = useUserAccount()
   const { startTokenPricePolling } = useTokens()
-  const { priceImpact, priceImpactColor, priceImpactLevel } = usePriceImpact()
+  const { priceImpact, priceImpactColor, priceImpactLevel, resetPriceImpact } = usePriceImpact()
 
   const isLoadingSwaps = simulationQuery.isLoading
   const isLoading = isLoadingSwaps || !isMounted
@@ -190,6 +189,7 @@ export function SwapForm({
 
     if (swapTxHash) {
       resetSwapAmounts()
+      resetPriceImpact()
       transactionSteps.resetTransactionSteps()
       if (isPoolSwapUrl || isLbpSwap) return redirectToPoolPage?.()
       replaceUrlPath()
@@ -345,7 +345,6 @@ export function SwapForm({
                     action="swap"
                     cowLink={cowLink}
                     isDisabled={!simulationQuery.data}
-                    setNeedsToAcceptPIRisk={setNeedsToAcceptHighPI}
                   />
                 </>
               )}

--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -128,7 +128,6 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
   )
 
   const swapState = useReactiveVar(swapStateVar)
-  const [needsToAcceptHighPI, setNeedsToAcceptHighPI] = useState(false)
   const [tokenSelectKey, setTokenSelectKey] = useState<'tokenIn' | 'tokenOut'>('tokenIn')
   const hasInitializedUserChain = useRef(false)
 
@@ -137,7 +136,9 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
   const { getToken, getTokensByChain, usdValueForToken, isLoadingTokens } = useTokens()
   const { tokens, setTokens } = useTokenBalances()
   const { hasValidationErrors, resetValidationErrors } = useTokenInputsValidation()
-  const { setPriceImpact, resetPriceImpact } = usePriceImpact()
+  const { setPriceImpact, resetPriceImpact, acceptPriceImpactRisk, hasToAcceptHighPriceImpact } =
+    usePriceImpact()
+  const needsToAcceptHighPI = hasToAcceptHighPriceImpact && !acceptPriceImpactRisk
 
   const selectedChain = isPoolSwap ? pool.chain : swapState.selectedChain
   const selectedChainRef = useRef(selectedChain)
@@ -341,6 +342,7 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
       })
       if (state.tokenIn.amount !== newState.tokenIn.amount) {
         setTokenOutAmount('', { userTriggered: false })
+        resetPriceImpact()
       }
     } else {
       // Sometimes we want to set the amount without triggering a fetch or
@@ -393,6 +395,7 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
       })
       if (state.tokenOut.amount !== newState.tokenOut.amount) {
         setTokenInAmount('', { userTriggered: false })
+        resetPriceImpact()
       }
     } else {
       // Sometimes we want to set the amount without triggering a fetch or
@@ -441,6 +444,8 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
         scaledAmount: BigInt(0),
       },
     })
+
+    resetPriceImpact()
   }
 
   function setDefaultTokens() {
@@ -477,10 +482,24 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
   }
 
   function calcPriceImpact() {
-    // Only calculate price impact if both tokens are selected
-    if (isTokenInSet && isTokenOutSet && !bn(tokenInUsd).isZero() && !bn(tokenOutUsd).isZero()) {
-      setPriceImpact(calcMarketPriceImpact(tokenInUsd, tokenOutUsd))
-    } else if (simulationQuery.data) {
+    // Always derive from the latest swap state so stale effects cannot re-apply an old price
+    // impact after the swap state has been reset (e.g. returning to a pool swap page).
+    const currentState = swapStateVar()
+    const currentTokenInInfo = getToken(currentState.tokenIn.address, selectedChain)
+    const currentTokenOutInfo = getToken(currentState.tokenOut.address, selectedChain)
+    const currentTokenInUsd = usdValueForToken(currentTokenInInfo, currentState.tokenIn.amount)
+    const currentTokenOutUsd = usdValueForToken(currentTokenOutInfo, currentState.tokenOut.amount)
+    const currentIsTokenInSet = currentState.tokenIn.address !== emptyAddress
+    const currentIsTokenOutSet = currentState.tokenOut.address !== emptyAddress
+
+    if (
+      currentIsTokenInSet &&
+      currentIsTokenOutSet &&
+      !bn(currentTokenInUsd).isZero() &&
+      !bn(currentTokenOutUsd).isZero()
+    ) {
+      setPriceImpact(calcMarketPriceImpact(currentTokenInUsd, currentTokenOutUsd))
+    } else {
       resetPriceImpact()
     }
   }
@@ -744,7 +763,6 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
     setTokenIn,
     setTokenOut,
     switchTokens,
-    setNeedsToAcceptHighPI,
   }
 }
 

--- a/packages/lib/shared/layouts/AddLiquidityLayout.tsx
+++ b/packages/lib/shared/layouts/AddLiquidityLayout.tsx
@@ -37,9 +37,9 @@ export function AddLiquidityLayout({ txHash, children }: Props) {
         <RelayerSignatureProvider>
           <Permit2SignatureProvider>
             <TokenInputsValidationProvider>
-              <AddLiquidityProvider urlTxHash={urlTxHash}>
-                <PriceImpactProvider>{children}</PriceImpactProvider>
-              </AddLiquidityProvider>
+              <PriceImpactProvider>
+                <AddLiquidityProvider urlTxHash={urlTxHash}>{children}</AddLiquidityProvider>
+              </PriceImpactProvider>
             </TokenInputsValidationProvider>
           </Permit2SignatureProvider>
         </RelayerSignatureProvider>

--- a/packages/lib/shared/pages/RemoveLiquidityPage.tsx
+++ b/packages/lib/shared/pages/RemoveLiquidityPage.tsx
@@ -24,13 +24,13 @@ export function RemoveLiquidityPage({ txHash, redirectPath }: Props) {
       <TransactionStateProvider>
         <RelayerSignatureProvider>
           <PermitSignatureProvider>
-            <RemoveLiquidityProvider urlTxHash={urlTxHash}>
-              <PoolActionsLayout redirectPath={redirectPath}>
-                <PriceImpactProvider>
+            <PriceImpactProvider>
+              <RemoveLiquidityProvider urlTxHash={urlTxHash}>
+                <PoolActionsLayout redirectPath={redirectPath}>
                   <RemoveLiquidityForm />
-                </PriceImpactProvider>
-              </PoolActionsLayout>
-            </RemoveLiquidityProvider>
+                </PoolActionsLayout>
+              </RemoveLiquidityProvider>
+            </PriceImpactProvider>
           </PermitSignatureProvider>
         </RelayerSignatureProvider>
       </TransactionStateProvider>

--- a/packages/lib/test/utils/custom-renderers.tsx
+++ b/packages/lib/test/utils/custom-renderers.tsx
@@ -25,6 +25,7 @@ import { Permit2SignatureProvider } from '@repo/lib/modules/tokens/approvals/per
 import { PermitSignatureProvider } from '@repo/lib/modules/tokens/approvals/permit2/PermitSignatureProvider'
 import { sleep } from '@repo/lib/shared/utils/sleep'
 import { ApolloProvider } from '@apollo/client/react'
+import { PriceImpactProvider } from '@repo/lib/modules/price-impact/PriceImpactProvider'
 
 export type Wrapper = ({ children }: PropsWithChildren) => ReactNode
 
@@ -102,26 +103,33 @@ export async function waitForLoadedUseQuery(hookResult: { current: { loading: bo
 
 export function DefaultAddLiquidityTestProvider({ children }: PropsWithChildren) {
   return (
-    <RelayerSignatureProvider>
-      <Permit2SignatureProvider>
-        <TokenInputsValidationProvider>
-          <AddLiquidityProvider>{children}</AddLiquidityProvider>
-        </TokenInputsValidationProvider>
-      </Permit2SignatureProvider>
-    </RelayerSignatureProvider>
+    <PriceImpactProvider>
+      <RelayerSignatureProvider>
+        <Permit2SignatureProvider>
+          <TokenInputsValidationProvider>
+            <AddLiquidityProvider>{children}</AddLiquidityProvider>
+          </TokenInputsValidationProvider>
+        </Permit2SignatureProvider>
+      </RelayerSignatureProvider>
+    </PriceImpactProvider>
   )
 }
 
 export function DefaultRemoveLiquidityTestProvider({ children }: PropsWithChildren) {
   return (
-    <RelayerSignatureProvider>
-      <RemoveLiquidityProvider>{children}</RemoveLiquidityProvider>
-    </RelayerSignatureProvider>
+    <PriceImpactProvider>
+      <RelayerSignatureProvider>
+        <RemoveLiquidityProvider>{children}</RemoveLiquidityProvider>
+      </RelayerSignatureProvider>
+    </PriceImpactProvider>
   )
 }
 
 /* Builds a PoolProvider that injects the provided pool data*/
-export const buildDefaultPoolTestProvider = (pool: GqlPoolElement = aGqlPoolElementMock()) =>
+export const buildDefaultPoolTestProvider = (
+  pool: GqlPoolElement = aGqlPoolElementMock(),
+  LiquidityProviderWrapper: Wrapper = EmptyWrapper
+) =>
   function ({ children }: PropsWithChildren) {
     return (
       <TransactionStateProvider>
@@ -136,7 +144,7 @@ export const buildDefaultPoolTestProvider = (pool: GqlPoolElement = aGqlPoolElem
               id={pool.id}
               variant={BaseVariant.v2}
             >
-              {children}
+              <LiquidityProviderWrapper>{children}</LiquidityProviderWrapper>
             </PoolProvider>
           </PermitSignatureProvider>
         </RelayerSignatureProvider>


### PR DESCRIPTION
Part of #2076 — split from #2537

## Summary

Lift `PriceImpactProvider` to wrap above `AddLiquidityProvider`, `RemoveLiquidityProvider`, and Relic providers in all layouts and test renderers. Remove `setNeedsToAcceptHighPI` state mirroring from swap, add, and remove providers — derive `needsToAcceptHighPI` from `hasToAcceptHighPriceImpact && !acceptPriceImpactRisk` inside `usePriceImpact` instead. Reset price impact on amount changes and navigation.

## Files

- `AddLiquidityLayout.tsx` — move `PriceImpactProvider` above `AddLiquidityProvider`
- `RemoveLiquidityPage.tsx` — move `PriceImpactProvider` above `RemoveLiquidityProvider`
- 3 beets reliquary layout files — wrap `PriceImpactProvider` around relic providers
- `ReliquaryAddLiquidityPage.tsx` / `ReliquaryRemoveLiquidityPage.tsx` — remove `setNeedsToAcceptHighPI` prop
- `AddLiquidityProvider.tsx` — remove `needsToAcceptHighPI` state, derive from `usePriceImpact`
- `AddLiquidityForm.tsx` — remove `setNeedsToAcceptHighPI` prop usage
- `RemoveLiquidityProvider.tsx` — remove `needsToAcceptHighPI` state, derive from `usePriceImpact`
- `RemoveLiquidityProvider.spec.tsx` — update test setup
- `RemoveLiquidityForm.tsx` — remove `setNeedsToAcceptHighPI` prop usage
- `SwapProvider.tsx` — remove `needsToAcceptHighPI` state, derive from `usePriceImpact`, reset PI on amount changes
- `SwapForm.tsx` — reset price impact on tx hash, remove `setNeedsToAcceptHighPI` prop
- `PriceImpactAccordion.tsx` — remove `setNeedsToAcceptPIRisk` prop
- `custom-renderers.tsx` — wrap test providers with `PriceImpactProvider`

## Test plan

- [x] Add liquidity: trigger high price impact, accept risk, verify button shows checked state
- [x] Add liquidity: change amount after accepting risk, verify risk acceptance resets
- [ ] Remove liquidity: trigger high price impact, accept risk, verify button shows checked state
- [x] Remove liquidity: switch between proportional and single-token, verify PI updates
- [x] Swap: trigger high price impact, accept risk, verify button shows checked state
- [x] Swap: change amount after accepting risk, verify risk acceptance resets
- [x] Swap: complete a transaction, verify PI resets after navigating away and back
- [x] Reliquary add/remove: verify PI accordion works correctly
- [x] Verify no console errors when switching tabs or clearing amounts on any flow