### PR TITLE
ci: split balancer dev e2e tests into two parallel jobs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -141,7 +141,7 @@ jobs:
             ./packages/e2e-tests/playwright-report/
           retention-days: 30
 
-  E2E-Dev-Test-Balancer:
+  E2E-Dev-Test-Balancer-1:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -157,15 +157,41 @@ jobs:
         uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
       - name: Start anvil fork in mainnet
         run: anvil --mnemonic "${{ env.TEST_ACCOUNT_MNEMONIC }}" --fork-url "https://lb.drpc.live/ethereum/${{ env.NEXT_PRIVATE_DRPC_KEY }}" --port 8545 &
-      - name: Run Playwright dev tests (Balancer)
-        run: pnpm test:e2e:dev:bal
+      - name: Run Playwright dev tests (Balancer part 1)
+        run: pnpm test:e2e:dev:bal:1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-dev-report-bal
+          name: playwright-dev-report-bal-1
           path: |
             ./packages/e2e-tests/playwright-report/
           retention-days: 30
+
+    E2E-Dev-Test-Balancer-2:
+      timeout-minutes: 15
+      runs-on: ubuntu-latest
+      container:
+        image: mcr.microsoft.com/playwright:v1.59.1-noble
+      env:
+        NEXT_PUBLIC_PROJECT_ID: balancer
+        PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+      steps:
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        - name: Setup
+          uses: ./.github/actions/setup
+        - name: Set up foundry (includes anvil)
+          uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
+        - name: Start anvil fork in mainnet
+          run: anvil --mnemonic "${{ env.TEST_ACCOUNT_MNEMONIC }}" --fork-url "https://lb.drpc.live/ethereum/${{ env.NEXT_PRIVATE_DRPC_KEY }}" --port 8545 &
+        - name: Run Playwright dev tests (Balancer part 2)
+          run: pnpm test:e2e:dev:bal:2
+        - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+          if: ${{ !cancelled() }}
+          with:
+            name: playwright-dev-report-bal-2
+            path: |
+              ./packages/e2e-tests/playwright-report/
+            retention-days: 30
 
   E2E-Dev-Test-Beets:
     timeout-minutes: 15

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -167,31 +167,31 @@ jobs:
             ./packages/e2e-tests/playwright-report/
           retention-days: 30
 
-    E2E-Dev-Test-Balancer-2:
-      timeout-minutes: 15
-      runs-on: ubuntu-latest
-      container:
-        image: mcr.microsoft.com/playwright:v1.59.1-noble
-      env:
-        NEXT_PUBLIC_PROJECT_ID: balancer
-        PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
-      steps:
-        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        - name: Setup
-          uses: ./.github/actions/setup
-        - name: Set up foundry (includes anvil)
-          uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
-        - name: Start anvil fork in mainnet
-          run: anvil --mnemonic "${{ env.TEST_ACCOUNT_MNEMONIC }}" --fork-url "https://lb.drpc.live/ethereum/${{ env.NEXT_PRIVATE_DRPC_KEY }}" --port 8545 &
-        - name: Run Playwright dev tests (Balancer part 2)
-          run: pnpm test:e2e:dev:bal:2
-        - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-          if: ${{ !cancelled() }}
-          with:
-            name: playwright-dev-report-bal-2
-            path: |
-              ./packages/e2e-tests/playwright-report/
-            retention-days: 30
+  E2E-Dev-Test-Balancer-2:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+    env:
+      NEXT_PUBLIC_PROJECT_ID: balancer
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Set up foundry (includes anvil)
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
+      - name: Start anvil fork in mainnet
+        run: anvil --mnemonic "${{ env.TEST_ACCOUNT_MNEMONIC }}" --fork-url "https://lb.drpc.live/ethereum/${{ env.NEXT_PRIVATE_DRPC_KEY }}" --port 8545 &
+      - name: Run Playwright dev tests (Balancer part 2)
+        run: pnpm test:e2e:dev:bal:2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-dev-report-bal-2
+          path: |
+            ./packages/e2e-tests/playwright-report/
+          retention-days: 30
 
   E2E-Dev-Test-Beets:
     timeout-minutes: 15

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "test:e2e:build:analytics": "turbo test:e2e:build:analytics --ui=stream --log-order=stream --",
     "test:e2e:build:ui:analytics": "turbo test:e2e:build:ui:analytics --ui=stream --log-order=stream --",
     "test:e2e:dev:bal": "NEXT_PUBLIC_E2E_DEV=1 turbo test:e2e:dev:bal --ui=stream --log-order=stream --",
