### PR TITLE
chore: add GitHub Actions workflow to auto-retry failed runs

### DIFF
--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -1,0 +1,22 @@
+name: retry
+on:
+  workflow_run:
+    workflows: ['**']
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  retry:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 && github.event.workflow_run.name != 'retry' }}
+    permissions:
+      actions: write
+    steps:
+      - name: Retry failed workflow
+        run: |
+          echo "Retrying workflow: ${{ github.event.workflow_run.name }} (run ${{ github.event.workflow_run.id }})"
+          gh run rerun "${{ github.event.workflow_run.id }}" --repo "${{ github.event.repository.full_name }}" --failed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add .github/workflows/retry.yml that triggers on workflow_run completion events for the main branch. When a workflow fails on its first attempt, automatically reruns only the failed jobs using the GitHub CLI. Excludes the retry workflow itself from triggering to prevent infinite loops.