### PR TITLE
test(pool): guard fixture indexed access

### DIFF
--- a/packages/lib/modules/pool/pool-tokens.utils.spec.ts
+++ b/packages/lib/modules/pool/pool-tokens.utils.spec.ts
@@ -287,8 +287,8 @@ describe('Given a fully boosted pool', () => {
   it('underlying tokens are used as actionable by default', () => {
     const tokens = getPoolActionableTokens(pool)
 
-    const firstUnderlyingToken = tokens[0]
-    const firstWrappedToken = tokens[0].wrappedToken
+    const firstUnderlyingToken = requiredAt(tokens, 0)
+    const firstWrappedToken = firstUnderlyingToken.wrappedToken
 
     expect(firstUnderlyingToken.symbol).toEqual('USDT')
     expect(firstUnderlyingToken.wrappedToken?.symbol).toEqual('waEthUSDT')
@@ -300,8 +300,8 @@ describe('Given a fully boosted pool', () => {
     expect(firstWrappedToken.wrappedToken).toBeUndefined()
     expect(shouldUseUnderlyingToken(firstWrappedToken, pool)).toBe(true)
 
-    const secondUnderlyingToken = tokens[1]
-    const secondWrappedToken = tokens[1].wrappedToken
+    const secondUnderlyingToken = requiredAt(tokens, 1)
+    const secondWrappedToken = secondUnderlyingToken.wrappedToken
 
     expect(secondUnderlyingToken.symbol).toEqual('USDC')
     expect(secondUnderlyingToken.wrappedToken?.symbol).toEqual('waEthUSDC')
@@ -316,7 +316,7 @@ describe('Given a fully boosted pool', () => {
 
   it('wrapped/underlying pair is sorted with underlying first by default', () => {
     const tokens = getPoolActionableTokens(pool)
-    const firstUnderlyingToken = tokens[0]
+    const firstUnderlyingToken = requiredAt(tokens, 0)
 
     const pair = getWrappedAndUnderlyingTokenFn(firstUnderlyingToken, pool, balanceForMock)?.()
 
@@ -335,7 +335,7 @@ describe('Given a fully boosted pool', () => {
 
   it('wrapped/underlying pair is sorted with wrapped first when wrapped balance > underlying balance', () => {
     const tokens = getPoolActionableTokens(pool)
-    const firstUnderlyingToken = tokens[0]
+    const firstUnderlyingToken = requiredAt(tokens, 0)
 
     const balanceForMock: BalanceForFn = (token: TokenBase | string) => {
       if (typeof token === 'string') return aTokenAmount(token)
@@ -364,7 +364,7 @@ describe('Given a fully boosted pool', () => {
   it(`when useWrappedForAddRemove is not true in the wrapped token
     getWrappedAndUnderlyingTokenFn should return an empty function to avoid the wrapped/underlying selector the UI`, () => {
     const tokens = getPoolActionableTokens(pool)
-    const firstUnderlyingToken = tokens[0]
+    const firstUnderlyingToken = requiredAt(tokens, 0)
 
     // Set useWrappedForAddRemove to false as we don't have a real pool example with in this scenario yet
     if (firstUnderlyingToken.wrappedToken?.useWrappedForAddRemove) {
@@ -391,7 +391,7 @@ describe('getBoostedActionableTokens', () => {
 
     const boostedTokens = getBoostedActionableTokens(pool)
 
-    const firstUnderlyingToken = boostedTokens[0]
+    const firstUnderlyingToken = requiredAt(boostedTokens, 0)
     expect(firstUnderlyingToken.symbol).toBe('USDC')
     expect(firstUnderlyingToken.underlyingToken).toBeUndefined()
 
@@ -399,7 +399,7 @@ describe('getBoostedActionableTokens', () => {
     expect(firstWrappedToken?.symbol).toBe('csUSDC')
     expect(firstWrappedToken?.underlyingToken?.symbol).toBe('USDC')
 
-    const secondUnderlyingToken = boostedTokens[1]
+    const secondUnderlyingToken = requiredAt(boostedTokens, 1)
     expect(secondUnderlyingToken.symbol).toBe('wUSDL')
     expect(secondUnderlyingToken.underlyingToken).toBeUndefined()
 
@@ -408,3 +408,8 @@ describe('getBoostedActionableTokens', () => {
     expect(secondWrappedToken?.underlyingToken?.symbol).toBe('wUSDL')
   })
 })
+function requiredAt<T>(items: readonly T[], index: number): T {
+  const item = items[index]
+  if (!item) throw new Error(`Missing item at index ${index}`)
+  return item
+}

--- a/packages/lib/modules/pool/pool.helpers.spec.ts
+++ b/packages/lib/modules/pool/pool.helpers.spec.ts
@@ -111,7 +111,7 @@ describe('shouldBlockAddLiquidity', () => {
   describe('v2 pool with ERC4626 token', () => {
     it('should block liquidity if one of the tokens is not allowed', () => {
       const pool = getApiPoolMock(sDAIWeighted)
-      pool.poolTokens[0].isAllowed = false
+      getPoolToken(pool, 0).isAllowed = false
 
       expect(shouldBlockAddLiquidity(pool)).toBe(true)
       expect(getPoolAddBlockedReason(pool)).toHaveLength(1)
@@ -128,8 +128,8 @@ describe('shouldBlockAddLiquidity', () => {
     it('should block exploited V2 composable stable pools with rate providers', () => {
       const pool = getApiPoolMock(sDAIWeighted)
       pool.type = GqlPoolTypeValues.ComposableStable
-      pool.poolTokens[0].priceRateProvider = '0x1a8f81c256aee9c640e14bb0453ce247ea0dfe6f'
-      pool.poolTokens[0].priceRateProviderData = {
+      getPoolToken(pool, 0).priceRateProvider = '0x1a8f81c256aee9c640e14bb0453ce247ea0dfe6f'
+      getPoolToken(pool, 0).priceRateProviderData = {
         __typename: 'GqlPriceRateProviderData',
         address: '0x1a8f81c256aee9c640e14bb0453ce247ea0dfe6f',
         reviewed: true,
@@ -143,7 +143,7 @@ describe('shouldBlockAddLiquidity', () => {
     it('should not block exploited V2 composable stable pools without rate providers', () => {
       const pool = getApiPoolMock(sDAIWeighted)
       pool.type = GqlPoolTypeValues.ComposableStable
-      pool.poolTokens[0].priceRateProvider = zeroAddress
+      getPoolToken(pool, 0).priceRateProvider = zeroAddress
 
       expect(shouldBlockAddLiquidity(pool)).toBe(false)
     })
@@ -151,8 +151,8 @@ describe('shouldBlockAddLiquidity', () => {
     it('should block exploited V2 metastable pools with rate providers', () => {
       const pool = getApiPoolMock(sDAIWeighted)
       pool.type = GqlPoolTypeValues.MetaStable
-      pool.poolTokens[0].priceRateProvider = '0x1a8f81c256aee9c640e14bb0453ce247ea0dfe6f'
-      pool.poolTokens[0].priceRateProviderData = {
+      getPoolToken(pool, 0).priceRateProvider = '0x1a8f81c256aee9c640e14bb0453ce247ea0dfe6f'
+      getPoolToken(pool, 0).priceRateProviderData = {
         __typename: 'GqlPriceRateProviderData',
         address: '0x1a8f81c256aee9c640e14bb0453ce247ea0dfe6f',
         reviewed: true,
@@ -166,14 +166,14 @@ describe('shouldBlockAddLiquidity', () => {
     it('should not block exploited V2 metastable pools without rate providers', () => {
       const pool = getApiPoolMock(sDAIWeighted)
       pool.type = GqlPoolTypeValues.MetaStable
-      pool.poolTokens[0].priceRateProvider = zeroAddress
+      getPoolToken(pool, 0).priceRateProvider = zeroAddress
 
       expect(shouldBlockAddLiquidity(pool)).toBe(false)
     })
 
     it('should not block liquidity if all tokens are allowed', () => {
       const pool = getApiPoolMock(sDAIWeighted)
-      pool.poolTokens[0].isAllowed = true
+      getPoolToken(pool, 0).isAllowed = true
 
       expect(shouldBlockAddLiquidity(pool)).toBe(false)
     })
@@ -182,21 +182,21 @@ describe('shouldBlockAddLiquidity', () => {
   describe('v3 pool with ERC4626 tokens', () => {
     it('Should not block liquidity if all tokenized vaults are reviewed and safe', () => {
       const pool = getApiPoolMock(usdcUsdtAaveBoosted)
-      expect(pool.poolTokens[0].erc4626ReviewData?.summary).toBe('safe')
-      expect(pool.poolTokens[1].erc4626ReviewData?.summary).toBe('safe')
+      expect(getPoolToken(pool, 0).erc4626ReviewData?.summary).toBe('safe')
+      expect(getPoolToken(pool, 1).erc4626ReviewData?.summary).toBe('safe')
       expect(shouldBlockAddLiquidity(pool)).toBe(false)
     })
 
     it('should block liquidity if the usdt tokenized vault is not reviewed', () => {
       const pool = getApiPoolMock(usdcUsdtAaveBoosted)
-      pool.poolTokens[0].erc4626ReviewData = null
+      getPoolToken(pool, 0).erc4626ReviewData = null
       expect(shouldBlockAddLiquidity(pool)).toBe(true)
       expect(getPoolAddBlockedReason(pool)).toHaveLength(1)
     })
 
     it('Should block liquidity if the usdt tokenized vault is not reviewed as safe', () => {
       const pool = getApiPoolMock(usdcUsdtAaveBoosted)
-      pool.poolTokens[0].erc4626ReviewData!.summary = 'unsafe'
+      getPoolToken(pool, 0).erc4626ReviewData!.summary = 'unsafe'
       expect(shouldBlockAddLiquidity(pool)).toBe(true)
       expect(getPoolAddBlockedReason(pool)).toHaveLength(1)
     })
@@ -243,7 +243,7 @@ describe('shouldBlockAddLiquidity', () => {
 
     it('should block if pool token is not reviewed', () => {
       const pool = getApiPoolMock(usdcUsdtAaveBoosted)
-      pool.poolTokens[0].priceRateProviderData = null
+      getPoolToken(pool, 0).priceRateProviderData = null
 
       expect(shouldBlockAddLiquidity(pool)).toBe(true)
       expect(getPoolAddBlockedReason(pool)).toHaveLength(1)
@@ -251,7 +251,7 @@ describe('shouldBlockAddLiquidity', () => {
 
     it('should block if pool token is not safe', () => {
       const pool = getApiPoolMock(usdcUsdtAaveBoosted)
-      pool.poolTokens[0].priceRateProviderData!.summary = 'unsafe'
+      getPoolToken(pool, 0).priceRateProviderData!.summary = 'unsafe'
 
       expect(shouldBlockAddLiquidity(pool)).toBe(true)
       expect(getPoolAddBlockedReason(pool)).toHaveLength(1)
@@ -259,7 +259,7 @@ describe('shouldBlockAddLiquidity', () => {
 
     it('should block if pool token is not allowed', () => {
       const pool = getApiPoolMock(usdcUsdtAaveBoosted)
-      pool.poolTokens[0].isAllowed = false
+      getPoolToken(pool, 0).isAllowed = false
 
       expect(shouldBlockAddLiquidity(pool)).toBe(true)
       expect(getPoolAddBlockedReason(pool)).toHaveLength(1)
@@ -267,15 +267,15 @@ describe('shouldBlockAddLiquidity', () => {
 
     it('should not block if no reviewer', () => {
       const pool = getApiPoolMock(usdcUsdtAaveBoosted)
-      pool.poolTokens[0].priceRateProvider = null
+      getPoolToken(pool, 0).priceRateProvider = null
 
       expect(shouldBlockAddLiquidity(pool)).toBe(false)
     })
 
     it('should not block if reviewer is zero address', () => {
       const pool = getApiPoolMock(usdcUsdtAaveBoosted)
-      pool.poolTokens[0].priceRateProvider = zeroAddress
-      pool.poolTokens[0].priceRateProviderData!.summary = 'unsafe'
+      getPoolToken(pool, 0).priceRateProvider = zeroAddress
+      getPoolToken(pool, 0).priceRateProviderData!.summary = 'unsafe'
 
       expect(shouldBlockAddLiquidity(pool)).toBe(false)
     })
@@ -283,16 +283,16 @@ describe('shouldBlockAddLiquidity', () => {
     it('should not block if reviewer is the nested pool', () => {
       const pool = getApiPoolMock(v3SepoliaNestedBoosted)
       pool.chain = GqlChainValues.Mainnet // Sepolia pools are never blocked
-      pool.poolTokens[0].priceRateProvider = pool.poolTokens[0].nestedPool!.address
-      pool.poolTokens[0].priceRateProviderData = null
+      getPoolToken(pool, 0).priceRateProvider = getPoolToken(pool, 0).nestedPool!.address
+      getPoolToken(pool, 0).priceRateProviderData = null
 
       expect(shouldBlockAddLiquidity(pool)).toBe(false)
     })
 
     it('should return multiple reasons if present', () => {
       const pool = getApiPoolMock(usdcUsdtAaveBoosted)
-      pool.poolTokens[0].erc4626ReviewData!.summary = 'unsafe'
-      pool.poolTokens[1].erc4626ReviewData!.summary = 'unsafe'
+      getPoolToken(pool, 0).erc4626ReviewData!.summary = 'unsafe'
+      getPoolToken(pool, 1).erc4626ReviewData!.summary = 'unsafe'
       expect(getPoolAddBlockedReason(pool)).toHaveLength(2)
     })
   })
@@ -354,3 +354,8 @@ describe('getPoolActivityDateCaption', () => {
     expect(getPoolActivityDateCaption(daysAgo(7))).toBe('in last 7 days')
   })
 })
+function getPoolToken(pool: Pool, index: number) {
+  const token = pool.poolTokens[index]
+  if (!token) throw new Error(`Missing pool token at index ${index}`)
+  return token
+}


### PR DESCRIPTION
## What

- Added guarded indexed-access helpers to pool unit tests.
- Updated pool helper and actionable-token fixtures to fail explicitly when expected tokens are missing.
- Removed 42 `noUncheckedIndexedAccess` compilation errors across two test files.

## Why

- Prepares the shared library for incremental activation of `noUncheckedIndexedAccess`.
- Keeps this migration step small and test-only while preserving fixture invariants.
- Related to #1028. This PR does not complete or close the broader migration.

## Test Steps

- [x] Run `pnpm --filter @repo/lib exec vitest run modules/pool/pool.helpers.spec.ts modules/pool/pool-tokens.utils.spec.ts` and confirm all 54 tests pass.
- [x] Run `pnpm --filter @repo/lib typecheck` and confirm the normal typecheck passes.
- [x] Run `pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit --incremental false --noUncheckedIndexedAccess --pretty false` and confirm neither changed file reports an error.
- [x] Run ESLint and Prettier checks for both changed files.

## Risks / Breaking Changes

- Test-only changes; no runtime behavior or public types changed.
- Files live in shared `packages/lib`, but the changes only affect unit tests and do not change Balancer or Beets application behavior.

## Other Notes

- The strict check still reports unrelated errors assigned to future incremental migration PRs.
