### PR TITLE
fix(frontend): redirect deprecated pool chains

### DIFF
--- a/apps/frontend-v3/next.config.ts
+++ b/apps/frontend-v3/next.config.ts
@@ -34,6 +34,16 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   redirects: async () => [
     {
+      source: '/pools/mode/:path*',
+      destination: 'https://legacy.balancer.fi',
+      permanent: true,
+    },
+    {
+      source: '/pools/fraxtal/:path*',
+      destination: 'https://legacy.balancer.fi',
+      permanent: true,
+    },
+    {
       source: '/vebal',
       destination: '/vebal/manage',
       permanent: true,


### PR DESCRIPTION
## What

- Added permanent redirects for Mode and Fraxtal pool URLs to `https://legacy.balancer.fi`.

## Why

- Deprecated Mode and Fraxtal pool URLs should send users to the legacy exit app.
- Fixes #2667.

## Test Steps

- [x] Open a `/pools/mode/...` URL on the Balancer frontend.
- [x] Confirm it permanently redirects to `https://legacy.balancer.fi`.
- [x] Open a `/pools/fraxtal/...` URL on the Balancer frontend.
- [x] Confirm it permanently redirects to `https://legacy.balancer.fi`.
- [x] Confirm existing `/vebal` redirect remains functional.
- [x] Run frontend typecheck and lint.

## Risks / Breaking Changes

- Mode and Fraxtal pool URLs now leave the Balancer frontend and redirect to the legacy app.
- No shared `packages/lib` or Beets app code changed.
