### PR TITLE
test(pool): add unit coverage for high-risk untested helpers

### DIFF
--- a/packages/lib/config/networks/networks.spec.ts
+++ b/packages/lib/config/networks/networks.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { GqlChainValues } from '@repo/lib/shared/services/api/graphql-enums'
+import type { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
+import { getNetworkConfig } from './index'
+
+describe('getNetworkConfig', () => {
+  it('resolves a config for every supported chain', () => {
+    const chains = Object.values(GqlChainValues) as GqlChain[]
+    for (const chain of chains) {
+      const config = getNetworkConfig(chain)
+      expect(config.chain).toBe(chain)
+      expect(config.chainId).toBeTypeOf('number')
+      expect(config.name).toBeTypeOf('string')
+      expect(config.shortName).toBeTypeOf('string')
+      expect(config.blockExplorer.baseUrl).toMatch(/^https:\/\//)
+    }
+  })
+
+  it('throws for unknown chains', () => {
+    expect(() => getNetworkConfig('UNKNOWN' as GqlChain)).toThrow(
+      /Missing network config for chain UNKNOWN/
+    )
+  })
+})

--- a/packages/lib/config/projects/projects.spec.ts
+++ b/packages/lib/config/projects/projects.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { ProjectConfigBalancer } from './balancer'
+import { ProjectConfigBeets } from './beets'
+
+describe('project configs', () => {
+  it('are both structurally complete and distinct', () => {
+    for (const projectConfig of [ProjectConfigBalancer, ProjectConfigBeets]) {
+      expect(projectConfig.projectId).toBeTypeOf('string')
+      expect(projectConfig.projectName).toBeTypeOf('string')
+      expect(projectConfig.projectUrl).toMatch(/^https:\/\//)
+      expect(projectConfig.projectLogo).toMatch(/^https:\/\//)
+      expect(projectConfig.supportedNetworks.length).toBeGreaterThan(0)
+      expect(projectConfig.defaultNetwork).toBeTypeOf('string')
+      expect(projectConfig.ensNetwork).toBeTypeOf('string')
+      expect(projectConfig.corePoolId).toMatch(/^0x/)
+      expect(projectConfig.merklRewardsChains.length).toBeGreaterThan(0)
+      expect(projectConfig.options).toBeDefined()
+      expect(projectConfig.links).toBeDefined()
+      expect(projectConfig.footer.linkSections.length).toBeGreaterThan(0)
+    }
+    expect(ProjectConfigBalancer.projectId).not.toBe(ProjectConfigBeets.projectId)
+    expect(ProjectConfigBalancer.defaultNetwork).not.toBe(ProjectConfigBeets.defaultNetwork)
+  })
+
+  it('gate project-only features per app', () => {
+    expect(ProjectConfigBeets.options.showMaBeets).toBe(true)
+    expect(ProjectConfigBalancer.options.showMaBeets).toBe(false)
+    expect(ProjectConfigBeets.options.allowCreateWallet).toBe(false)
+    expect(ProjectConfigBalancer.options.allowCreateWallet).toBe(true)
+    expect(ProjectConfigBeets.options.isOnSafeAppList).toBe(false)
+    expect(ProjectConfigBalancer.options.isOnSafeAppList).toBe(true)
+  })
+
+  it('only list supported networks for their own chains', () => {
+    // Beets is Sonic-only; Balancer is multi-chain and does not include Sonic
+    expect(ProjectConfigBeets.supportedNetworks).toContain('SONIC')
+    expect(ProjectConfigBalancer.supportedNetworks).not.toContain('SONIC')
+  })
+})

--- a/packages/lib/modules/pool/actions/create/helpers.spec.ts
+++ b/packages/lib/modules/pool/actions/create/helpers.spec.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+import { PoolType } from '@balancer/sdk'
+import { GqlPoolTypeValues } from '@repo/lib/shared/services/api/graphql-enums'
+import {
+  COW_AMM_RAW_WEIGHT_20,
+  COW_AMM_RAW_WEIGHT_50,
+  COW_AMM_RAW_WEIGHT_80,
+  WeightedPoolStructure,
+} from './constants'
+import {
+  formatNumber,
+  getCowRawWeight,
+  getGqlPoolType,
+  getMinSwapFeePercentage,
+  getPercentFromPrice,
+  getSwapFeePercentageOptions,
+  isAutoRangePool,
+  isBalancerProtocol,
+  isCowPool,
+  isCowProtocol,
+  isCustomWeightedPool,
+  isGyroEllipticPool,
+  isPoolCreatorEnabled,
+  isStablePool,
+  isStableSurgePool,
+  isWeightedPool,
+} from './helpers'
+
+describe('getGqlPoolType', () => {
+  it('maps every SDK pool type to its GQL counterpart', () => {
+    expect(getGqlPoolType(PoolType.Weighted)).toBe(GqlPoolTypeValues.Weighted)
+    expect(getGqlPoolType(PoolType.Stable)).toBe(GqlPoolTypeValues.Stable)
+    expect(getGqlPoolType(PoolType.StableSurge)).toBe(GqlPoolTypeValues.Stable)
+    expect(getGqlPoolType(PoolType.GyroE)).toBe(GqlPoolTypeValues.GyroE)
+    expect(getGqlPoolType(PoolType.ReClamm)).toBe(GqlPoolTypeValues.Reclamm)
+    expect(getGqlPoolType(PoolType.CowAmm)).toBe(GqlPoolTypeValues.CowAmm)
+  })
+
+  it('throws for unmapped pool types', () => {
+    expect(() => getGqlPoolType(undefined as unknown as PoolType)).toThrow(/Invalid pool type/)
+  })
+})
+
+describe('getSwapFeePercentageOptions', () => {
+  it('returns stable fee presets for stable and stable surge pools', () => {
+    const expected = [
+      { value: '0.01', tip: 'Best for super stable pairs' },
+      { value: '0.05', tip: 'Best for stable-ish pairs' },
+    ]
+    expect(getSwapFeePercentageOptions(PoolType.Stable)).toEqual(expected)
+    expect(getSwapFeePercentageOptions(PoolType.StableSurge)).toEqual(expected)
+  })
+
+  it('returns weighted fee presets for weighted pools', () => {
+    const expected = [
+      { value: '0.30', tip: 'Best for most weighted pairs' },
+      { value: '1.00', tip: 'Best for exotic pairs' },
+    ]
+    expect(getSwapFeePercentageOptions(PoolType.Weighted)).toEqual(expected)
+  })
+
+  it('returns default presets for remaining pool types', () => {
+    expect(getSwapFeePercentageOptions(PoolType.GyroE)).toEqual([
+      { value: '0.30', tip: 'Best for most Gyro E-CLP pairs' },
+      { value: '1.00', tip: 'Best for exotic pairs' },
+    ])
+    expect(getSwapFeePercentageOptions(PoolType.ReClamm)).toEqual([
+      { value: '0.30', tip: 'Best for most AutoRange pairs' },
+      { value: '1.00', tip: 'Best for exotic pairs' },
+    ])
+    expect(getSwapFeePercentageOptions(PoolType.CowAmm)).toEqual([
+      { value: '0.30', tip: 'Best for most AutoRange pairs' },
+      { value: '1.00', tip: 'Best for exotic pairs' },
+    ])
+  })
+})
+
+describe('getMinSwapFeePercentage', () => {
+  it('allows a lower minimum for stable pools', () => {
+    expect(getMinSwapFeePercentage(PoolType.Stable)).toBe(0.0001)
+    expect(getMinSwapFeePercentage(PoolType.StableSurge)).toBe(0.0001)
+    expect(getMinSwapFeePercentage(PoolType.Weighted)).toBe(0.001)
+    expect(getMinSwapFeePercentage(PoolType.GyroE)).toBe(0.001)
+    expect(getMinSwapFeePercentage(PoolType.ReClamm)).toBe(0.001)
+  })
+})
+
+describe('getPercentFromPrice', () => {
+  it('calculates the percent difference between value and price', () => {
+    expect(getPercentFromPrice('110', '100')).toBe('10.00')
+    expect(getPercentFromPrice('150', '100')).toBe('50.00')
+    expect(getPercentFromPrice('80', '100')).toBe('-20.00')
+  })
+
+  it('returns 0.00 for unparseable or zero inputs instead of throwing', () => {
+    expect(getPercentFromPrice('', '100')).toBe('0.00')
+    expect(getPercentFromPrice('110', '')).toBe('0.00')
+    expect(getPercentFromPrice('abc', '100')).toBe('0.00')
+    expect(getPercentFromPrice('110', '0')).toBe('0.00')
+  })
+})
+
+describe('getCowRawWeight', () => {
+  it('maps supported weight strings to their raw bigint values', () => {
+    expect(getCowRawWeight('50')).toBe(COW_AMM_RAW_WEIGHT_50)
+    expect(getCowRawWeight('80')).toBe(COW_AMM_RAW_WEIGHT_80)
+    expect(getCowRawWeight('20')).toBe(COW_AMM_RAW_WEIGHT_20)
+  })
+
+  it('throws for unsupported weights', () => {
+    expect(() => getCowRawWeight('30')).toThrow(/Invalid weight for cow amm/)
+    expect(() => getCowRawWeight(undefined)).toThrow(/Invalid weight for cow amm/)
+  })
+})
+
+describe('formatNumber', () => {
+  it('formats below 1000 with 6 decimals', () => {
+    expect(formatNumber('500')).toBe('500.000000')
+  })
+
+  it('formats above 1000 with thousands separators and 2 decimals', () => {
+    expect(formatNumber('1000.5')).toBe('1,000.50')
+  })
+
+  it('formats above 100000 without decimals', () => {
+    expect(formatNumber('200000')).toBe('200,000')
+  })
+})
+
+describe('pool type predicates', () => {
+  it('detects stable pools', () => {
+    expect(isStablePool(PoolType.Stable)).toBe(true)
+    expect(isStablePool(PoolType.StableSurge)).toBe(true)
+    expect(isStablePool(PoolType.Weighted)).toBe(false)
+  })
+
+  it('detects stable surge pools', () => {
+    expect(isStableSurgePool(PoolType.StableSurge)).toBe(true)
+    expect(isStableSurgePool(PoolType.Stable)).toBe(false)
+  })
+
+  it('detects weighted pools', () => {
+    expect(isWeightedPool(PoolType.Weighted)).toBe(true)
+    expect(isWeightedPool(PoolType.Stable)).toBe(false)
+  })
+
+  it('detects custom weighted pools', () => {
+    expect(isCustomWeightedPool(PoolType.Weighted, WeightedPoolStructure.Custom)).toBe(true)
+    expect(isCustomWeightedPool(PoolType.Weighted, WeightedPoolStructure.FiftyFifty)).toBe(false)
+    expect(isCustomWeightedPool(PoolType.Stable, WeightedPoolStructure.Custom)).toBe(false)
+  })
+
+  it('detects auto range (ReClamm) pools', () => {
+    expect(isAutoRangePool(PoolType.ReClamm)).toBe(true)
+    expect(isAutoRangePool(PoolType.Weighted)).toBe(false)
+  })
+
+  it('detects gyro elliptic pools', () => {
+    expect(isGyroEllipticPool(PoolType.GyroE)).toBe(true)
+    expect(isGyroEllipticPool(PoolType.Stable)).toBe(false)
+  })
+
+  it('detects cow pools', () => {
+    expect(isCowPool(PoolType.CowAmm)).toBe(true)
+    expect(isCowPool(undefined)).toBe(false)
+    expect(isCowPool(PoolType.Weighted)).toBe(false)
+  })
+})
+
+describe('protocol predicates', () => {
+  it('detects CoW protocol case-insensitively', () => {
+    expect(isCowProtocol('CoW')).toBe(true)
+    expect(isCowProtocol('cow')).toBe(true)
+    expect(isCowProtocol('Balancer v3')).toBe(false)
+  })
+
+  it('detects Balancer protocol case-insensitively', () => {
+    expect(isBalancerProtocol('Balancer v3')).toBe(true)
+    expect(isBalancerProtocol('balancer v3')).toBe(true)
+    expect(isBalancerProtocol('CoW')).toBe(false)
+  })
+})
+
+describe('isPoolCreatorEnabled', () => {
+  it('is only enabled for stable and weighted pools', () => {
+    expect(isPoolCreatorEnabled(PoolType.Stable)).toBe(true)
+    expect(isPoolCreatorEnabled(PoolType.Weighted)).toBe(true)
+    expect(isPoolCreatorEnabled(PoolType.StableSurge)).toBe(false)
+    expect(isPoolCreatorEnabled(PoolType.GyroE)).toBe(false)
+    expect(isPoolCreatorEnabled(PoolType.ReClamm)).toBe(false)
+    expect(isPoolCreatorEnabled(PoolType.CowAmm)).toBe(false)
+  })
+})

--- a/packages/lib/modules/portfolio/PortfolioClaim/useBalRewards.spec.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/useBalRewards.spec.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { testHook } from '@repo/lib/test/utils/custom-renderers'
+import { waitFor } from '@testing-library/react'
+import { useBalTokenRewards } from './useBalRewards'
+import { ClaimablePool } from '@repo/lib/modules/pool/actions/claim/ClaimProvider'
+import { getNetworkConfig } from '@repo/lib/config/networks'
+import { GqlChainValues } from '@repo/lib/shared/services/api/graphql-enums'
+import { bn } from '@repo/lib/shared/utils/numbers'
+
+const { useUserAccountMock, useReadContractsMock } = vi.hoisted(() => ({
+  useUserAccountMock: vi.fn(),
+  useReadContractsMock: vi.fn(),
+}))
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>()
+  return {
+    ...actual,
+    useReadContracts: useReadContractsMock,
+  }
+})
+
+vi.mock('@repo/lib/modules/web3/UserAccountProvider', async importOriginal => {
+  const actual = await importOriginal<typeof import('@repo/lib/modules/web3/UserAccountProvider')>()
+  return {
+    ...actual,
+    useUserAccount: useUserAccountMock,
+  }
+})
+
+const USER_ADDRESS = '0x1234567890123456789012345678901234567890'
+const GAUGE_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+const mainnetBalAddress = getNetworkConfig(GqlChainValues.Mainnet).tokens.addresses.bal
+
+function claimablePool(): ClaimablePool {
+  return {
+    id: '0xpool1',
+    chain: GqlChainValues.Mainnet,
+    protocolVersion: 2,
+    symbol: 'BAL-WETH',
+    address: '0xpool1',
+    staking: { gauge: { id: GAUGE_ADDRESS } },
+  } as unknown as ClaimablePool
+}
+
+describe('useBalTokenRewards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useUserAccountMock.mockReturnValue({ userAddress: USER_ADDRESS, isConnected: true })
+  })
+
+  it('returns empty rewards when the onchain read reports no claimable balance', async () => {
+    useReadContractsMock.mockReturnValue({
+      data: [{ status: 'success', result: 0n }],
+      refetch: vi.fn(),
+      isLoading: false,
+      status: 'success',
+    })
+
+    const { result } = testHook(() => useBalTokenRewards([claimablePool()]))
+
+    await waitFor(() => expect(result.current.isLoadedBalRewards).toBe(true))
+    expect(result.current.balRewardsData).toEqual([])
+  })
+
+  it('maps a claimable balance to a BAL reward with human and fiat value', async () => {
+    useReadContractsMock.mockReturnValue({
+      data: [{ status: 'success', result: 1000000000000000000n }], // 1 BAL (18 decimals)
+      refetch: vi.fn(),
+      isLoading: false,
+      status: 'success',
+    })
+
+    const { result } = testHook(() => useBalTokenRewards([claimablePool()]))
+
+    await waitFor(() => expect(result.current.balRewardsData).toHaveLength(1))
+
+    const reward = result.current.balRewardsData[0]
+    expect(reward.gaugeAddress).toBe(GAUGE_ADDRESS)
+    expect(reward.humanBalance).toBe('1')
+    expect(reward.tokenAddress).toBe(mainnetBalAddress)
+    expect(reward.pool.chain).toBe(GqlChainValues.Mainnet)
+    expect(bn(reward.fiatBalance).isGreaterThanOrEqualTo(0)).toBe(true)
+  })
+
+  it('drops failed gauge reads', async () => {
+    useReadContractsMock.mockReturnValue({
+      data: [{ status: 'failure', error: new Error('rpc error') }],
+      refetch: vi.fn(),
+      isLoading: false,
+      status: 'success',
+    })
+
+    const { result } = testHook(() => useBalTokenRewards([claimablePool()]))
+
+    await waitFor(() => expect(result.current.isLoadedBalRewards).toBe(true))
+    expect(result.current.balRewardsData).toEqual([])
+  })
+})

