### PR TITLE
Replace Defilytica footer and Build popover links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,6 @@ This file provides guidance to coding agents working in this repository.
 
 Before any Next.js work, find and read the relevant doc in `apps/frontend-v3/node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
 
-### Always verify lint before committing
-
-Cloud Agent git hooks override `core.hooksPath`, so Husky / `lint-staged` (eslint `--fix`, prettier, typecheck) do **not** run on commit here. Do not assume a green commit means lint passed.
-
-Before every commit:
-
-1. Run eslint on every touched file (e.g. `pnpm --filter @repo/lib exec eslint <path> --max-warnings 0`, or the matching app/package `lint` script). Fix `padding-line-between-statements` and other style errors — do not strip required blank lines around multiline statements.
-2. Review the full `git diff --staged` (not just the intended hunk). Odd stats like `1 insertion, 2 deletions` for a one-line edit usually mean an accidental whitespace/padding change.
-
 ### Never hardcode project-specific values in `packages/lib`
 
 Both apps share `packages/lib`; the active project is resolved from `NEXT_PUBLIC_PROJECT_ID` in `config/getProjectConfig.ts`, which exposes `PROJECT_CONFIG` and `isBalancer` / `isBeets`. Hardcoding breaks the other app silently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,15 @@ This file provides guidance to coding agents working in this repository.
 
 Before any Next.js work, find and read the relevant doc in `apps/frontend-v3/node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
 
+### Always verify lint before committing
+
+Cloud Agent git hooks override `core.hooksPath`, so Husky / `lint-staged` (eslint `--fix`, prettier, typecheck) do **not** run on commit here. Do not assume a green commit means lint passed.
+
+Before every commit:
+
+1. Run eslint on every touched file (e.g. `pnpm --filter @repo/lib exec eslint <path> --max-warnings 0`, or the matching app/package `lint` script). Fix `padding-line-between-statements` and other style errors — do not strip required blank lines around multiline statements.
+2. Review the full `git diff --staged` (not just the intended hunk). Odd stats like `1 insertion, 2 deletions` for a one-line edit usually mean an accidental whitespace/padding change.
+
 ### Never hardcode project-specific values in `packages/lib`
 
 Both apps share `packages/lib`; the active project is resolved from `NEXT_PUBLIC_PROJECT_ID` in `config/getProjectConfig.ts`, which exposes `PROJECT_CONFIG` and `isBalancer` / `isBeets`. Hardcoding breaks the other app silently.

--- a/apps/frontend-v3/lib/components/navs/BuildPopover.tsx
+++ b/apps/frontend-v3/lib/components/navs/BuildPopover.tsx
@@ -29,7 +29,7 @@ const RESOURCE_LINKS = {
     },
     {
       label: 'DAO & Partner OPs',
-      href: 'https://balancer.defilytica.tools/',
+      href: 'https://ops.balancer.fi/',
       isExternal: true,
     },
   ],

--- a/packages/lib/config/projects/balancer.ts
+++ b/packages/lib/config/projects/balancer.ts
@@ -4,6 +4,7 @@ import { GqlChainValues, GqlPoolTypeValues } from '@repo/lib/shared/services/api
 import { isProd, isDev, isStaging } from '@repo/lib/config/app.config'
 
 const prodHiddenPoolTypes = [GqlPoolTypeValues.LiquidityBootstrapping] satisfies PoolFilterType[]
