### PR TITLE
fix(alerts): render lucide icons in Chakra alerts

### DIFF
--- a/packages/lib/modules/lbp/steps/sale-structure/DynamicLbpTokenAmountInputs.tsx
+++ b/packages/lib/modules/lbp/steps/sale-structure/DynamicLbpTokenAmountInputs.tsx
@@ -56,7 +56,9 @@ export function DynamicLbpTokenAmountInputs() {
                 status={saleStartsSoon(saleStart) ? 'warning' : 'info'}
                 variant="WideOnDesktop"
               >
-                <AlertIcon as={saleStartsSoon(saleStart) ? AlertTriangle : LightbulbIcon} />
+                <AlertIcon>
+                  {saleStartsSoon(saleStart) ? <AlertTriangle /> : <LightbulbIcon />}
+                </AlertIcon>
                 <AlertDescription color="#000" fontSize="sm">
                   {saleStartsSoon(saleStart) && 'This sale is scheduled to start soon. '}
                   The LBP will fail to launch unless you seed the initial liquidity before the

--- a/packages/lib/modules/pool/LbpDetail/GetFundsWarning.tsx
+++ b/packages/lib/modules/pool/LbpDetail/GetFundsWarning.tsx
@@ -17,7 +17,9 @@ export function GetFundsWarning() {
 
   return (
     <Alert status="warning">
-      <AlertIcon as={AlertTriangle} />
+      <AlertIcon>
+        <AlertTriangle />
+      </AlertIcon>
 
       <HStack>
         <AlertTitle>Access the funds that you raised</AlertTitle>

--- a/packages/lib/shared/components/alerts/BalAlert.tsx
+++ b/packages/lib/shared/components/alerts/BalAlert.tsx
@@ -41,9 +41,14 @@ export function BalAlert({
     h: '24px',
     w: '24px',
   }
+
   return (
     <Alert rounded={isNavAlert ? 'none' : 'default'} status={status} {...rest}>
-      {ssr ? <AlertIcon {...iconSize} /> : <AlertIcon as={getAlertIcon(status)} {...iconSize} />}
+      {ssr ? (
+        <AlertIcon {...iconSize} />
+      ) : (
+        <AlertIcon {...iconSize}>{getAlertIcon(status)}</AlertIcon>
+      )}
 
       {title ? (
         <VStack align="start" gap="0.5" w="full">
@@ -101,16 +106,16 @@ export function BalAlert({
 function getAlertIcon(status: AlertStatus) {
   switch (status) {
     case 'info':
-      return LightbulbIcon
+      return <LightbulbIcon />
     case 'warning':
-      return AlertTriangle
+      return <AlertTriangle />
     case 'success':
-      return Check
+      return <Check />
     case 'error':
-      return XOctagon
+      return <XOctagon />
     case 'loading':
-      return Loader
+      return <Loader />
     default:
-      return LightbulbIcon
+      return <LightbulbIcon />
   }
 }

--- a/packages/lib/shared/components/errors/ErrorAlert.tsx
+++ b/packages/lib/shared/components/errors/ErrorAlert.tsx
@@ -11,7 +11,9 @@ type Props = AlertProps & {
 export function ErrorAlert({ title, children, ...rest }: PropsWithChildren<Props>) {
   return (
     <Alert mb="0" rounded="md" status="error" {...rest}>
-      <AlertIcon as={XCircle} boxSize="1.5em" />
+      <AlertIcon boxSize="1.5em">
+        <XCircle />
+      </AlertIcon>
       <Box maxHeight="160" ml="md" overflowY="auto" paddingRight="2">
         {title && <AlertTitle color="black">{title}</AlertTitle>}
         <AlertDescription>{children}</AlertDescription>


### PR DESCRIPTION
## What

- Updated shared alert components to render Lucide icons as `AlertIcon` children.
- Updated LBP warning alerts to use the same Chakra-compatible rendering pattern.

## Why

Chakra UI v2 `AlertIcon` renders a styled wrapper and does not correctly support Lucide SVG components through its `as` prop. After the React Feather to Lucide migration, affected alert icons were not visible.

## Test Steps

- [x] Run `pnpm typecheck` from the repository root.
- [x] Run `pnpm lint` in `packages/lib`.
- [ ] Open an alert using `BalAlert` and confirm its status icon is visible.
- [ ] Open the LBP sale structure and get-funds warning alerts and confirm their icons are visible.

## Risks / Breaking Changes

- Low risk: changes only how icons are nested inside Chakra alert wrappers.
- Shared `packages/lib` code affects both Balancer and Beets; alert spacing, sizing, status colors, and loading animation remain controlled by Chakra.