### PR TITLE
fix: replace TRM Labs with Hypernative in privacy policy

### DIFF
--- a/apps/frontend-v3/app/(marketing)/privacy-policy/page.tsx
+++ b/apps/frontend-v3/app/(marketing)/privacy-policy/page.tsx
@@ -15,7 +15,7 @@ export default function Privacy() {
               <Box mt="3xl">
                 <h1>Balancer Foundation Privacy&nbsp;Policy</h1>
                 <p>
-                  <em>Last Updated: April 2025</em>
+                  <em>Last Updated: August 2026</em>
                 </p>
               </Box>
               <p>
@@ -308,8 +308,8 @@ export default function Privacy() {
                     </p>
 
                     <p>
-                      With our compliance partner, TRM Labs, we only share wallet addresses used to
-                      connect a wallet to our UI (all other user information like IP addresses,
+                      With our compliance partner, Hypernative, we only share wallet addresses used
+                      to connect a wallet to our UI (all other user information like IP addresses,
                       device identifiers and location are not shared). The code for the UI is open
                       source, and can be reviewed by anyone at any time.
                     </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Updates the Balancer privacy policy to name **Hypernative** (not TRM Labs) as the compliance partner for wallet address screening
- Bumps the policy “Last Updated” date to August 2026

Beets already listed Hypernative correctly; this aligns Balancer with the actual Hypernative wallet-check integration used in the app.

## Test plan
- [x] Open `/privacy-policy` on Balancer and confirm the Identifiers section mentions Hypernative
- [x] Confirm no remaining TRM Labs references in the privacy policy
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://balancerecosystem.slack.com/archives/C02F9EMRKQA/p1785923395011379?thread_ts=1785923395.011379&cid=C02F9EMRKQA)

<div><a href="https://cursor.com/agents/bc-06568156-22ec-5d94-95af-61dc565cc605?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06568156-22ec-5d94-95af-61dc565cc605&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