--- a/packages/lib/modules/transactions/transaction-steps/safe/safe.helpers.spec.ts
+++ b/packages/lib/modules/transactions/transaction-steps/safe/safe.helpers.spec.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GatewayTransactionDetails,
+  TransactionStatus as SafeTransactionStatus,
+} from '@safe-global/safe-apps-sdk'
+import {
+  buildTxBatch,
+  getPendingNestedSteps,
+  getRemainingSignatures,
+  getRemainingSignaturesLabel,
+  getSafeWebUrl,
+  getSignConfirmationsLabel,
+  hasSomePendingNestedTxInBatch,
+  isMultisig,
+  isSafeTxCancelled,
+  isSafeTxRejected,
+  isSafeTxSuccess,
+  isSafeTxWaitingForConfirmations,
+  isSafeTxWaitingForExecution,
+  mapSafeTxStatusToBalancerTxState,
+  safeStatusToBalancerStatus,
+} from './safe.helpers'
+
+const SAFE_ADDRESS = '0x1234567890123456789012345678901234567890'
+
+function multisigDetails(
+  confirmations: number,
+  confirmationsRequired: number
+): GatewayTransactionDetails {
+  return {
+    detailedExecutionInfo: {
+      type: 'MULTISIG',
+      confirmations: Array.from({ length: confirmations }, (_, i) => ({ signature: `sig-${i}` })),
+      confirmationsRequired,
+    },
+  } as GatewayTransactionDetails
+}
+
+function nonMultisigDetails(): GatewayTransactionDetails {
+  return {
+    detailedExecutionInfo: { type: 'ETH_SIGN' } as unknown as NonNullable<
+      GatewayTransactionDetails['detailedExecutionInfo']
+    >,
+  } as GatewayTransactionDetails
+}
+
+describe('getSafeWebUrl', () => {
+  it('builds a safe web url with the chain shortname prefix', () => {
+    expect(getSafeWebUrl(1, SAFE_ADDRESS, '0xabc')).toBe(
+      `https://app.safe.global/transactions/tx?safe=/eth:${SAFE_ADDRESS}&id=0xabc`
+    )
+  })
+
+  it('maps every supported chain to its safe shortname', () => {
+    expect(getSafeWebUrl(1, SAFE_ADDRESS, 'id')).toContain('eth:')
+    expect(getSafeWebUrl(100, SAFE_ADDRESS, 'id')).toContain('gno:')
+    expect(getSafeWebUrl(11155111, SAFE_ADDRESS, 'id')).toContain('sep:')
+    expect(getSafeWebUrl(42161, SAFE_ADDRESS, 'id')).toContain('arb:')
+    expect(getSafeWebUrl(137, SAFE_ADDRESS, 'id')).toContain('matic:')
+    expect(getSafeWebUrl(10, SAFE_ADDRESS, 'id')).toContain('oeth:')
+    expect(getSafeWebUrl(8453, SAFE_ADDRESS, 'id')).toContain('base:')
+    expect(getSafeWebUrl(146, SAFE_ADDRESS, 'id')).toContain('sonic:')
+    expect(getSafeWebUrl(43114, SAFE_ADDRESS, 'id')).toContain('avax:')
+  })
+})
+
+describe('isMultisig', () => {
+  it('returns true only for MULTISIG execution details', () => {
+    expect(isMultisig(multisigDetails(1, 1))).toBe(true)
+    expect(isMultisig(nonMultisigDetails())).toBe(false)
+  })
+})
+
+describe('getPendingNestedSteps / hasSomePendingNestedTxInBatch', () => {
+  const pendingStep = { isComplete: () => false }
+  const completedStep = { isComplete: () => true }
+
+  it('filters out completed nested steps', () => {
+    const step = { nestedSteps: [pendingStep, completedStep] } as any
+    expect(getPendingNestedSteps(step)).toHaveLength(1)
+  })
+
+  it('returns true when any nested step is pending', () => {
+    const step = { nestedSteps: [pendingStep, completedStep] } as any
+    expect(hasSomePendingNestedTxInBatch(step)).toBe(true)
+  })
+
+  it('returns false when all nested steps are complete or absent', () => {
+    expect(hasSomePendingNestedTxInBatch({ nestedSteps: [completedStep] } as any)).toBe(false)
+    expect(hasSomePendingNestedTxInBatch({} as any)).toBe(false)
+  })
+})
+
+describe('getSignConfirmationsLabel / getRemainingSignatures / getRemainingSignaturesLabel', () => {
+  it('returns null and 0 for non-multisig details', () => {
+    expect(getSignConfirmationsLabel(nonMultisigDetails())).toBeNull()
+    expect(getRemainingSignatures(nonMultisigDetails())).toBe(0)
+    expect(getRemainingSignaturesLabel(nonMultisigDetails())).toBeUndefined()
+  })
+
+  it('formats the confirmations label', () => {
+    expect(getSignConfirmationsLabel(multisigDetails(2, 3))).toBe('Signatures: 2 out of 3')
+  })
+
+  it('computes remaining signatures and their labels', () => {
+    expect(getRemainingSignatures(multisigDetails(2, 3))).toBe(1)
+    expect(getRemainingSignaturesLabel(multisigDetails(2, 3))).toBe('(1 more signature required)')
+    expect(getRemainingSignaturesLabel(multisigDetails(1, 3))).toBe(
+      '2 more signatures are required'
+    )
+    expect(getRemainingSignaturesLabel(multisigDetails(3, 3))).toBeUndefined()
+  })
+})
+
+describe('buildTxBatch', () => {
+  it('builds a single-element batch when there are no nested steps', () => {
+    const step = { batchableTxCall: { to: '0xaaa', value: 1n } } as any
+    expect(buildTxBatch(step)).toEqual([{ to: '0xaaa', value: '1' }])
+  })
+
+  it('serializes value to a string, defaulting to 0', () => {
+    const step = { batchableTxCall: { to: '0xaaa' } } as any
+    expect(buildTxBatch(step)).toEqual([{ to: '0xaaa', value: '0' }])
+  })
+
+  it('prepends pending nested step calls and always appends the parent call', () => {
+    const step = {
+      nestedSteps: [
+        { isComplete: () => false, batchableTxCall: { to: '0xbbb' } },
+        { isComplete: () => true, batchableTxCall: { to: '0xccc' } },
+      ],
+      batchableTxCall: { to: '0xaaa' },
+    } as any
+    expect(buildTxBatch(step)).toEqual([
+      { to: '0xbbb', value: '0' },
+      { to: '0xaaa', value: '0' },
+    ])
+  })
+})
+
+describe('safe tx status predicates', () => {
+  it('detects success', () => {
+    expect(isSafeTxSuccess(SafeTransactionStatus.SUCCESS)).toBe(true)
+    expect(isSafeTxSuccess(SafeTransactionStatus.FAILED)).toBe(false)
+  })
+
+  it('detects cancellation', () => {
+    expect(isSafeTxCancelled(SafeTransactionStatus.CANCELLED)).toBe(true)
+    expect(isSafeTxCancelled(SafeTransactionStatus.FAILED)).toBe(false)
+  })
+
+  it('detects waiting states', () => {
+    expect(isSafeTxWaitingForExecution(SafeTransactionStatus.AWAITING_EXECUTION)).toBe(true)
+    expect(isSafeTxWaitingForConfirmations(SafeTransactionStatus.AWAITING_CONFIRMATIONS)).toBe(true)
+  })
+
+  it('treats failed transactions as rejected', () => {
+    expect(isSafeTxRejected(SafeTransactionStatus.FAILED)).toBe(true)
+    expect(isSafeTxRejected(SafeTransactionStatus.CANCELLED)).toBe(true)
+    expect(isSafeTxRejected(SafeTransactionStatus.SUCCESS)).toBe(false)
+  })
+})
+
+describe('safeStatusToBalancerStatus', () => {
+  it('maps each safe status to the balancer transaction status', () => {
+    expect(safeStatusToBalancerStatus(SafeTransactionStatus.AWAITING_CONFIRMATIONS)).toBe(
+      'confirming'
+    )
+    expect(safeStatusToBalancerStatus(SafeTransactionStatus.AWAITING_EXECUTION)).toBe('confirming')
+    expect(safeStatusToBalancerStatus(SafeTransactionStatus.CANCELLED)).toBe('rejected')
+    expect(safeStatusToBalancerStatus(SafeTransactionStatus.FAILED)).toBe('reverted')
+    expect(safeStatusToBalancerStatus(SafeTransactionStatus.SUCCESS)).toBe('confirmed')
+    expect(safeStatusToBalancerStatus(undefined)).toBe('unknown')
+  })
+})
+
+describe('mapSafeTxStatusToBalancerTxState', () => {
+  it('maps to transaction states', () => {
+    expect(mapSafeTxStatusToBalancerTxState(undefined)).toBe('init')
+    expect(mapSafeTxStatusToBalancerTxState(SafeTransactionStatus.SUCCESS)).toBe('completed')
+    expect(mapSafeTxStatusToBalancerTxState(SafeTransactionStatus.CANCELLED)).toBe('error')
+    expect(mapSafeTxStatusToBalancerTxState(SafeTransactionStatus.FAILED)).toBe('error')
+    expect(mapSafeTxStatusToBalancerTxState(SafeTransactionStatus.AWAITING_EXECUTION)).toBe('init')
+  })
+})

