### PR TITLE
fix: skip staking suggestion in add-liquidity flow when gauge has no rewards

### DIFF
--- a/packages/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
+++ b/packages/lib/modules/pool/actions/add-liquidity/modal/AddLiquiditySummary.tsx
@@ -22,6 +22,7 @@ import {
   SlippageSelector,
 } from '../../SlippageSelector'
 import { bn, isZero } from '@repo/lib/shared/utils/numbers'
+import { getCanStake } from '../../stake.helpers'
 
 export function AddLiquiditySummary({
   isLoading: isLoadingReceipt,
@@ -143,7 +144,7 @@ export function AddLiquiditySummary({
         <>
           <GasCostSummaryCard chain={pool.chain} transactionSteps={transactionSteps.steps} />
           <CardPopAnim key="staking-options">
-            {pool.staking && (
+            {pool.staking && getCanStake(pool) && (
               <Box pt="sm">
                 <Divider mb="md" />
                 <StakingOptions />


### PR DESCRIPTION
## Problem

When adding liquidity to a pool that has a gauge deployed, the UI flow directs users to stake to the gauge, even if the gauge is not emitting rewards. The My Liquidity tab correctly disables the Stake button in this case, but the add-liquidity flow still shows the staking suggestion (with a disabled button).

## Root cause

`AddLiquiditySummary.tsx` gated the `StakingOptions` card on `pool.staking` (gauge deployed) but not on whether the gauge actually emits rewards. The check used by the My Liquidity tab — `getCanStake(pool)` in `stake.helpers.ts` — already encapsulates both conditions via `hasActiveGaugeRewards` (checks `pool.staking?.gauge?.rewards` for any `rewardPerSecond > 0`).

## Fix

Gate the `StakingOptions` render on `pool.staking && getCanStake(pool)` instead of just `pool.staking`. This hides the staking suggestion entirely when the gauge has no active rewards, rather than showing a disabled button.

## Testing

- [x] Typecheck passes