### PR TITLE
fix(analytics): restore Balancer v3 TVL/volume on Protocol Metrics

### DIFF
--- a/apps/balancer-analytics/app/api/cron/backfill/route.ts
+++ b/apps/balancer-analytics/app/api/cron/backfill/route.ts
@@ -32,8 +32,11 @@
  * won't touch api-v3 rows) and also deletes orphaned defillama rows for any
  * chain that's no longer in supportedNetworks.
  *
- * Auth: same `CRON_SECRET` Bearer as the hourly cron. Not on a Vercel cron
- * schedule — run manually:
+ * Auth: same `CRON_SECRET` Bearer as the hourly cron. Scheduled daily in
+ * `vercel.json` (`15 1 * * *` UTC) so V2/V3 breakdowns stay fresh — without
+ * that, the Protocol Metrics stack falls back to 100% v2 once the chart
+ * window no longer overlaps the last DefiLlama day. Still safe to run
+ * manually:
  *   curl -H "Authorization: Bearer $CRON_SECRET" .../api/cron/backfill
  */
 

--- a/apps/balancer-analytics/app/api/snapshots/route.ts
+++ b/apps/balancer-analytics/app/api/snapshots/route.ts
@@ -41,10 +41,7 @@ import {
   PROTOCOL_V3,
   PROTOCOL_COW_AMM,
 } from '@analytics/lib/db'
