### PR TITLE
Fix slippage input reset and persistence

### DIFF
--- a/packages/lib/modules/user/settings/UserSettings.spec.tsx
+++ b/packages/lib/modules/user/settings/UserSettings.spec.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+import { SlippageInput } from './UserSettings'
+
+function StatefulSlippageInput() {
+  const [slippage, setSlippage] = useState('10')
+
+  return <SlippageInput setSlippage={setSlippage} slippage={slippage} />
+}
+
+function DismissibleSlippageInput({ isVisible }: { isVisible: boolean }) {
+  const [slippage, setSlippage] = useState('0.5')
+
+  return (
+    <>
+      <output data-testid="slippage">{slippage}</output>
+      {isVisible && <SlippageInput setSlippage={setSlippage} slippage={slippage} />}
+    </>
+  )
+}
+
+describe('SlippageInput', () => {
+  test('keeps a cleared value local until a valid replacement is entered', () => {
+    const setSlippage = vi.fn()
+
+    render(<SlippageInput setSlippage={setSlippage} slippage="0.5" />)
+
+    const input = screen.getByRole('spinbutton')
+    fireEvent.change(input, { target: { value: '' } })
+
+    expect(input).toHaveValue(null)
+    expect(setSlippage).not.toHaveBeenCalled()
+
+    fireEvent.change(input, { target: { value: '1' } })
+
+    expect(setSlippage).toHaveBeenCalledWith('1')
+  })
+
+  test('keeps focus while deleting a multi-digit value', () => {
+    render(<StatefulSlippageInput />)
+
+    const input = screen.getByRole('spinbutton')
+    input.focus()
+
+    fireEvent.change(input, { target: { value: '1' } })
+
+    const updatedInput = screen.getByRole('spinbutton')
+    expect(updatedInput).toHaveFocus()
+
+    fireEvent.change(updatedInput, { target: { value: '' } })
+
+    expect(screen.getByRole('spinbutton')).toHaveFocus()
+  })
+
+  test('restores the previous slippage when an empty draft is dismissed', () => {
+    const { rerender } = render(<DismissibleSlippageInput isVisible />)
+    const input = screen.getByRole('spinbutton')
+
+    input.focus()
+    fireEvent.change(input, { target: { value: '0' } })
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '' } })
+
+    rerender(<DismissibleSlippageInput isVisible={false} />)
+
+    expect(screen.getByTestId('slippage')).toHaveTextContent('0.5')
+  })
+})

--- a/packages/lib/modules/user/settings/UserSettings.tsx
+++ b/packages/lib/modules/user/settings/UserSettings.tsx
@@ -19,10 +19,11 @@ import {
   Switch,
 } from '@chakra-ui/react'
 import { useUserSettings } from './UserSettingsProvider'
-import { blockInvalidNumberInput } from '@repo/lib/shared/utils/numbers'
+import { blockInvalidNumberInput, bn, isBnParseable } from '@repo/lib/shared/utils/numbers'
 import { Percent, Settings } from 'react-feather'
 import { CurrencySelect } from './CurrencySelect'
 import { EnableTxBundleSetting } from './EnableTxBundlesSetting'