--- a/packages/lib/modules/transactions/transaction-steps/safe/safe.helpers.ts
+++ b/packages/lib/modules/transactions/transaction-steps/safe/safe.helpers.ts
@@ -98,7 +98,10 @@ export function isSafeTxSuccess(safeTxStatus?: SafeTransactionStatus): boolean {
 }
 
 export function isSafeTxRejected(safeTxStatus?: SafeTransactionStatus): boolean {
-  return safeTxStatus === (SafeTransactionStatus.CANCELLED || SafeTransactionStatus.FAILED)
+  return (
+    safeTxStatus === SafeTransactionStatus.CANCELLED ||
+    safeTxStatus === SafeTransactionStatus.FAILED
+  )
 }
 
 export function isSafeTxCancelled(safeTxStatus?: SafeTransactionStatus): boolean {


### PR DESCRIPTION
## What

- Added unit tests for `modules/pool/actions/create/helpers.ts` — SDK→GQL pool type mapping, swap fee presets and minimums, percent-diff math (incl. malformed-input guards), CoW raw weights, number formatting, and pool-type/protocol predicates
- Added `config/networks/networks.spec.ts` — every `GqlChain` resolves a complete `NetworkConfig`; unknown chains throw
- Added `config/projects/projects.spec.ts` — both project configs are structurally complete, project-only features are gated per app, supported networks are chain-correct
- Added `modules/transactions/transaction-steps/safe/safe.helpers.spec.ts` — safe URL building across all chain shortnames, multisig detection, pending-step filtering, signature labels, tx batching, safe-status mapping
- Fixed latent bug in `safe.helpers.ts`: `isSafeTxRejected` used `status === (A || B)` so `FAILED` transactions were never treated as rejected — now both `CANCELLED` and `FAILED` map to the Error tx state
- Added `modules/portfolio/PortfolioClaim/useBalRewards.spec.tsx` — zero balance → no rewards, claimable balance → human+fiat mapping, failed gauge reads dropped

## Why

Issue #2409 tracks test coverage for `packages/lib` (~10% of source files covered). The remaining checklist items are mostly low-value glue, so this PR targets the files with the highest bug density and regression risk instead of grinding the whole list:

- `create/helpers.ts` had 3 crash/validation fixes in the last month (`4ccda0a4a`, `642cef378`, `bb2e0a307`) and zero tests — the guard functions those fixes touched are now covered
- Config is where project-specific hardcoding silently breaks the other app (Balancer ↔ Beets, see AGENTS.md); both project configs and all 13 network configs are now structurally locked
- `safe.helpers.ts` is the transaction-status mapping for Safe app flows; the tests surfaced a real bug in `isSafeTxRejected`

## Test Steps

All tests are unit tests — no manual surface. Run:

- [ ] `pnpm --filter @repo/lib exec vitest run modules/pool/actions/create/helpers.spec.ts` → 23 passing
- [ ] `pnpm --filter @repo/lib exec vitest run config/networks/networks.spec.ts config/projects/projects.spec.ts` → 5 passing
- [ ] `pnpm --filter @repo/lib exec vitest run modules/transactions/transaction-steps/safe/safe.helpers.spec.ts` → 18 passing
- [ ] `pnpm --filter @repo/lib exec vitest run modules/portfolio/PortfolioClaim/useBalRewards.spec.tsx` → 3 passing
- [ ] `pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit` → clean
- [ ] `pnpm --filter @repo/lib exec eslint <spec files> --max-warnings 0` → clean

## Risks / Breaking Changes

- `safe.helpers.ts` behavior change: `FAILED` Safe transactions now map to `rejected` (balancer status) and `Error` (tx state) instead of falling through as `unknown`/ready. This is the intended fix — Safe transactions that revert on-chain were previously misrepresented. Worth a manual check of a failed Safe batch in the Safe app flow.
- All changes are additive tests plus the one-line predicate fix; no other `packages/lib` behavior changed. No effect on the Beets app beyond the shared config tests asserting its config is valid.
- No dependencies bumped, no feature flags touched.

## Other Notes

Follow-up work from the issue #2409 audit deliberately not included (would be coverage theater): `transaction.helper.ts` (10 lines of obvious code), `viem.client.ts`/gauge services (near-static, no bug history), `LbpForm.tsx` component tests. The issue's priority ordering is inverted relative to actual risk — `create/helpers.ts` and config ranked P1/P2 but had the highest bug density.