### PR TITLE
chore(cursor): run lint-staged on cloud agent commits

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/lint-staged.sh",
+        "matcher": "git commit[[:space:]]"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/lint-staged.sh
+++ b/.cursor/hooks/lint-staged.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Cursor Cloud Agent overrides core.hooksPath, so the repo's husky/lint-staged
+# pre-commit never runs on `git commit`. This hook re-applies the same gate:
+# run lint-staged on the staged files, then block the commit if it fails.
+# lint-staged re-stages its fixes, so the following `git commit` picks them up.
+
+# Consume stdin (hook input JSON) so the shell doesn't wait on it.
+cat > /dev/null
+
+if pnpm lint-staged; then
+  echo '{"permission": "allow"}'
+  exit 0
+else
+  echo '{"permission": "deny", "user_message": "lint-staged failed. Fix the reported issues and retry the commit."}'
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Cursor Cloud Agent overrides `core.hooksPath` to its own agent hooks, so the repo's husky/lint-staged pre-commit never runs on `git commit` in that environment. This means eslint/prettier/stylelint fixes and the typecheck gate are silently skipped for cloud-agent commits.

## Change

Add a Cursor `beforeShellExecution` hook (supported in Cloud Agents) that matches `git commit` and runs `pnpm lint-staged` on the staged files, blocking the commit if it fails.

- `.cursor/hooks.json` — hook config, matcher `git commit[[:space:]]` (strict, avoids `git commit-tree`/graph)
- `.cursor/hooks/lint-staged.sh` — runs `pnpm lint-staged`; `allow` on success, `deny` on failure

## Why this approach

- Fires on commit only, not on edit.
- `beforeShellExecution` is in the Cloud Agent supported-hooks table.
- Doesn't depend on `core.hooksPath`, so the Cloud Agent's override is irrelevant.
- Cursor-only: lives in `.cursor/`, local commits still go through husky as before.