+
 const hiddenPoolTypes: PoolFilterType[] = [
   GqlPoolTypeValues.Fx,
   ...(isProd ? prodHiddenPoolTypes : []),

--- a/packages/lib/config/projects/balancer.ts
+++ b/packages/lib/config/projects/balancer.ts
@@ -4,7 +4,6 @@ import { GqlChainValues, GqlPoolTypeValues } from '@repo/lib/shared/services/api
 import { isProd, isDev, isStaging } from '@repo/lib/config/app.config'
 
 const prodHiddenPoolTypes = [GqlPoolTypeValues.LiquidityBootstrapping] satisfies PoolFilterType[]
-
 const hiddenPoolTypes: PoolFilterType[] = [
   GqlPoolTypeValues.Fx,
   ...(isProd ? prodHiddenPoolTypes : []),
@@ -134,7 +133,7 @@ export const ProjectConfigBalancer: ProjectConfig = {
             isExternal: true,
           },
           { label: 'Dune Analytics', href: 'https://dune.com/balancer', isExternal: true },
-          { label: 'Defilytica', href: 'https://balancer.defilytica.com', isExternal: true },
+          { label: 'Analytics', href: 'https://analytics.balancer.fi/', isExternal: true },
           {
             label: 'Brand assets',
             href: 'https://github.com/balancer/brand-assets',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Updated the Balancer footer Ecosystem link from Defilytica (`balancer.defilytica.com`) to Analytics (`https://analytics.balancer.fi/`).
- Updated the Build popover “DAO & Partner OPs” link from Defilytica tools (`balancer.defilytica.tools`) to `https://ops.balancer.fi/`.

## Why

Defilytica links in the frontend should point at the new Balancer Analytics and Ops sites.

## Test Steps

- [x] Open the Balancer app (frontend-v3) on any page that shows the site footer
- [x] Scroll to the footer Ecosystem section
- [x] Confirm the former Defilytica link is gone
- [x] Confirm an Analytics link is present and points to `https://analytics.balancer.fi/`
- [x] Open the top-nav Build popover
- [x] Confirm “DAO & Partner OPs” points to `https://ops.balancer.fi/`
- [x] Confirm `packages/lib/config/projects/balancer.ts` keeps a blank line between `prodHiddenPoolTypes` and the multiline `hiddenPoolTypes` declaration
- [x] Run `pnpm --filter @repo/lib exec eslint config/projects/balancer.ts --max-warnings 0` (should pass)

## Risks / Breaking Changes

- Footer change touches shared `packages/lib` project config, but only `projects/balancer.ts`, so Beets is unaffected (`NEXT_PUBLIC_PROJECT_ID`).
- Build popover change is Balancer app-only (`apps/frontend-v3`).
- Footer Ecosystem now has both "Dune Analytics" and "Analytics" labels (different destinations); intentional per request.

## Other Notes

- No remaining Defilytica URL references in the repo after this change.

[Footer Ecosystem with Analytics link](https://cursor.com/agents/bc-016c5983-fb37-5f09-89fe-170d6b5b301b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffooter_ecosystem_analytics_link.webp)
[Analytics link hover showing analytics.balancer.fi](https://cursor.com/agents/bc-016c5983-fb37-5f09-89fe-170d6b5b301b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffooter_analytics_link_hover.webp)
[footer_analytics_link_demo.mp4](https://cursor.com/agents/bc-016c5983-fb37-5f09-89fe-170d6b5b301b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffooter_analytics_link_demo.mp4)
[Build popover with DAO and Partner OPs](https://cursor.com/agents/bc-016c5983-fb37-5f09-89fe-170d6b5b301b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_popover_open.webp)
[DAO and Partner OPs hover showing ops.balancer.fi](https://cursor.com/agents/bc-016c5983-fb37-5f09-89fe-170d6b5b301b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_popover_dao_ops_hover.webp)
[build_popover_ops_link_demo.mp4](https://cursor.com/agents/bc-016c5983-fb37-5f09-89fe-170d6b5b301b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_popover_ops_link_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://balancerecosystem.slack.com/archives/C02F9EMRKQA/p1787121422216059?thread_ts=1787121422.216059&cid=C02F9EMRKQA)

<div><a href="https://cursor.com/agents/bc-016c5983-fb37-5f09-89fe-170d6b5b301b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-016c5983-fb37-5f09-89fe-170d6b5b301b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