-import {
-  forwardFillVersionBreakdowns,
-  type VersionBreakdownSeed,
-} from '@analytics/lib/snapshots/forwardFillBreakdowns'
+import { forwardFillVersionBreakdowns } from '@analytics/lib/snapshots/forwardFillBreakdowns'
 import type {
   ChainSnapshotPoint,
   ProtocolBreakdown,
@@ -52,6 +49,7 @@ import type {
   ProtocolSnapshotPoint,
   ProtocolSnapshotSeries,
   SnapshotSource,
+  VersionBreakdownSeed,
 } from '@analytics/lib/snapshots/types'
 
 export const runtime = 'nodejs'

--- a/apps/balancer-analytics/app/api/snapshots/route.ts
+++ b/apps/balancer-analytics/app/api/snapshots/route.ts
@@ -24,6 +24,10 @@
  * data — it only keeps Neon warm and burns compute units. Different
  * `granularity` values get independent cache entries, so daily-for-90D
  * and hourly-for-7D coexist.
+ *
+ * When a window is missing V2/V3 DefiLlama rows, the response forward-fills
+ * those breakdowns from the latest ALL-chain V2/V3 seed so charts do not
+ * silently attribute everything to v2.
  */
 
 import 'server-only'
@@ -37,6 +41,10 @@ import {
   PROTOCOL_V3,
   PROTOCOL_COW_AMM,
 } from '@analytics/lib/db'
+import {
+  forwardFillVersionBreakdowns,
+  type VersionBreakdownSeed,
+} from '@analytics/lib/snapshots/forwardFillBreakdowns'
 import type {
   ChainSnapshotPoint,
   ProtocolBreakdown,
@@ -255,6 +263,59 @@ function foldRows(rows: DbRow[]): ProtocolSnapshotSeries {
   return { points, generatedAt: points.at(-1)?.timestamp ?? null }
 }
 
+/**
+ * Latest ALL-chain V2 + V3 rows, used as a ratio seed when the requested
+ * window has no DefiLlama breakdowns (e.g. backfill lagged and the 90D chart
+ * only sees api-v3 CORE+COW rows). Without this, the client defaults the
+ * stack to 100% v2 / 0% v3.
+ */
+async function fetchLatestVersionSeed(): Promise<VersionBreakdownSeed | null> {
+  const rows = (await sql`
+    SELECT DISTINCT ON (protocol)
+           protocol, total_liquidity, swap_volume_24h, swap_fee_24h
+    FROM protocol_snapshots
+    WHERE chain = ${AGGREGATE_KEY}
+      AND protocol = ANY(${[PROTOCOL_V2, PROTOCOL_V3]}::text[])
+    ORDER BY protocol, ts DESC
+  `) as {
+    protocol: string
+    total_liquidity: string
+    swap_volume_24h: string
+    swap_fee_24h: string
+  }[]
+
+  let v2: VersionBreakdownSeed['v2'] | null = null
+  let v3: VersionBreakdownSeed['v3'] | null = null
+  for (const r of rows) {
+    const partial = {
+      totalLiquidity: Number.parseFloat(r.total_liquidity) || 0,
+      swapVolume24h: Number.parseFloat(r.swap_volume_24h) || 0,
+      swapFee24h: Number.parseFloat(r.swap_fee_24h) || 0,
+    }
+    if (r.protocol === PROTOCOL_V2) v2 = partial
+    if (r.protocol === PROTOCOL_V3) v3 = partial
+  }
+  if (!v2 || !v3) return null
+  return { v2, v3 }
+}
+
+function seriesNeedsVersionSeed(series: ProtocolSnapshotSeries): boolean {
+  return series.points.some(p => !p.breakdowns?.V2 || !p.breakdowns?.V3)
+}
+
+async function buildSnapshotSeries(
+  days: AllowedDays,
+  granularity: Granularity
+): Promise<ProtocolSnapshotSeries> {
+  const rows = await fetchRows(days, granularity)
+  const series = foldRows(rows)
+  // Only hit the seed query when the window is missing V2/V3 somewhere —
+  // healthy DefiLlama-backed windows skip the extra round trip.
+  const seed = seriesNeedsVersionSeed(series) ? await fetchLatestVersionSeed() : null
+  forwardFillVersionBreakdowns(series.points, seed)
+  return series
+}
+
 // Cache the entire folded payload. Keyed on the validated (days, granularity)
 // tuple so the only distinct keys ever generated are
 // `4 buckets × 2 granularities = 8`, regardless of what the URL string
@@ -263,10 +324,11 @@ function foldRows(rows: DbRow[]): ProtocolSnapshotSeries {
 // more than once per (days, granularity) per `revalidate` window.
 const getSnapshotSeries = unstable_cache(
   async (days: AllowedDays, granularity: Granularity): Promise<ProtocolSnapshotSeries> => {
-    const rows = await fetchRows(days, granularity)
-    return foldRows(rows)
+    return buildSnapshotSeries(days, granularity)
   },
-  ['protocol-snapshots'],
+  // Bump the key when the forward-fill seed lands so CDN/unstable_cache
+  // entries that predate V2/V3 attribution don't keep serving a zeroed stack.
+  ['protocol-snapshots-v2'],
   // 1-hour TTL matches the cron write cadence. Combined with the
   // `s-maxage=3600` Cache-Control below, the CDN serves between writes and
   // the function only re-fetches from Postgres once per (days, granularity)
@@ -293,7 +355,7 @@ export async function GET(req: Request) {
   // below and the client's module-level cache, so origin load stays bounded.
   const series =
     granularity === 'hourly'
-      ? foldRows(await fetchRows(days, granularity))
+      ? await buildSnapshotSeries(days, granularity)
       : await getSnapshotSeries(days, granularity)
   // Browser + CDN cache. `s-maxage=3600` lets the Vercel edge share-cache
   // the response across visitors for the full snapshot interval; without

--- a/apps/balancer-analytics/lib/hooks/useTvlSeries.ts
+++ b/apps/balancer-analytics/lib/hooks/useTvlSeries.ts
@@ -11,12 +11,10 @@ export type Range = '24H' | '7D' | '30D' | '90D' | '1Y' | 'ALL'
 export type MetricKey = 'TVL' | 'VOLUME' | 'FEES' | 'YIELD' | 'SURPLUS' | 'LPS' | 'POOLS'
 
 // Maps the visible range to the number of days the snapshot endpoint should
-// return. Short ranges (24H, 7D) deliberately over-fetch so the v2/v3 ratio
-// warmup in `buildSeries` can find a DefiLlama backfill row — only those rows
-// carry explicit V2/V3 splits, the hourly api-v3 cron does not. Without the
-// warmup, 24H mode renders the entire stack as v2 (and v3 silently vanishes).
-// Bonus: 24H/7D/30D now share a snapshot fetch, so switching between them
-// hits the cache instead of re-fetching.
+// return. Short ranges (24H, 7D) over-fetch to share a snapshot fetch with
+// 30D, so switching between them hits the cache instead of re-fetching.
+// V2/V3 attribution is filled server-side (`/api/snapshots`), so the client
+// no longer needs a pre-window ratio warmup.
 const RANGE_DAYS: Record<Range, number> = {
   '24H': 30,
   '7D': 30,
@@ -163,32 +161,11 @@ function buildSeries(
   }
 
   const stacked = isStackedMetric(metric)
-  // Forward-fill V2/V3 share from explicit breakdowns. Initial ratio assumes
-  // 100% v2 (pre-v3 era) so points before the first explicit split don't
-  // accidentally show v3 attribution.
+  // `/api/snapshots` already forward-fills V2/V3 onto api-v3 points. Keep a
+  // thin in-slice fallback for the rare case a point still lacks the pair
+  // (e.g. empty DB / no DefiLlama seed yet). Default is 100% v2 so pre-v3
+  // points don't invent a v3 share.
   const ratio = { v2: 1, v3: 0, known: false }
-
-  // Warm the ratio from snapshots *before* the visible window. Only the
-  // DefiLlama backfill rows carry explicit V2/V3 splits — the hourly api-v3
-  // cron rows do not. Short ranges (24H, 7D) often see only cron rows inside
-  // their visible slice, so without this preheat the ratio stays at the
-  // {v2:1, v3:0} default and v3 silently disappears from the stack. We walk
-  // ascending so the final value reflects the *most recent* known split.
-  if (stacked) {
-    for (const p of snapshots) {
-      if (p.timestamp >= effectiveCutoff) break
-      const v2 = pickBreakdownMetric(p.breakdowns?.V2, metric)
-      const v3 = pickBreakdownMetric(p.breakdowns?.V3, metric)
-      if (v2 !== undefined && v3 !== undefined) {
-        const sum = v2 + v3
-        if (sum > 0) {
-          ratio.v2 = v2 / sum
-          ratio.v3 = v3 / sum
-          ratio.known = true
-        }
-      }
-    }
-  }
 
   const points: SeriesPoint[] = []
   let realPointCount = 0
@@ -246,9 +223,9 @@ function buildSeries(
 
 /**
  * Reads protocol metric history from the cron-driven snapshotter. For TVL and
- * Volume, returns a v2/v3/CoW AMM stack (forward-filling the ratio between
- * explicit breakdown rows). For fees / yield / surplus / LPs / pools, returns
- * the headline aggregate as a single series.
+ * Volume, returns a v2/v3/CoW AMM stack from the breakdowns `/api/snapshots`
+ * already filled. For fees / yield / surplus / LPs / pools, returns the
+ * headline aggregate as a single series.
  *
  * For "sparse" metrics (those introduced recently — YIELD, SURPLUS, LPS,
  * POOLS) the series is auto-trimmed to start at the first day we recorded a

--- a/apps/balancer-analytics/lib/snapshots/README.md
+++ b/apps/balancer-analytics/lib/snapshots/README.md
@@ -50,7 +50,7 @@ we already run for the Hyperliquid dashboard, and we know it works.
 - `../db.ts` — Neon client + `ensureSchema()`.
 - `../../app/api/cron/snapshot/route.ts` — hourly writer.
 - `../../app/api/snapshots/route.ts` — public read endpoint.
-- `../../vercel.json` — cron schedule (`0 * * * *`, UTC).
+- `../../vercel.json` — cron schedule (`0 * * * *` snapshot + `15 1 * * *` DefiLlama backfill, UTC).
 
 ## Setup
 

--- a/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.spec.ts
+++ b/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { forwardFillVersionBreakdowns, type VersionBreakdownSeed } from './forwardFillBreakdowns'
-import type { ProtocolSnapshotPoint } from './types'
+import { forwardFillVersionBreakdowns } from './forwardFillBreakdowns'
+import type { ProtocolSnapshotPoint, VersionBreakdownSeed } from './types'
 
 function point(
   partial: Partial<ProtocolSnapshotPoint> & { timestamp: number }

--- a/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.spec.ts
+++ b/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.spec.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  forwardFillVersionBreakdowns,
-  type VersionBreakdownSeed,
-} from './forwardFillBreakdowns'
+import { forwardFillVersionBreakdowns, type VersionBreakdownSeed } from './forwardFillBreakdowns'
 import type { ProtocolSnapshotPoint } from './types'
 
 function point(

--- a/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.spec.ts
+++ b/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  forwardFillVersionBreakdowns,
+  type VersionBreakdownSeed,
+} from './forwardFillBreakdowns'
+import type { ProtocolSnapshotPoint } from './types'
+
+function point(
+  partial: Partial<ProtocolSnapshotPoint> & { timestamp: number }
+): ProtocolSnapshotPoint {
+  return {
+    totalLiquidity: 0,
+    swapVolume24h: 0,
+    swapFee24h: 0,
+    yieldCapture24h: 0,
+    surplus24h: 0,
+    poolCount: 0,
+    numLiquidityProviders: 0,
+    byChain: {},
+    ...partial,
+  }
+}
+
+describe('forwardFillVersionBreakdowns', () => {
+  it('attributes CORE−COW using a seed ratio when the window has no V2/V3', () => {
+    const seed: VersionBreakdownSeed = {
+      v2: { totalLiquidity: 40, swapVolume24h: 10, swapFee24h: 1 },
+      v3: { totalLiquidity: 60, swapVolume24h: 30, swapFee24h: 3 },
+    }
+    const points = [
+      point({
+        timestamp: 1,
+        totalLiquidity: 110,
+        swapVolume24h: 50,
+        swapFee24h: 5,
+        breakdowns: {
+          COW_AMM: {
+            totalLiquidity: 10,
+            swapVolume24h: 10,
+            swapFee24h: 1,
+            yieldCapture24h: 0,
+            surplus24h: 0,
+            poolCount: 1,
+            byChain: {},
+          },
+        },
+      }),
+    ]
+
+    const filled = forwardFillVersionBreakdowns(points, seed)
+    expect(filled).toBe(1)
+    expect(points[0].breakdowns?.V2?.totalLiquidity).toBeCloseTo(40)
+    expect(points[0].breakdowns?.V3?.totalLiquidity).toBeCloseTo(60)
+    expect(points[0].breakdowns?.V2?.swapVolume24h).toBeCloseTo(10)
+    expect(points[0].breakdowns?.V3?.swapVolume24h).toBeCloseTo(30)
+    // Stack still equals CORE
+    const stack =
+      (points[0].breakdowns?.V2?.totalLiquidity ?? 0) +
+      (points[0].breakdowns?.V3?.totalLiquidity ?? 0) +
+      (points[0].breakdowns?.COW_AMM?.totalLiquidity ?? 0)
+    expect(stack).toBeCloseTo(110)
+  })
+
+  it('leaves explicit V2/V3 pairs untouched and uses them as the running ratio', () => {
+    const points = [
+      point({
+        timestamp: 1,
+        totalLiquidity: 100,
+        breakdowns: {
+          V2: {
+            totalLiquidity: 25,
+            swapVolume24h: 0,
+            swapFee24h: 0,
+            yieldCapture24h: 0,
+            surplus24h: 0,
+            poolCount: 0,
+            byChain: {},
+          },
+          V3: {
+            totalLiquidity: 75,
+            swapVolume24h: 0,
+            swapFee24h: 0,
+            yieldCapture24h: 0,
+            surplus24h: 0,
+            poolCount: 0,
+            byChain: {},
+          },
+        },
+      }),
+      point({
+        timestamp: 2,
+        totalLiquidity: 200,
+        breakdowns: {
+          COW_AMM: {
+            totalLiquidity: 0,
+            swapVolume24h: 0,
+            swapFee24h: 0,
+            yieldCapture24h: 0,
+            surplus24h: 0,
+            poolCount: 0,
+            byChain: {},
+          },
+        },
+      }),
+    ]
+
+    const filled = forwardFillVersionBreakdowns(points, null)
+    expect(filled).toBe(1)
+    expect(points[0].breakdowns?.V2?.totalLiquidity).toBe(25)
+    expect(points[0].breakdowns?.V3?.totalLiquidity).toBe(75)
+    expect(points[1].breakdowns?.V2?.totalLiquidity).toBeCloseTo(50)
+    expect(points[1].breakdowns?.V3?.totalLiquidity).toBeCloseTo(150)
+  })
+
+  it('does nothing when there is no seed and no in-window pair', () => {
+    const points = [point({ timestamp: 1, totalLiquidity: 100 })]
+    const filled = forwardFillVersionBreakdowns(points, null)
+    expect(filled).toBe(0)
+    expect(points[0].breakdowns?.V2).toBeUndefined()
+    expect(points[0].breakdowns?.V3).toBeUndefined()
+  })
+})

--- a/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.ts
+++ b/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.ts
@@ -1,0 +1,135 @@
+/**
+ * Forward-fill V2/V3 protocol breakdowns onto snapshot points that only have
+ * CORE (+ optional COW_AMM).
+ *
+ * Why this exists:
+ *   The hourly api-v3 cron writes CORE + COW_AMM only — it cannot emit a clean
+ *   V2/V3 split (BPT double-count). Explicit V2/V3 rows come from the DefiLlama
+ *   backfill. When that backfill lags (or a chart window simply doesn't reach
+ *   the last DefiLlama day), `useTvlSeries` defaults the stack to 100% v2 /
+ *   0% v3 and Balancer v3 silently disappears from the Protocol Metrics chart.
+ *
+ * Strategy:
+ *   Walk points ascending. Whenever an explicit V2+V3 pair is present, remember
+ *   its TVL/volume share. For subsequent points missing that pair, attribute
+ *   `(CORE − COW)` using the last known share so the stacked total still
+ *   matches the api-v3 headline.
+ *
+ *   Callers that have no in-window seed should pass `seed` from the most recent
+ *   V2/V3 ALL-chain rows in Postgres (see `/api/snapshots`).
+ */
+
+import type { ProtocolBreakdown, ProtocolSnapshotPoint } from './types'
+
+export type VersionBreakdownSeed = {
+  v2: Pick<ProtocolBreakdown, 'totalLiquidity' | 'swapVolume24h' | 'swapFee24h'>
+  v3: Pick<ProtocolBreakdown, 'totalLiquidity' | 'swapVolume24h' | 'swapFee24h'>
+}
+
+function emptyBreakdown(
+  partial: Pick<ProtocolBreakdown, 'totalLiquidity' | 'swapVolume24h' | 'swapFee24h'>
+): ProtocolBreakdown {
+  return {
+    totalLiquidity: partial.totalLiquidity,
+    swapVolume24h: partial.swapVolume24h,
+    swapFee24h: partial.swapFee24h,
+    yieldCapture24h: 0,
+    surplus24h: 0,
+    poolCount: 0,
+    byChain: {},
+  }
+}
+
+function hasExplicitPair(p: ProtocolSnapshotPoint): boolean {
+  return p.breakdowns?.V2 !== undefined && p.breakdowns?.V3 !== undefined
+}
+
+/**
+ * Mutates `points` in place. Returns the number of points that received a
+ * synthetic V2/V3 pair.
+ */
+export function forwardFillVersionBreakdowns(
+  points: ProtocolSnapshotPoint[],
+  seed: VersionBreakdownSeed | null = null
+): number {
+  let ratioTvlV2 = 1
+  let ratioTvlV3 = 0
+  let ratioVolV2 = 1
+  let ratioVolV3 = 0
+  let ratioFeeV2 = 1
+  let ratioFeeV3 = 0
+  let known = false
+
+  if (seed) {
+    const tvlSum = seed.v2.totalLiquidity + seed.v3.totalLiquidity
+    const volSum = seed.v2.swapVolume24h + seed.v3.swapVolume24h
+    const feeSum = seed.v2.swapFee24h + seed.v3.swapFee24h
+    if (tvlSum > 0) {
+      ratioTvlV2 = seed.v2.totalLiquidity / tvlSum
+      ratioTvlV3 = seed.v3.totalLiquidity / tvlSum
+      known = true
+    }
+    if (volSum > 0) {
+      ratioVolV2 = seed.v2.swapVolume24h / volSum
+      ratioVolV3 = seed.v3.swapVolume24h / volSum
+      known = true
+    }
+    if (feeSum > 0) {
+      ratioFeeV2 = seed.v2.swapFee24h / feeSum
+      ratioFeeV3 = seed.v3.swapFee24h / feeSum
+      known = true
+    }
+  }
+
+  let filled = 0
+
+  for (const p of points) {
+    if (hasExplicitPair(p)) {
+      const v2 = p.breakdowns!.V2!
+      const v3 = p.breakdowns!.V3!
+      const tvlSum = v2.totalLiquidity + v3.totalLiquidity
+      const volSum = v2.swapVolume24h + v3.swapVolume24h
+      const feeSum = v2.swapFee24h + v3.swapFee24h
+      if (tvlSum > 0) {
+        ratioTvlV2 = v2.totalLiquidity / tvlSum
+        ratioTvlV3 = v3.totalLiquidity / tvlSum
+        known = true
+      }
+      if (volSum > 0) {
+        ratioVolV2 = v2.swapVolume24h / volSum
+        ratioVolV3 = v3.swapVolume24h / volSum
+        known = true
+      }
+      if (feeSum > 0) {
+        ratioFeeV2 = v2.swapFee24h / feeSum
+        ratioFeeV3 = v3.swapFee24h / feeSum
+        known = true
+      }
+      continue
+    }
+
+    if (!known) continue
+
+    const cowTvl = p.breakdowns?.COW_AMM?.totalLiquidity ?? 0
+    const cowVol = p.breakdowns?.COW_AMM?.swapVolume24h ?? 0
+    const cowFee = p.breakdowns?.COW_AMM?.swapFee24h ?? 0
+    const nonCowTvl = Math.max(p.totalLiquidity - cowTvl, 0)
+    const nonCowVol = Math.max(p.swapVolume24h - cowVol, 0)
+    const nonCowFee = Math.max(p.swapFee24h - cowFee, 0)
+
+    if (!p.breakdowns) p.breakdowns = {}
+    p.breakdowns.V2 = emptyBreakdown({
+      totalLiquidity: nonCowTvl * ratioTvlV2,
+      swapVolume24h: nonCowVol * ratioVolV2,
+      swapFee24h: nonCowFee * ratioFeeV2,
+    })
+    p.breakdowns.V3 = emptyBreakdown({
+      totalLiquidity: nonCowTvl * ratioTvlV3,
+      swapVolume24h: nonCowVol * ratioVolV3,
+      swapFee24h: nonCowFee * ratioFeeV3,
+    })
+    filled++
+  }
+
+  return filled
+}

--- a/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.ts
+++ b/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.ts
@@ -6,12 +6,12 @@
  *   The hourly api-v3 cron writes CORE + COW_AMM only — it cannot emit a clean
  *   V2/V3 split (BPT double-count). Explicit V2/V3 rows come from the DefiLlama
  *   backfill. When that backfill lags (or a chart window simply doesn't reach
- *   the last DefiLlama day), `useTvlSeries` defaults the stack to 100% v2 /
- *   0% v3 and Balancer v3 silently disappears from the Protocol Metrics chart.
+ *   the last DefiLlama day), charts would otherwise default the stack to 100%
+ *   v2 / 0% v3 and Balancer v3 would silently disappear.
  *
  * Strategy:
  *   Walk points ascending. Whenever an explicit V2+V3 pair is present, remember
- *   its TVL/volume share. For subsequent points missing that pair, attribute
+ *   its TVL/volume/fees share. For subsequent points missing that pair, attribute
  *   `(CORE − COW)` using the last known share so the stacked total still
  *   matches the api-v3 headline.
  *
@@ -19,16 +19,56 @@
  *   V2/V3 ALL-chain rows in Postgres (see `/api/snapshots`).
  */
 
-import type { ProtocolBreakdown, ProtocolSnapshotPoint } from './types'
+import type {
+  ProtocolBreakdown,
+  ProtocolSnapshotPoint,
+  VersionBreakdownSeed,
+  VersionMetricSlice,
+} from './types'
 
-export type VersionBreakdownSeed = {
-  v2: Pick<ProtocolBreakdown, 'totalLiquidity' | 'swapVolume24h' | 'swapFee24h'>
-  v3: Pick<ProtocolBreakdown, 'totalLiquidity' | 'swapVolume24h' | 'swapFee24h'>
+type VersionShare = { v2: number; v3: number }
+
+type VersionRatios = {
+  tvl: VersionShare
+  volume: VersionShare
+  fees: VersionShare
+  known: boolean
 }
 
-function emptyBreakdown(
-  partial: Pick<ProtocolBreakdown, 'totalLiquidity' | 'swapVolume24h' | 'swapFee24h'>
-): ProtocolBreakdown {
+function emptyRatios(): VersionRatios {
+  return {
+    tvl: { v2: 1, v3: 0 },
+    volume: { v2: 1, v3: 0 },
+    fees: { v2: 1, v3: 0 },
+    known: false,
+  }
+}
+
+function share(a: number, b: number): VersionShare | null {
+  const sum = a + b
+  if (sum <= 0) return null
+  return { v2: a / sum, v3: b / sum }
+}
+
+function applyPair(ratios: VersionRatios, v2: VersionMetricSlice, v3: VersionMetricSlice): void {
+  const tvl = share(v2.totalLiquidity, v3.totalLiquidity)
+  if (tvl) {
+    ratios.tvl = tvl
+    ratios.known = true
+  }
+  const volume = share(v2.swapVolume24h, v3.swapVolume24h)
+  if (volume) {
+    ratios.volume = volume
+    ratios.known = true
+  }
+  const fees = share(v2.swapFee24h, v3.swapFee24h)
+  if (fees) {
+    ratios.fees = fees
+    ratios.known = true
+  }
+}
+
+function emptyBreakdown(partial: VersionMetricSlice): ProtocolBreakdown {
   return {
     totalLiquidity: partial.totalLiquidity,
     swapVolume24h: partial.swapVolume24h,
@@ -52,63 +92,18 @@ export function forwardFillVersionBreakdowns(
   points: ProtocolSnapshotPoint[],
   seed: VersionBreakdownSeed | null = null
 ): number {
-  let ratioTvlV2 = 1
-  let ratioTvlV3 = 0
-  let ratioVolV2 = 1
-  let ratioVolV3 = 0
-  let ratioFeeV2 = 1
-  let ratioFeeV3 = 0
-  let known = false
-
-  if (seed) {
-    const tvlSum = seed.v2.totalLiquidity + seed.v3.totalLiquidity
-    const volSum = seed.v2.swapVolume24h + seed.v3.swapVolume24h
-    const feeSum = seed.v2.swapFee24h + seed.v3.swapFee24h
-    if (tvlSum > 0) {
-      ratioTvlV2 = seed.v2.totalLiquidity / tvlSum
-      ratioTvlV3 = seed.v3.totalLiquidity / tvlSum
-      known = true
-    }
-    if (volSum > 0) {
-      ratioVolV2 = seed.v2.swapVolume24h / volSum
-      ratioVolV3 = seed.v3.swapVolume24h / volSum
-      known = true
-    }
-    if (feeSum > 0) {
-      ratioFeeV2 = seed.v2.swapFee24h / feeSum
-      ratioFeeV3 = seed.v3.swapFee24h / feeSum
-      known = true
-    }
-  }
+  const ratios = emptyRatios()
+  if (seed) applyPair(ratios, seed.v2, seed.v3)
 
   let filled = 0
 
   for (const p of points) {
     if (hasExplicitPair(p)) {
-      const v2 = p.breakdowns!.V2!
-      const v3 = p.breakdowns!.V3!
-      const tvlSum = v2.totalLiquidity + v3.totalLiquidity
-      const volSum = v2.swapVolume24h + v3.swapVolume24h
-      const feeSum = v2.swapFee24h + v3.swapFee24h
-      if (tvlSum > 0) {
-        ratioTvlV2 = v2.totalLiquidity / tvlSum
-        ratioTvlV3 = v3.totalLiquidity / tvlSum
-        known = true
-      }
-      if (volSum > 0) {
-        ratioVolV2 = v2.swapVolume24h / volSum
-        ratioVolV3 = v3.swapVolume24h / volSum
-        known = true
-      }
-      if (feeSum > 0) {
-        ratioFeeV2 = v2.swapFee24h / feeSum
-        ratioFeeV3 = v3.swapFee24h / feeSum
-        known = true
-      }
+      applyPair(ratios, p.breakdowns!.V2!, p.breakdowns!.V3!)
       continue
     }
 
-    if (!known) continue
+    if (!ratios.known) continue
 
     const cowTvl = p.breakdowns?.COW_AMM?.totalLiquidity ?? 0
     const cowVol = p.breakdowns?.COW_AMM?.swapVolume24h ?? 0
@@ -119,14 +114,14 @@ export function forwardFillVersionBreakdowns(
 
     if (!p.breakdowns) p.breakdowns = {}
     p.breakdowns.V2 = emptyBreakdown({
-      totalLiquidity: nonCowTvl * ratioTvlV2,
-      swapVolume24h: nonCowVol * ratioVolV2,
-      swapFee24h: nonCowFee * ratioFeeV2,
+      totalLiquidity: nonCowTvl * ratios.tvl.v2,
+      swapVolume24h: nonCowVol * ratios.volume.v2,
+      swapFee24h: nonCowFee * ratios.fees.v2,
     })
     p.breakdowns.V3 = emptyBreakdown({
-      totalLiquidity: nonCowTvl * ratioTvlV3,
-      swapVolume24h: nonCowVol * ratioVolV3,
-      swapFee24h: nonCowFee * ratioFeeV3,
+      totalLiquidity: nonCowTvl * ratios.tvl.v3,
+      swapVolume24h: nonCowVol * ratios.volume.v3,
+      swapFee24h: nonCowFee * ratios.fees.v3,
     })
     filled++
   }

--- a/apps/balancer-analytics/lib/snapshots/types.ts
+++ b/apps/balancer-analytics/lib/snapshots/types.ts
@@ -13,11 +13,13 @@ import { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
  *
  * Stacking V2 + V3 + COW_AMM approximates CORE. From DefiLlama backfill rows
  * they sum exactly (CORE was derived as the sum). From api-v3 cron rows
- * only COW_AMM is populated (no clean V2/V3 split available without BPT
- * double-counting), so the stack only renders for historical days.
+ * only COW_AMM is written by the hourly job; `/api/snapshots` forward-fills
+ * V2/V3 onto those points from the latest DefiLlama ratio so the stack does
+ * not collapse to 100% v2 when the chart window no longer overlaps a
+ * backfill day.
  *
  * Source: `'api-v3'` rows come from the hourly cron. `'defillama'` rows come
- * from the one-shot historical backfill (only TVL / volume / fees populated;
+ * from the daily DefiLlama backfill cron (only TVL / volume / fees populated;
  * the Balancer-specific fields are 0).
  */
 
@@ -58,7 +60,7 @@ export type ProtocolSnapshotPoint = {
   numLiquidityProviders: number
   /** Per-chain CORE breakdown. Sparse — chains absent at capture time are omitted. */
   byChain: Partial<Record<GqlChain, ChainSnapshotPoint>>
-  /** Optional per-version sub-series (V2 / V3 / COW_AMM). Always present for defillama rows, COW_AMM-only for api-v3 rows. */
+  /** Optional per-version sub-series (V2 / V3 / COW_AMM). Always present for defillama rows; api-v3 rows get COW_AMM from the hourly cron and V2/V3 forward-filled from the latest DefiLlama ratio at read time. */
   breakdowns?: Partial<Record<ProtocolKey, ProtocolBreakdown>>
   /** Where this point came from. */
   source?: SnapshotSource

--- a/apps/balancer-analytics/lib/snapshots/types.ts
+++ b/apps/balancer-analytics/lib/snapshots/types.ts
@@ -45,6 +45,17 @@ export type ProtocolBreakdown = {
   byChain: Partial<Record<GqlChain, ChainSnapshotPoint>>
 }
 
+/** TVL / volume / fees slice used to seed V2 vs V3 attribution. */
+export type VersionMetricSlice = Pick<
+  ProtocolBreakdown,
+  'totalLiquidity' | 'swapVolume24h' | 'swapFee24h'
+>
+
+export type VersionBreakdownSeed = {
+  v2: VersionMetricSlice
+  v3: VersionMetricSlice
+}
+
 export type ProtocolKey = 'V2' | 'V3' | 'COW_AMM'
 
 export type ProtocolSnapshotPoint = {

--- a/apps/balancer-analytics/vercel.json
+++ b/apps/balancer-analytics/vercel.json
@@ -6,6 +6,10 @@
       "schedule": "0 * * * *"
     },
     {
+      "path": "/api/cron/backfill",
+      "schedule": "15 1 * * *"
+    },
+    {
       "path": "/api/cron/sync-dune-labels",
       "schedule": "0 3 * * 1"
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Added server-side V2/V3 breakdown forward-fill in `/api/snapshots` so api-v3-only windows no longer render Balancer v3 as `$0`
- Scheduled the DefiLlama `/api/cron/backfill` job daily (`15 1 * * *` UTC) so V2/V3 rows stay fresh
- Added unit tests for the forward-fill helper and updated snapshot docs/types comments

## Why

On analytics.balancer.fi, Protocol Metrics showed **Balancer v3 TVL (and volume) as $0** while DefiLlama still reports ~$22M V3 TVL.

Root cause:
- The hourly cron only writes `CORE` + `COW_AMM` (no clean api-v3 V2/V3 split)
- Explicit V2/V3 rows come from the DefiLlama backfill, which was **manual-only**
- Last V2/V3 rows in Postgres stop around **2026-05-07**
- The 90D chart window therefore has no V2/V3 points, and the client defaults the stack to **100% v2 / 0% v3**

## Test Steps

- [x] Run `pnpm --filter balancer-analytics test:unit -- lib/snapshots/forwardFillBreakdowns.spec.ts` — all tests pass
- [ ] After deploy, trigger one backfill: `curl -H "Authorization: Bearer $CRON_SECRET" https://analytics.balancer.fi/api/cron/backfill` (or wait for 01:15 UTC)
- [ ] Open https://analytics.balancer.fi, Protocol Metrics, range **90D**, metric **TVL**
- [ ] Confirm **Balancer v3** is non-zero in the BY PROTOCOL breakdown (not `$0` / `0.0%`)
- [ ] Switch metric to **Volume** and confirm v3 is also non-zero
- [ ] Confirm total TVL still roughly matches the previous CORE headline (forward-fill attributes `CORE − COW`, it does not invent liquidity)

## Risks / Breaking Changes

- Touches shared-looking analytics code under `apps/balancer-analytics` only (not `packages/lib` / Beets)
- Until the first post-deploy backfill runs, forward-fill uses the latest stored V2/V3 ratio (currently from May), so the v2/v3 split may be imperfect vs live DefiLlama; it will correct once absolute DefiLlama rows are written for the May→now gap
- Cache key for `/api/snapshots` was bumped (`protocol-snapshots-v2`) so stale CDN/unstable_cache entries without V2/V3 attribution are not reused

## Other Notes

- DefiLlama currently reports balancer-v3 TVL ≈ $22.4M and meaningful daily volume — the `$0` was an attribution bug, not missing upstream TVL
- A one-shot backfill after merge is the fastest way to replace ratio-based attribution with fresh absolute DefiLlama V2/V3 rows for the gap
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://balancerecosystem.slack.com/archives/C02F9EMRKQA/p1786972912858759?thread_ts=1786972912.858759&cid=C02F9EMRKQA)

<div><a href="https://cursor.com/agents/bc-e90d9afe-b4f9-579c-9490-543bec49a522?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e90d9afe-b4f9-579c-9490-543bec49a522&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

