### PR TITLE
Fix malformed persisted LBP numeric values

### DIFF
--- a/packages/lib/modules/lbp/LbpFormProvider.spec.tsx
+++ b/packages/lib/modules/lbp/LbpFormProvider.spec.tsx
@@ -1,0 +1,43 @@
+import { testHook } from '@repo/lib/test/utils/custom-renderers'
+import { clearLocalStorageMock, mockLocalStorage } from '@repo/lib/test/utils/localstorage-mock'
+import { LS_KEYS } from '@repo/lib/modules/local-storage/local-storage.constants'
+import { FiatFxRatesProvider } from '@repo/lib/shared/hooks/FxRatesProvider'
+import { INITIAL_SALE_STRUCTURE } from './constants.lbp'
+import { useLbpFormLogic } from './LbpFormProvider'
+import { waitFor } from '@testing-library/react'
+import { PropsWithChildren } from 'react'
+
+function LbpTestWrapper({ children }: PropsWithChildren) {
+  return <FiatFxRatesProvider data={undefined}>{children}</FiatFxRatesProvider>
+}
+
+vi.mock('next/navigation', async importOriginal => {
+  const actual = await importOriginal<typeof import('next/navigation')>()
+  return {
+    ...actual,
+    usePathname: () => '/lbp/create',
+    useSearchParams: () => new URLSearchParams(),
+  }
+})
+
+beforeEach(() => {
+  mockLocalStorage()
+})
+
+afterAll(() => {
+  clearLocalStorageMock()
+})
+
+test('ignores malformed persisted sale amounts when calculating derived values', async () => {
+  window.localStorage.setItem(
+    LS_KEYS.LbpConfig.SaleStructure,
+    JSON.stringify({ ...INITIAL_SALE_STRUCTURE, saleTokenAmount: '.' })
+  )
+
+  const rendered = testHook(() => useLbpFormLogic(), { wrapper: LbpTestWrapper })
+
+  await waitFor(() => expect(rendered.result.current.saleStructureForm.isHydrated).toBe(true))
+
+  expect(rendered.result.current.launchTokenSeed).toBe(0)
+  expect(rendered.result.current.totalValueRaw).toBe('0')
+})

--- a/packages/lib/modules/lbp/LbpFormProvider.tsx
+++ b/packages/lib/modules/lbp/LbpFormProvider.tsx
@@ -8,7 +8,7 @@ import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 import { LS_KEYS } from '@repo/lib/modules/local-storage/local-storage.constants'
 import { useLocalStorage } from 'usehooks-ts'
 import { useTokenMetadata } from '../tokens/useTokenMetadata'
-import { bn, fNum } from '@repo/lib/shared/utils/numbers'
+import { bn, fNum, isBnParseable } from '@repo/lib/shared/utils/numbers'
 import { Address } from 'viem'
 import { LbpPrice, max, min } from './pool/usePriceInfo'
 import { CustomToken } from '@repo/lib/modules/tokens/token.types'
@@ -115,7 +115,11 @@ export function useLbpFormLogic() {
   const isCollateralNativeAsset =
     (collateralTokenAddress || '').toLowerCase() === tokens.nativeAsset.address.toLowerCase()
 
-  const launchTokenSeed = Number(saleTokenAmount || 0)
+  const hasParseableSaleTokenAmount = isBnParseable(saleTokenAmount)
+  const hasParseableLaunchTokenRate = isBnParseable(launchTokenRate)
+  const safeSaleTokenAmount = hasParseableSaleTokenAmount ? (saleTokenAmount ?? '0') : '0'
+  const safeLaunchTokenRate = hasParseableLaunchTokenRate ? (launchTokenRate ?? '0') : '0'
+  const launchTokenSeed = Number(safeSaleTokenAmount)
 
   const launchTokenMetadata = useTokenMetadata(launchTokenAddress || '', chain)
 
@@ -126,12 +130,12 @@ export function useLbpFormLogic() {
   const collateralTokenPrice = collateralTokenAddress ? priceFor(collateralTokenAddress, chain) : 0
 
   const launchTokenPriceUsd =
-    collateralTokenPrice && launchTokenRate
-      ? bn(launchTokenRate).times(collateralTokenPrice).toString()
+    collateralTokenPrice && hasParseableLaunchTokenRate
+      ? bn(safeLaunchTokenRate).times(collateralTokenPrice).toString()
       : '0'
 
-  const totalValue = saleTokenAmount
-    ? bn(saleTokenAmount).times(launchTokenPriceUsd).toString()
+  const totalValue = hasParseableSaleTokenAmount
+    ? bn(safeSaleTokenAmount).times(launchTokenPriceUsd).toString()
     : '0'
 
   const updatePriceStats = (prices: LbpPrice[]) => {


### PR DESCRIPTION
## Summary
- guard persisted sale amount and launch rate before `bn()` conversions
- fall back to zero-valued derived data for malformed storage

## Tests
- `LbpFormProvider.spec.tsx`