### PR TITLE
fix(eclp): validate balance count

### DIFF
--- a/packages/lib/modules/eclp/helpers/gyroEMathFunctions.spec.ts
+++ b/packages/lib/modules/eclp/helpers/gyroEMathFunctions.spec.ts
@@ -1,0 +1,34 @@
+import { ONE } from './constants'
+import { normalizedLiquidityXIn } from './gyroEMathFunctions'
+import type { DerivedGyroEParams, GyroEParams, Vector2 } from './gyroEMathHelpers'
+
+const params: GyroEParams = {
+  alpha: 0n,
+  beta: 0n,
+  c: ONE,
+  s: 0n,
+  lambda: ONE,
+}
+
+const derived: DerivedGyroEParams = {
+  tauAlpha: { x: 0n, y: 0n },
+  tauBeta: { x: 0n, y: 0n },
+  u: 0n,
+  v: 0n,
+  w: 0n,
+  z: 0n,
+  dSq: ONE,
+}
+
+const invariant: Vector2 = { x: ONE, y: ONE }
+
+describe('normalizedLiquidityXIn', () => {
+  it.each([{ balances: [] }, { balances: [ONE] }])(
+    'rejects balances with fewer than two entries',
+    ({ balances }) => {
+      expect(() => normalizedLiquidityXIn(balances, params, derived, 0n, invariant)).toThrow(
+        'ECLP requires at least two balances'
+      )
+    }
+  )
+})

--- a/packages/lib/modules/eclp/helpers/gyroEMathFunctions.ts
+++ b/packages/lib/modules/eclp/helpers/gyroEMathFunctions.ts
@@ -133,6 +133,9 @@ function setup(
   const r = rVec.y
   const { c, s, lambda } = params
   const [x0, y0] = balances
+  if (x0 === undefined || y0 === undefined) {
+    throw new Error('ECLP requires at least two balances')
+  }
   const a = virtualOffset0(params, derived, rVec)
   const b = virtualOffset1(params, derived, rVec)
   const ls = ONE - divDown(ONE, mulDown(lambda, lambda))


### PR DESCRIPTION
## What

- Added an explicit ECLP balance-count invariant before fixed-point calculations.
- Added unit coverage for empty and single-entry balance arrays.
- Removed all 24 `noUncheckedIndexedAccess` diagnostics from `gyroEMathFunctions.ts`.

## Why

ECLP calculations require at least two token balances. Previously, incomplete arrays either reached bigint arithmetic with `undefined` or were silently accepted on code paths that only accessed the first balance.

This is a preparatory migration PR related to #1028. It does not enable `noUncheckedIndexedAccess` for the package or close the broader migration issue.

## Test Steps

- [x] Run `pnpm --filter @repo/lib exec vitest run modules/eclp/helpers/gyroEMathFunctions.spec.ts` and confirm both tests pass.
- [x] Run `pnpm --filter @repo/lib typecheck` and confirm it passes.
- [x] Run `pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit --incremental false --noUncheckedIndexedAccess` and confirm `gyroEMathFunctions.ts` reports no errors.

## Risks / Breaking Changes

- Invalid ECLP calls with fewer than two balances now throw an explicit error earlier instead of continuing into invalid arithmetic.
- The change is in `packages/lib`, shared by Balancer and Beets, but valid two-or-more-balance inputs are unchanged.

## Other Notes

- The strict `@repo/lib` diagnostic count is reduced from 469 to 445.
- Remaining `noUncheckedIndexedAccess` errors will be handled in follow-up PRs under #1028.
