### PR TITLE
feat: manual iOS smoke test workflow for pool list crash

### DIFF
--- a/.github/workflows/ios-smoke-test.yml
+++ b/.github/workflows/ios-smoke-test.yml
@@ -1,0 +1,40 @@
+name: iOS Smoke Test
+
+# Manual only — run from the Actions tab. Not part of regular PR CI.
+on:
+  workflow_dispatch:
+
+env:
+  NEXT_PUBLIC_BALANCER_API_URL: https://test-api-v3.balancer.fi/graphql
+  NEXT_PUBLIC_WALLET_CONNECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_ID }}
+  NEXT_PRIVATE_ALCHEMY_KEY: ${{ secrets.PRIVATE_ALCHEMY_KEY }}
+  NEXT_PRIVATE_DRPC_KEY: ${{ secrets.PRIVATE_DRPC_KEY }}
+  NEXT_PUBLIC_PROJECT_ID: balancer
+
+jobs:
+  ios-smoke:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Install Playwright WebKit
+        working-directory: packages/e2e-tests
+        run: pnpm exec playwright install webkit
+      - name: Build frontend
+        run: pnpm build --filter frontend-v3
+      - name: Run iOS smoke tests (WebKit / iPhone 13 profile)
+        working-directory: packages/e2e-tests
+        run: |
+          pnpm exec start-server-and-test \
+            'cd ../../ && pnpm start --filter frontend-v3' \
+            'http://localhost:3000' \
+            'pnpm run test:e2e:ios'
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-ios-report
+          path: |
+            ./packages/e2e-tests/playwright-report/
+          retention-days: 30

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -18,7 +18,8 @@
     "test:e2e:dev:ui:bal": "NEXT_PUBLIC_E2E_DEV=1 pnpm exec playwright test tests/dev/balancer --ui",
     "test:e2e:dev:beets": "NEXT_PUBLIC_E2E_DEV=1 start-server-and-test 'cd ../../ &&  pnpm start --filter beets-frontend-v3' 'http://localhost:3001' 'pnpm exec playwright test tests/dev/beets'",
     "test:e2e:dev:ui:beets": "NEXT_PUBLIC_E2E_DEV=1 pnpm exec playwright test tests/dev/beets --ui",
-    "test:e2e:local": "pnpm exec playwright test tests"
+    "test:e2e:local": "pnpm exec playwright test tests",
+    "test:e2e:ios": "pnpm exec playwright test tests/ios --config=playwright.ios.config.ts"
   },
   "keywords": [],
   "author": "",

--- a/packages/e2e-tests/playwright.ios.config.ts
+++ b/packages/e2e-tests/playwright.ios.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test'
+import { config } from 'dotenv'
+import { resolve } from 'path'
+
+config({ path: resolve(__dirname, '.env.local') })
+
+/**
+ * Manual iOS smoke test — run via `pnpm --filter e2e-tests test:e2e:ios`.
+ *
+ * Uses Playwright's WebKit engine (the same engine family as Safari) with an
+ * iPhone 13 device profile. This is the closest free proxy to the iOS Safari
+ * crash reported in https://github.com/balancer/frontend-monorepo/issues/1457
+ * that runs on macOS CI without the Xcode simulator.
+ *
+ * Not part of the default CI suite — only triggered via workflow_dispatch.
+ */
+export default defineConfig({
+  testDir: './tests/ios',
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 1 : 0,
+  /* WebKit builds are heavy; keep it single-threaded */
+  workers: 1,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    /* Collect trace when retrying the failed test */
+    trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
+  },
+  globalTimeout: 15 * 60 * 1000,
+  timeout: 1.5 * 60 * 1000,
+  expect: { timeout: 60 * 1000 },
+  projects: [
+    {
+      name: 'Mobile Safari (iPhone 13)',
+      use: { ...devices['iPhone 13'] },
+    },
+  ],
+})

--- a/packages/e2e-tests/tests/ios/bal.pools.spec.ts
+++ b/packages/e2e-tests/tests/ios/bal.pools.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test'
+
+const pageSizes = [10, 20, 30, 40, 50]
+
+test('Balancer: pools page handles all page sizes on mobile Safari', async ({ page }) => {
+  const pageErrors: string[] = []
+  page.on('pageerror', err => pageErrors.push(err.message))
+
+  await page.goto('http://localhost:3000/pools')
+  await expect(page.getByRole('heading', { name: 'Liquidity pools' }).first()).toBeVisible()
+
+  // Chakra Select renders a native <select> whose options are "Show 10".."Show 50"
+  const showSelect = page.locator('select').filter({ hasText: 'Show' })
+
+  for (const size of pageSizes) {
+    await showSelect.selectOption({ label: `Show ${size}` })
+    await expect(showSelect).toHaveValue(String(size))
+
+    // The pool list should still be alive after changing page size — a crash
+    // (issue #1457) would blow away the page here and time out the asserts.
+    await expect(page.getByRole('heading', { name: 'Liquidity pools' }).first()).toBeVisible()
+    await page.waitForTimeout(500)
+  }
+
+  expect(pageErrors).toEqual([])
+})


### PR DESCRIPTION
## Summary

Adds a manual-only GitHub Actions workflow that reproduces the iOS Safari pool list crash from #1457 in CI.

**Why WebKit:** Playwright's WebKit engine is the same engine family as Safari — the closest free proxy to iOS Safari that runs on macOS runners. The workflow lives on `macos-latest`, so swapping to the real Xcode simulator later is a drop-in change.

**Manual only:** `on: workflow_dispatch` — never runs on PRs or pushes. Trigger from the Actions tab → *iOS Smoke Test* → *Run workflow*.

## Changes

- **`.github/workflows/ios-smoke-test.yml`** — macos job: checkout → setup → install WebKit → build `frontend-v3` → start server → run test → upload Playwright report on failure. Same pinned action SHAs and env as `checks.yml`.
- **`packages/e2e-tests/playwright.ios.config.ts`** — standalone config: iPhone 13 device profile on WebKit, single worker, `tests/ios` dir.
- **`packages/e2e-tests/tests/ios/bal.pools.spec.ts`** — repro: load `/pools`, cycle Show 10→50, assert heading still alive and zero `pageerror` events.
- **`packages/e2e-tests/package.json`** — `test:e2e:ios` script.

## Verification

- YAML lint passes; config loads; test passes locally against dev API in WebKit (1 passed, 16s).
- The crash did **not** reproduce on Playwright's WebKit on Linux — suggests it's real-iOS/hardware specific. The macOS runner run is the real check.

Refs: #1457
