### PR TITLE
chore: add PR template and AGENTS.md PR guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+## What
+
+What changes did you make at a high level?
+
+<!-- Examples:
+- Added...
+- Updated...
+- Refactored...
+- Moved...
+-->
+
+## Why
+
+Why are these changes helpful or necessary?
+
+<!-- Examples:
+- New feature requested...
+- Refactoring in preparation for...
+- Addressing design feedback...
+- Fast-follow to previous PR...
+-->
+
+## Test Steps
+
+What are all the steps to testing your code changes?
+
+<!-- Examples:
+- [ ] Enable `feature_flag`
+- [ ] Go to this page: /a-test-page
+- [ ] Simulate "Browser Feature"
+- [ ] Scroll to "Example Section Name"
+- [ ] It should show...
+- [ ] Activate the "Example Button" button
+- [ ] You should see...
+- [ ] Wait for the page to load...
+-->
+
+## Risks / Breaking Changes
+
+What could this change break? Anything reviewers should test or watch for?
+
+<!-- Examples:
+- Changes token decimals handling — affects all swap/pool flows
+- Migration required for existing users
+- Behind feature flag: <flag_name>
+-->
+
+## Other Notes
+
+What, if anything, hasn't been addressed in these code changes but should be in future changes?
+
+<!-- Examples:
+- ABC wasn't working as expected...
+- XYZ needs more research...
+- A fast-follow PR is already planned for addressing 1, 2, 3...
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,26 @@ pnpm workspaces + Turborepo. Both `apps/frontend-v3` (Balancer) and `apps/beets-
 - **URL state**: `nuqs` for query-string-based state management.
 - **Pool types**: Weighted, Stable, CowAmm, LBP, AutoRange, ECLP — each with specific UI and action handlers.
 
+## Pull Requests
+
+When creating a PR, read `.github/pull_request_template.md` and fill in every section. The `<!-- -->` blocks in the template are examples — treat them as guidance for tone and format, but strip them from the final PR body. Do not leave placeholder text, empty sections, or `...` in the body.
+
+Use `gh pr create --title ... --body ...` with a fully populated body. Do not rely on the interactive editor.
+
+### Section guidance
+
+- **What** — Summarize the diff at a high level, one bullet per logical change: `- Added...`, `- Updated...`, `- Refactored...`, `- Moved...`. Do not restate every file; group related changes.
+- **Why** — Ground the motivation in something concrete: a requested feature, design feedback, a fast-follow fix, or preparation for a planned change. If the change was requested in an issue/ticket, reference it here.
+- **Test Steps** — List concrete manual verification steps a reviewer can follow, one checkbox per step. Include the feature flag to enable (if any), the page/route to visit, and the expected result. If the change has no manual surface, say so explicitly instead of leaving it blank.
+- **Risks / Breaking Changes** — Call out anything that could regress: changed token decimals or balances handling, migration requirements, changes behind a feature flag (name the flag), dependency bumps, or anything touching shared `packages/lib` code that also serves the Beets app.
+- **Other Notes** — Only if genuinely applicable: known limitations, follow-up work, or things deliberately left out of this change. Omit the section entirely if there is nothing to note.
+
+### Rules
+
+- Verify each claim against the actual diff — do not invent test steps, flags, or risks. If you did not change it, do not describe it.
+- If the PR touches `packages/lib`, note in **Risks** whether the change affects the other app (Balancer ↔ Beets) via `NEXT_PUBLIC_PROJECT_ID`.
+- Always write test steps you could actually run — no generic filler.
+
 ## Testing
 
 Vitest across all packages. Integration tests live in `packages/lib` and use a separate config.


### PR DESCRIPTION
## What

- Added `.github/pull_request_template.md` with sections: What, Why, Test Steps, Risks / Breaking Changes, Other Notes
- Example bullets live in HTML comments (`<!-- -->`) so they guide the author while editing but don't render in the final description
- Added a `## Pull Requests` section to `AGENTS.md` so coding agents fill every template section, strip example comments, and verify test steps against the actual diff

## Why

- PR descriptions lacked a consistent structure, making reviews slower
- The template constrains humans; AGENTS.md constrains agents, which otherwise skip the template when creating PRs via `gh pr create`

## Test Steps

- [ ] Open a new PR in the web UI and confirm the template auto-fills with the five sections
- [ ] Confirm the `<!-- -->` example blocks are visible in the editor but hidden once rendered
- [ ] Ask an agent to create a PR and confirm it reads AGENTS.md and produces a populated description

## Risks / Breaking Changes

- None. Docs/config only — no runtime code touched. PR template is inert until a PR is opened.