### PR TITLE
chore(deps): remove dead npm dependencies (lokijs, deepmerge, @layerzerolabs/scan-client, @chakra-ui/next-js, graphql-request)

### DIFF
--- a/apps/beets-frontend-v3/next.config.ts
+++ b/apps/beets-frontend-v3/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from 'next'
 
 /** @type {import('next').NextConfig} */
 const config: NextConfig = {
-  serverExternalPackages: ['thread-stream', 'real-require', 'lokijs', 'encoding'],
+  serverExternalPackages: ['thread-stream', 'real-require', 'encoding'],
   logging: {
     fetches: {
       fullUrl: true,

--- a/apps/beets-frontend-v3/package.json
+++ b/apps/beets-frontend-v3/package.json
@@ -63,8 +63,7 @@
     "babel-plugin-react-compiler": "1.0.0",
     "concurrently": "10.0.4",
     "cross-fetch": "4.1.0",
-    "eslint": "9.39.5",
-    "lokijs": "1.5.12"
+    "eslint": "9.39.5"
   },
   "engines": {
     "node": "24.x"

--- a/apps/frontend-v3/next.config.ts
+++ b/apps/frontend-v3/next.config.ts
@@ -4,7 +4,7 @@ import type { NextConfig } from 'next'
 
 /** @type {import('next').NextConfig} */
 const nextConfig: NextConfig = {
-  serverExternalPackages: ['thread-stream', 'real-require', 'lokijs', 'encoding'],
+  serverExternalPackages: ['thread-stream', 'real-require', 'encoding'],
   logging: {
     fetches: {
       fullUrl: true,

--- a/apps/frontend-v3/package.json
+++ b/apps/frontend-v3/package.json
@@ -77,7 +77,6 @@
     "concurrently": "10.0.4",
     "cross-fetch": "4.1.0",
     "eslint": "9.39.5",
-    "lokijs": "1.5.12",
     "prool": "0.2.14"
   },
   "engines": {

--- a/apps/frontend-v3/package.json
+++ b/apps/frontend-v3/package.json
@@ -32,7 +32,6 @@
     "@chakra-ui/icons": "2.2.4",
     "@chakra-ui/react": "2.10.10",
     "@chakra-ui/theme-tools": "2.2.6",
-    "@layerzerolabs/scan-client": "^0.0.8",
     "@nikolovlazar/chakra-ui-prose": "^1.2.1",
     "@repo/lib": "workspace:*",
     "@repo/test": "workspace:*",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -56,7 +56,6 @@
     "echarts": "6.1.0",
     "echarts-for-react": "3.0.6",
     "graphql": "16.14.2",
-    "graphql-request": "7.4.0",
     "graphql-tag": "^2.12.6",
     "lodash": "4.18.1",
     "mockdate": "3.0.5",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -114,7 +114,6 @@
     "autoprefixer": "10.5.4",
     "cross-fetch": "4.1.0",
     "eslint": "9.39.5",
-    "lokijs": "1.5.12",
     "msw": "2.15.0",
     "prool": "0.2.14",
     "sentry-testkit": "7.2.1"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -38,7 +38,6 @@
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@hookform/resolvers": "5.5.8",
-    "@layerzerolabs/scan-client": "^0.0.8",
     "@nikolovlazar/chakra-ui-prose": "^1.2.1",
     "@nktkas/hyperliquid": "0.23.1",
     "@rainbow-me/rainbowkit": "2.2.11",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -29,7 +29,6 @@
     "@chakra-ui/clickable": "^2.1.0",
     "@chakra-ui/hooks": "2.4.2",
     "@chakra-ui/icons": "2.2.4",
-    "@chakra-ui/next-js": "2.4.2",
     "@chakra-ui/react": "2.10.10",
     "@chakra-ui/theme-tools": "2.2.6",
     "@coinbase/wallet-sdk": "4.3.7",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -54,7 +54,6 @@
     "bignumber.js": "11.1.5",
     "chakra-react-select": "5.1.1",
     "date-fns": "4.4.0",
-    "deepmerge": "^4.3.1",
     "echarts": "6.1.0",
     "echarts-for-react": "3.0.6",
     "graphql": "16.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,9 +628,6 @@ importers:
       graphql:
         specifier: 16.14.2
         version: 16.14.2
-      graphql-request:
-        specifier: 7.4.0
-        version: 7.4.0(graphql@16.14.2)
       graphql-tag:
         specifier: ^2.12.6
         version: 2.12.7(graphql@16.14.2)
@@ -6620,11 +6617,6 @@ packages:
     peerDependenciesMeta:
       cosmiconfig-toml-loader:
         optional: true
-
-  graphql-request@7.4.0:
-    resolution: {integrity: sha512-xfr+zFb/QYbs4l4ty0dltqiXIp07U6sl+tOKAb0t50/EnQek6CVVBLjETXi+FghElytvgaAWtIOt3EV7zLzIAQ==}
-    peerDependencies:
-      graphql: 14 - 16
 
   graphql-tag@2.12.7:
     resolution: {integrity: sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q==}
@@ -16783,11 +16775,6 @@ snapshots:
       - crossws
       - typescript
       - utf-8-validate
-
-  graphql-request@7.4.0(graphql@16.14.2):
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
-      graphql: 16.14.2
 
   graphql-tag@2.12.7(graphql@16.14.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,9 +318,6 @@ importers:
       '@chakra-ui/theme-tools':
         specifier: 2.2.6
         version: 2.2.6(@chakra-ui/styled-system@2.12.0(react@19.2.8))(react@19.2.8)
-      '@layerzerolabs/scan-client':
-        specifier: ^0.0.8
-        version: 0.0.8(axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2))
       '@nikolovlazar/chakra-ui-prose':
         specifier: ^1.2.1
         version: 1.2.1(@chakra-ui/react@2.10.10(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@chakra-ui/system@2.6.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react@19.2.8)
@@ -583,9 +580,6 @@ importers:
       '@hookform/resolvers':
         specifier: 5.5.8
         version: 5.5.8(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(react-hook-form@7.83.0(react@19.2.8))(zod@3.25.76)
-      '@layerzerolabs/scan-client':
-        specifier: ^0.0.8
-        version: 0.0.8(axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2))
       '@nikolovlazar/chakra-ui-prose':
         specifier: ^1.2.1
         version: 1.2.1(@chakra-ui/react@2.10.10(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@chakra-ui/system@2.6.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react@19.2.8)
@@ -2976,11 +2970,6 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
-
-  '@layerzerolabs/scan-client@0.0.8':
-    resolution: {integrity: sha512-V9vvt9GW0+AHoWXfOSNmZ9WUa28fVBmC93J/f9RLeDMEy5VR8srW2Du5pf1mMAg6ncEL0kQ1xkVCu+X6ARFBtQ==}
-    peerDependencies:
-      axios: '*'
 
   '@lit-labs/ssr-dom-shim@1.6.0':
     resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
@@ -11987,10 +11976,6 @@ snapshots:
       keyv: 5.6.0
 
   '@keyv/serialize@1.1.1': {}
-
-  '@layerzerolabs/scan-client@0.0.8(axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2))':
-    dependencies:
-      axios: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
 
   '@lit-labs/ssr-dom-shim@1.6.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,9 +628,6 @@ importers:
       date-fns:
         specifier: 4.4.0
         version: 4.4.0
-      deepmerge:
-        specifier: ^4.3.1
-        version: 4.3.1
       echarts:
         specifier: 6.1.0
         version: 6.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,9 +547,6 @@ importers:
       '@chakra-ui/icons':
         specifier: 2.2.4
         version: 2.2.4(@chakra-ui/react@2.10.10(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
-      '@chakra-ui/next-js':
-        specifier: 2.4.2
-        version: 2.4.2(@chakra-ui/react@2.10.10(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@chakra-ui/react':
         specifier: 2.10.10
         version: 2.10.10(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1116,14 +1113,6 @@ packages:
     resolution: {integrity: sha512-l5QdBgwrAg3Sc2BRqtNkJpfuLw/pWRDwwT58J6c4PqQT6wzXxyNa8Q0PForu1ltB5qEiFb1kxr/F/HO1EwNa6g==}
     peerDependencies:
       '@chakra-ui/react': '>=2.0.0'
-      react: '>=18'
-
-  '@chakra-ui/next-js@2.4.2':
-    resolution: {integrity: sha512-loo82RyPbMyvJwRhhZVZovut9v2hFBSkqd1vQoNXgMrCRApLwrrttu5Iuodns15gLE3mqI+it5oEhxTtO5DrxA==}
-    peerDependencies:
-      '@chakra-ui/react': '>=2.4.0'
-      '@emotion/react': '>=11'
-      next: '>=13'
       react: '>=18'
 
   '@chakra-ui/object-utils@2.1.0':
@@ -10138,14 +10127,6 @@ snapshots:
   '@chakra-ui/icons@2.2.4(@chakra-ui/react@2.10.10(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@chakra-ui/react': 2.10.10(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-
-  '@chakra-ui/next-js@2.4.2(@chakra-ui/react@2.10.10(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@chakra-ui/react': 2.10.10(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2)
-      next: 16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
   '@chakra-ui/object-utils@2.1.0': {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,9 +291,6 @@ importers:
       eslint:
         specifier: 9.39.5
         version: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
-      lokijs:
-        specifier: 1.5.12
-        version: 1.5.12
 
   apps/frontend-v3:
     dependencies:
@@ -448,9 +445,6 @@ importers:
       eslint:
         specifier: 9.39.5
         version: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
-      lokijs:
-        specifier: 1.5.12
-        version: 1.5.12
       prool:
         specifier: 0.2.14
         version: 0.2.14(debug@4.4.3(supports-color@10.2.2))
@@ -803,9 +797,6 @@ importers:
       eslint:
         specifier: 9.39.5
         version: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
-      lokijs:
-        specifier: 1.5.12
-        version: 1.5.12
       msw:
         specifier: 2.15.0
         version: 2.15.0(@types/node@24.13.3)(typescript@5.9.3)
@@ -7335,9 +7326,6 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
-
-  lokijs@1.5.12:
-    resolution: {integrity: sha512-Q5ALD6JiS6xAUWCwX3taQmgwxyveCtIIuL08+ml0nHwT3k0S/GIFJN+Hd38b1qYIMaE5X++iqsqWVksz7SYW+Q==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -17533,8 +17521,6 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
-
-  lokijs@1.5.12: {}
 
   long@5.3.2: {}
 


### PR DESCRIPTION
## What

- Removed unused dependency `@layerzerolabs/scan-client` from `packages/lib` and `apps/frontend-v3`
- Removed unused dependency `deepmerge` from `packages/lib`
- Removed unused devDependency `lokijs` from `packages/lib`, `apps/frontend-v3`, `apps/beets-frontend-v3`
- Removed the stale `'lokijs'` entry from `serverExternalPackages` in `apps/frontend-v3/next.config.ts` and `apps/beets-frontend-v3/next.config.ts` (`thread-stream`, `real-require`, `encoding` kept — they are real direct deps)
- Removed unused dependency `@chakra-ui/next-js` from `packages/lib`
- Removed unused dependency `graphql-request` from `packages/lib`
- Regenerated `pnpm-lock.yaml` via `pnpm install`

## Why

Renovate flagged these packages as long-unupdated (issue #2642). Investigation found all five are declared but never imported anywhere in the codebase, with no transitive or optional dependents — dead weight from earlier eras that survived the monorepo migration and a prior cleanup pass (#71).

Per-package history from git:

- `@layerzerolabs/scan-client` — genuinely used Oct 2024 – Apr 2026 as `getMessagesBySrcTxHash` in the veBAL cross-chain voting sync (added `4177d939b`, removed `07e111486` "[#2316] remove everything related to veBAL voting"). The package.json declaration outlived the code removal by ~4 months.
- `deepmerge` — never imported in any source across reachable git history; present since the monorepo switch (`f65554679`, Sep 2024), a promoted transitive dep never cleaned up.
- `lokijs` — never imported in source; its only role was a bundler hint (`config.externals.push('pino-pretty', 'lokijs', 'encoding')` since `a0fe77ec9`, Jul 2023) that carried into `serverExternalPackages`.
- `@chakra-ui/next-js` — last used as `ChakraCacheProvider` Mar 2024, dead since (`940034f7d` → `8086adea9`).
- `graphql-request` — last used as `GraphQLClient` Jun–Jul 2023, replaced by `@apollo/client` (`e2d561073` → `4b6fd3a08`).

## Test Steps

This change has no manual UI surface — it only removes dead dependency declarations and a bundler config entry. Verification is CI/build-level:

- [ ] `pnpm -r typecheck` passes in all 9 workspace projects
- [ ] `pnpm --filter frontend-v3 build` passes
- [ ] `pnpm --filter beets-frontend-v3 build` passes
- [ ] `pnpm install` regenerates the lockfile without peer-dependency errors

## Risks / Breaking Changes

- `deepmerge@4.3.1` remains in the lockfile as a transitive dep of `zustand` and `@vanilla-extract/css` (via rainbowkit) — only the direct edge is removed; no runtime behavior changes.
- `serverExternalPackages` change touches both apps' Next configs — `thread-stream`, `real-require`, `encoding` were deliberately kept as they are direct deps of both apps. Both apps' builds were verified.
- No `packages/lib` code changed; `NEXT_PUBLIC_PROJECT_ID` gating is unaffected for either app.

## Other Notes

Reference commits (one per package, hooks ran on each):

1. `601e5d400` chore(deps): remove unused @layerzerolabs/scan-client
2. `07ac3e8ce` chore(deps): remove unused deepmerge from @repo/lib
3. `2c90977c6` chore(deps): remove unused lokijs
4. `e7ec4fb66` chore(deps): remove unused @chakra-ui/next-js
5. `597b8dac7` chore(deps): remove unused graphql-request