+    "test:e2e:dev:bal:1": "NEXT_PUBLIC_E2E_DEV=1 turbo test:e2e:dev:bal:1 --ui=stream --log-order=stream --",
+    "test:e2e:dev:bal:2": "NEXT_PUBLIC_E2E_DEV=1 turbo test:e2e:dev:bal:2 --ui=stream --log-order=stream --",
     "test:e2e:dev:ui:bal": "NEXT_PUBLIC_E2E_DEV=1 turbo test:e2e:dev:ui:bal --ui=stream --log-order=stream --",
     "test:e2e:dev:beets": "NEXT_PUBLIC_E2E_DEV=1 turbo test:e2e:dev:beets --ui=stream --log-order=stream --",
     "test:e2e:dev:ui:beets": "NEXT_PUBLIC_E2E_DEV=1 turbo test:e2e:dev:ui:beets --ui=stream --log-order=stream --",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -13,6 +13,8 @@
     "test:e2e:build:analytics": "start-server-and-test 'cd ../../ && pnpm start --filter balancer-analytics' 'http://localhost:3002' 'pnpm exec playwright test tests/build/analytics'",
     "test:e2e:build:ui:analytics": "pnpm exec playwright test tests/build/analytics --ui",
     "test:e2e:dev:bal": "NEXT_PUBLIC_E2E_DEV=1 start-server-and-test 'cd ../../ &&  pnpm start --filter frontend-v3' 'http://localhost:3000' 'pnpm exec playwright test tests/dev/balancer'",
+    "test:e2e:dev:bal:1": "NEXT_PUBLIC_E2E_DEV=1 start-server-and-test 'cd ../../ &&  pnpm start --filter frontend-v3' 'http://localhost:3000' 'pnpm exec playwright test tests/dev/balancer/liquidity-operations.spec.ts tests/dev/balancer/swap.spec.ts'",
+    "test:e2e:dev:bal:2": "NEXT_PUBLIC_E2E_DEV=1 start-server-and-test 'cd ../../ &&  pnpm start --filter frontend-v3' 'http://localhost:3000' 'pnpm exec playwright test tests/dev/balancer/create-lbp.spec.ts tests/dev/balancer/create-pool.spec.ts'",
     "test:e2e:dev:ui:bal": "NEXT_PUBLIC_E2E_DEV=1 pnpm exec playwright test tests/dev/balancer --ui",
     "test:e2e:dev:beets": "NEXT_PUBLIC_E2E_DEV=1 start-server-and-test 'cd ../../ &&  pnpm start --filter beets-frontend-v3' 'http://localhost:3001' 'pnpm exec playwright test tests/dev/beets'",
     "test:e2e:dev:ui:beets": "NEXT_PUBLIC_E2E_DEV=1 pnpm exec playwright test tests/dev/beets --ui",

--- a/turbo.json
+++ b/turbo.json
@@ -216,6 +216,26 @@
         "NEXT_E2E_DEV"
       ]
     },
+    "test:e2e:dev:bal:1": {
+      "dependsOn": [
+        "frontend-v3#build"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        ".env*",
+        "NEXT_E2E_DEV"
+      ]
+    },
+    "test:e2e:dev:bal:2": {
+      "dependsOn": [
+        "frontend-v3#build"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        ".env*",
+        "NEXT_E2E_DEV"
+      ]
+    },
     "test:e2e:dev:ui:bal": {
       "cache": false,
       "persistent": true,


### PR DESCRIPTION
## Summary

The balancer dev e2e suite is long-running and prone to timing out on CI. Split it into two parallel jobs to reduce wall-clock time.

## Changes

- **Part 1** (`test:e2e:dev:bal:1`): `liquidity-operations.spec.ts` (7 tests, heaviest) + `swap.spec.ts` (1 test, lightest)
- **Part 2** (`test:e2e:dev:bal:2`): `create-lbp.spec.ts` + `create-pool.spec.ts`

### Files modified
- `packages/e2e-tests/package.json` — added `test:e2e:dev:bal:1` and `test:e2e:dev:bal:2` scripts
- `turbo.json` — added task definitions for both parts
- `package.json` — added root-level turbo wrapper scripts
- `.github/workflows/checks.yml` — replaced single `E2E-Dev-Test-Balancer` job with two parallel jobs

The original `test:e2e:dev:bal` script is preserved for running the full suite locally.

Closes #2591