+import { useEffect, useRef, useState } from 'react'
 
 interface SlippageInputProps {
   slippage: string
@@ -31,11 +32,59 @@ interface SlippageInputProps {
 
 export function SlippageInput({ slippage, setSlippage }: SlippageInputProps) {
   const presetOpts = ['0.5', '1', '2']
+  const [inputSlippage, setInputSlippage] = useState(slippage)
+  const [previousSlippage, setPreviousSlippage] = useState(slippage)
+  const inputSlippageRef = useRef(slippage)
+  const slippageBeforeEditingRef = useRef(slippage)
+  const isEditingRef = useRef(false)
+  const setSlippageRef = useRef(setSlippage)
+
+  if (slippage !== previousSlippage) {
+    setPreviousSlippage(slippage)
+    setInputSlippage(slippage)
+  }
+
+  useEffect(() => {
+    setSlippageRef.current = setSlippage
+  }, [setSlippage])
+
+  useEffect(() => {
+    inputSlippageRef.current = inputSlippage
+  }, [inputSlippage])
+
+  useEffect(() => {
+    return () => {
+      if (inputSlippageRef.current === '') {
+        setSlippageRef.current(slippageBeforeEditingRef.current)
+      }
+    }
+  }, [])
+
+  const beginEditing = () => {
+    if (!isEditingRef.current) {
+      slippageBeforeEditingRef.current = slippage
+      isEditingRef.current = true
+    }
+  }
+
+  const restoreEmptyDraft = () => {
+    if (inputSlippageRef.current === '') {
+      const previousSlippage = slippageBeforeEditingRef.current
+      inputSlippageRef.current = previousSlippage
+      setInputSlippage(previousSlippage)
+      setSlippage(previousSlippage)
+    }
+  }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    beginEditing()
     const value = e.currentTarget.value
-    if (parseFloat(value) <= 50 || !value) {
-      setSlippage(value)
+    if (!value || (parseFloat(value) <= 50 && isBnParseable(value))) {
+      inputSlippageRef.current = value
+      setInputSlippage(value)
+      if (value && bn(value).gt(0)) {
+        setSlippage(value)
+      }
     }
   }
 
@@ -52,10 +101,15 @@ export function SlippageInput({ slippage, setSlippage }: SlippageInputProps) {
           bg="background.level1"
           // max={50}
           min={0}
+          onBlur={() => {
+            restoreEmptyDraft()
+            isEditingRef.current = false
+          }}
           onChange={handleChange}
+          onFocus={beginEditing}
           onKeyDown={blockInvalidNumberInput}
           type="number"
-          value={slippage}
+          value={inputSlippage}
         />
         <InputRightElement pointerEvents="none">
           <Percent color="grayText" size="20px" />

--- a/packages/lib/modules/user/settings/UserSettingsProvider.spec.tsx
+++ b/packages/lib/modules/user/settings/UserSettingsProvider.spec.tsx
@@ -1,0 +1,55 @@
+import { LS_KEYS } from '@repo/lib/modules/local-storage/local-storage.constants'
+import { SupportedCurrency } from '@repo/lib/shared/utils/currencies'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { useUserSettingsLogic } from './UserSettingsProvider'
+
+const initialSettings = {
+  initCurrency: SupportedCurrency.USD,
+  initSlippage: '0.5',
+  initEnableSignatures: 'yes' as const,
+  initAcceptedPolicies: [],
+  initAllowSounds: 'yes' as const,
+  initEnableTxBundling: 'yes' as const,
+}
+
+describe('useUserSettingsLogic', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  test('keeps slippage values parseable when the slippage input is cleared', () => {
+    const { result } = renderHook(() => useUserSettingsLogic(initialSettings))
+
+    act(() => {
+      result.current.setSlippage('')
+    })
+
+    expect(result.current.slippage).toBe('0.5')
+    expect(result.current.slippageDecimal).toBe('0.005')
+    expect(result.current.slippageBps).toBe('50')
+    expect(window.localStorage.getItem(LS_KEYS.UserSettings.Slippage)).toBe('"0.5"')
+  })
+
+  test('recovers from an empty persisted slippage value', () => {
+    window.localStorage.setItem(LS_KEYS.UserSettings.Slippage, '""')
+
+    const { result } = renderHook(() => useUserSettingsLogic(initialSettings))
+
+    expect(result.current.slippage).toBe('0.5')
+    expect(result.current.slippageDecimal).toBe('0.005')
+    expect(result.current.slippageBps).toBe('50')
+    expect(window.localStorage.getItem(LS_KEYS.UserSettings.Slippage)).toBe('"0.5"')
+  })
+
+  test('recovers from a zero persisted slippage value', () => {
+    window.localStorage.setItem(LS_KEYS.UserSettings.Slippage, '"0"')
+
+    const { result } = renderHook(() => useUserSettingsLogic(initialSettings))
+
+    expect(result.current.slippage).toBe('0.5')
+    expect(result.current.slippageDecimal).toBe('0.005')
+    expect(result.current.slippageBps).toBe('50')
+    expect(window.localStorage.getItem(LS_KEYS.UserSettings.Slippage)).toBe('"0.5"')
+  })
+})

--- a/packages/lib/modules/user/settings/UserSettingsProvider.tsx
+++ b/packages/lib/modules/user/settings/UserSettingsProvider.tsx
@@ -3,7 +3,7 @@
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { SupportedCurrency } from '@repo/lib/shared/utils/currencies'
 import { PropsWithChildren, createContext, useCallback, useEffect } from 'react'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, isBnParseable } from '@repo/lib/shared/utils/numbers'
 import { useLocalStorage } from 'usehooks-ts'
 import { LS_KEYS } from '../../local-storage/local-storage.constants'
 import { useIsMounted } from '@repo/lib/shared/hooks/useIsMounted'
@@ -23,6 +23,10 @@ const DEFAULT_ENABLE_SIGNATURES: YesNo = 'yes'
 const DEFAULT_ACCEPTED_POLICIES: string[] = []
 const DEFAULT_ALLOW_SOUNDS: YesNo = 'yes'
 const DEFAULT_ENABLE_TX_BUNDLING: YesNo = 'yes'
+
+function isValidSlippage(value: string): boolean {
+  return isBnParseable(value) && bn(value).gt(0)
+}
 
 export type UseUserSettingsResult = ReturnType<typeof useUserSettingsLogic>
 export const UserSettingsContext = createContext<UseUserSettingsResult | null>(null)
@@ -50,7 +54,7 @@ export function useUserSettingsLogic({
   )
   const currency = isMounted ? _currency : initCurrency
 
-  const [_slippage, setSlippage] = useLocalStorage<string>(
+  const [_slippage, setStoredSlippage] = useLocalStorage<string>(
     LS_KEYS.UserSettings.Slippage,
     initSlippage
   )
@@ -68,9 +72,24 @@ export function useUserSettingsLogic({
   )
   const allowSounds = isMounted ? _allowSounds : initAllowSounds
 
-  const slippage = isMounted ? _slippage : initSlippage
+  const fallbackSlippage = isValidSlippage(initSlippage) ? initSlippage : DEFAULT_SLIPPAGE
+  const storedSlippage = isMounted ? _slippage : initSlippage
+  const slippage = isValidSlippage(storedSlippage) ? storedSlippage : fallbackSlippage
   const slippageDecimal = bn(slippage).div(100).toString()
   const slippageBps = bn(slippage).times(100).toString()
+
+  const setSlippage = useCallback(
+    (value: string) => {
+      setStoredSlippage(isValidSlippage(value) ? value : fallbackSlippage)
+    },
+    [fallbackSlippage, setStoredSlippage]
+  )
+
+  useEffect(() => {
+    if (isMounted && _slippage !== slippage) {
+      setStoredSlippage(slippage)
+    }
+  }, [isMounted, _slippage, setStoredSlippage, slippage])
 
   const [_acceptedPoliciesStorage, setAcceptedPoliciesStorage] =
     useLocalStorage<AcceptedPoliciesStorage>(


### PR DESCRIPTION
## Summary

- Treat empty and zero slippage values as invalid and repair persisted settings.
- Keep an editable local draft without losing focus, and restore the pre-edit value when an empty draft is dismissed.
- Add regression coverage for clearing, focus retention, dismissing an empty draft, and persisted empty or zero values.

## Validation

- pnpm --filter @repo/lib exec vitest run modules/user/settings/UserSettings.spec.tsx modules/user/settings/UserSettingsProvider.spec.tsx
- pnpm --filter @repo/lib lint
- pnpm --filter @repo/lib typecheck
- Pre-commit hooks: ESLint, Prettier, and package typecheck