### PR TITLE
feat: add link to legacy.balancer.fi in portfolio table

### DIFF
--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   useBreakpointValue,
   VStack,
+  Link,
 } from '@chakra-ui/react'
 import FadeInOnView from '@repo/lib/shared/components/containers/FadeInOnView'
 import { useUserAccount } from '../../web3/UserAccountProvider'
@@ -215,6 +216,13 @@ export function PortfolioTable() {
             </Text>
           </Checkbox>
         )}
+        <Text color="font.secondary" fontSize="sm">
+          Any positions for legacy chains can be found on{' '}
+          <Link href="https://legacy.balancer.fi" isExternal textDecoration="underline">
+            legacy.balancer.fi
+          </Link>
+          .
+        </Text>
       </VStack>
     </FadeInOnView>
   )


### PR DESCRIPTION
Closes #2625

Adds a muted footer note in the portfolio table pointing users to legacy.balancer.fi for positions on legacy chains.

Deprecated chains (Mode, Fraxtal, zkEVM) are fully removed from the app (see #2624) and no positions on those chains are retrieved from the API. We have no way to detect positions on those chains without a full wallet scan, so the link is shown to all users unconditionally — it does not depend on `isChainDeprecated`.