### PR TITLE
fix(create): guard indexed access for noUncheckedIndexedAccess

### DIFF
--- a/packages/lib/modules/pool/LbpDetail/MyTransactions.tsx
+++ b/packages/lib/modules/pool/LbpDetail/MyTransactions.tsx
@@ -47,6 +47,8 @@ export function MyTransactions({
   const projectToken = lbpPool.poolTokens[lbpPool.projectTokenIndex]
   const reserveToken = lbpPool.poolTokens[lbpPool.reserveTokenIndex]
 
+  if (!projectToken || !reserveToken) return null
+
   const tokenLogoURIs: Record<string, string> = {
     [projectToken.address]: projectToken.logoURI || '',
     [reserveToken.address]: reserveToken.logoURI || '',
@@ -231,28 +233,32 @@ function AddOrRemoveTokens({
   chain: GqlChain
   tokenLogoURIs: Record<string, string>
 }) {
+  const [tokenIn, tokenOut] = event.tokens
+
+  if (!tokenIn || !tokenOut) return null
+
   return (
     <HStack>
       <HStack gap={['xs', 'sm']} mb="sm">
         <TokenIcon
-          address={event.tokens[0].address}
-          alt={event.tokens[0].address}
+          address={tokenIn.address}
+          alt={tokenIn.address}
           chain={chain}
-          logoURI={tokenLogoURIs[event.tokens[0].address]}
+          logoURI={tokenLogoURIs[tokenIn.address]}
           size={24}
         />
         <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
-          {fNum('token', event.tokens[0].amount)}
+          {fNum('token', tokenIn.amount)}
         </Text>
         <TokenIcon
-          address={event.tokens[1].address}
-          alt={event.tokens[1].address}
+          address={tokenOut.address}
+          alt={tokenOut.address}
           chain={chain}
-          logoURI={tokenLogoURIs[event.tokens[1].address]}
+          logoURI={tokenLogoURIs[tokenOut.address]}
           size={24}
         />
         <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
-          {fNum('token', event.tokens[1].amount)}
+          {fNum('token', tokenOut.amount)}
         </Text>
       </HStack>
     </HStack>

--- a/packages/lib/modules/pool/actions/create/PoolCreationForm.tsx
+++ b/packages/lib/modules/pool/actions/create/PoolCreationForm.tsx
@@ -109,7 +109,7 @@ export function PoolCreationForm() {
 
               <Divider />
 
-              {canRenderStep && <currentStep.Component />}
+              {canRenderStep && currentStep && <currentStep.Component />}
             </VStack>
             {!isMobile && <PreviewPoolCreation />}
           </>

--- a/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
+++ b/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
@@ -6,6 +6,7 @@ import {
   INITIAL_POOL_CREATION_FORM,
   INITIAL_ECLP_CONFIG,
   INITIAL_AUTORANGE_CONFIG,
+  INITIAL_POOL_TOKENS,
 } from './constants'
 import { act, waitFor } from '@testing-library/react'
 
@@ -126,11 +127,11 @@ describe('usePoolFormLogic', () => {
     it('inverts alpha/beta/peakPrice, preserves lambda, and reverses poolTokens', async () => {
       const { result } = await renderPoolForm()
 
-      const tokenA = { ...INITIAL_POOL_CREATION_FORM.poolTokens[0]!, weight: '50' }
-      const tokenB = { ...INITIAL_POOL_CREATION_FORM.poolTokens[1]!, weight: '50' }
+      const tokenA = { ...INITIAL_POOL_TOKENS[0], weight: '50' }
+      const tokenB = { ...INITIAL_POOL_TOKENS[1], weight: '50' }
 
       act(() => {
-        result.current.poolCreationForm.setValue('poolTokens', [tokenA!, tokenB!])
+        result.current.poolCreationForm.setValue('poolTokens', [tokenA, tokenB])
         result.current.eclpConfigForm.setValue('alpha', '2')
         result.current.eclpConfigForm.setValue('beta', '4')
         result.current.eclpConfigForm.setValue('peakPrice', '5')
@@ -156,11 +157,11 @@ describe('usePoolFormLogic', () => {
     it('inverts target price, swaps min<->max with inversion, and reverses poolTokens', async () => {
       const { result } = await renderPoolForm()
 
-      const tokenA = { ...INITIAL_POOL_CREATION_FORM.poolTokens[0]!, weight: 'A' }
-      const tokenB = { ...INITIAL_POOL_CREATION_FORM.poolTokens[1]!, weight: 'B' }
+      const tokenA = { ...INITIAL_POOL_TOKENS[0], weight: 'A' }
+      const tokenB = { ...INITIAL_POOL_TOKENS[1], weight: 'B' }
 
       act(() => {
-        result.current.poolCreationForm.setValue('poolTokens', [tokenA!, tokenB!])
+        result.current.poolCreationForm.setValue('poolTokens', [tokenA, tokenB])
         result.current.autoRangeConfigForm.setValue('initialMinPrice', '2')
         result.current.autoRangeConfigForm.setValue('initialMaxPrice', '8')
         result.current.autoRangeConfigForm.setValue('initialTargetPrice', '4')

--- a/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
+++ b/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.integration.spec.tsx
@@ -126,11 +126,11 @@ describe('usePoolFormLogic', () => {
     it('inverts alpha/beta/peakPrice, preserves lambda, and reverses poolTokens', async () => {
       const { result } = await renderPoolForm()
 
-      const tokenA = { ...INITIAL_POOL_CREATION_FORM.poolTokens[0], weight: '50' }
-      const tokenB = { ...INITIAL_POOL_CREATION_FORM.poolTokens[1], weight: '50' }
+      const tokenA = { ...INITIAL_POOL_CREATION_FORM.poolTokens[0]!, weight: '50' }
+      const tokenB = { ...INITIAL_POOL_CREATION_FORM.poolTokens[1]!, weight: '50' }
 
       act(() => {
-        result.current.poolCreationForm.setValue('poolTokens', [tokenA, tokenB])
+        result.current.poolCreationForm.setValue('poolTokens', [tokenA!, tokenB!])
         result.current.eclpConfigForm.setValue('alpha', '2')
         result.current.eclpConfigForm.setValue('beta', '4')
         result.current.eclpConfigForm.setValue('peakPrice', '5')
@@ -156,11 +156,11 @@ describe('usePoolFormLogic', () => {
     it('inverts target price, swaps min<->max with inversion, and reverses poolTokens', async () => {
       const { result } = await renderPoolForm()
 
-      const tokenA = { ...INITIAL_POOL_CREATION_FORM.poolTokens[0], weight: 'A' }
-      const tokenB = { ...INITIAL_POOL_CREATION_FORM.poolTokens[1], weight: 'B' }
+      const tokenA = { ...INITIAL_POOL_CREATION_FORM.poolTokens[0]!, weight: 'A' }
+      const tokenB = { ...INITIAL_POOL_CREATION_FORM.poolTokens[1]!, weight: 'B' }
 
       act(() => {
-        result.current.poolCreationForm.setValue('poolTokens', [tokenA, tokenB])
+        result.current.poolCreationForm.setValue('poolTokens', [tokenA!, tokenB!])
         result.current.autoRangeConfigForm.setValue('initialMinPrice', '2')
         result.current.autoRangeConfigForm.setValue('initialMaxPrice', '8')
         result.current.autoRangeConfigForm.setValue('initialTargetPrice', '4')

--- a/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.tsx
+++ b/packages/lib/modules/pool/actions/create/PoolCreationFormProvider.tsx
@@ -59,7 +59,9 @@ export function usePoolFormLogic() {
   const updatePoolToken = (index: number, updates: Partial<PoolCreationToken>) => {
     const currentPoolTokens = poolCreationForm.getValues('poolTokens')
     const newPoolTokens = [...currentPoolTokens]
-    newPoolTokens[index] = { ...newPoolTokens[index], ...updates }
+    const currentToken = newPoolTokens[index]
+    if (!currentToken) return
+    newPoolTokens[index] = { ...currentToken, ...updates }
     poolCreationForm.setValue('poolTokens', newPoolTokens)
   }
 

--- a/packages/lib/modules/pool/actions/create/constants.ts
+++ b/packages/lib/modules/pool/actions/create/constants.ts
@@ -146,7 +146,10 @@ export const INITIAL_TOKEN_CONFIG: PoolCreationToken = {
   weight: '50',
 }
 
-export const INITIAL_POOL_TOKENS = [INITIAL_TOKEN_CONFIG, INITIAL_TOKEN_CONFIG]
+export const INITIAL_POOL_TOKENS: [PoolCreationToken, PoolCreationToken] = [
+  INITIAL_TOKEN_CONFIG,
+  INITIAL_TOKEN_CONFIG,
+]
 
 export const INITIAL_POOL_CREATION_FORM: PoolCreationForm = {
   protocol: BALANCER_PROTOCOL_OPTIONS[0].name,
@@ -159,7 +162,7 @@ export const INITIAL_POOL_CREATION_FORM: PoolCreationForm = {
   swapFeeManager: zeroAddress,
   pauseManager: zeroAddress,
   poolCreator: zeroAddress,
-  swapFeePercentage: getSwapFeePercentageOptions(PoolType.Stable)[0]!.value,
+  swapFeePercentage: getSwapFeePercentageOptions(PoolType.Stable)[0].value,
   amplificationParameter: '100',
   poolHooksContract: zeroAddress,
   enableDonation: false,

--- a/packages/lib/modules/pool/actions/create/constants.ts
+++ b/packages/lib/modules/pool/actions/create/constants.ts
@@ -159,7 +159,7 @@ export const INITIAL_POOL_CREATION_FORM: PoolCreationForm = {
   swapFeeManager: zeroAddress,
   pauseManager: zeroAddress,
   poolCreator: zeroAddress,
-  swapFeePercentage: getSwapFeePercentageOptions(PoolType.Stable)[0].value,
+  swapFeePercentage: getSwapFeePercentageOptions(PoolType.Stable)[0]!.value,
   amplificationParameter: '100',
   poolHooksContract: zeroAddress,
   enableDonation: false,

--- a/packages/lib/modules/pool/actions/create/helpers.ts
+++ b/packages/lib/modules/pool/actions/create/helpers.ts
@@ -27,7 +27,9 @@ export function getGqlPoolType(poolType: PoolType): GqlPoolType {
   return gqlPoolType
 }
 
-export function getSwapFeePercentageOptions(poolType: PoolType): { value: string; tip: string }[] {
+export function getSwapFeePercentageOptions(
+  poolType: PoolType
+): [SwapFeePercentageOption, SwapFeePercentageOption] {
   const isStablePool = poolType === PoolType.Stable || poolType === PoolType.StableSurge
 
   if (isStablePool) {
@@ -124,3 +126,5 @@ export function isPoolCreatorEnabled(poolType: PoolType): boolean {
   // AutoRange and eclp factories still require zero address
   return poolType === PoolType.Stable || poolType === PoolType.Weighted
 }
+
+export type SwapFeePercentageOption = { value: string; tip: string }

--- a/packages/lib/modules/pool/actions/create/modal/PoolCreationModal.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/PoolCreationModal.tsx
@@ -179,15 +179,15 @@ export function PoolCreationModal({
             setUsingBigBlocksError={setUsingBigBlocksError}
             shouldUseBigBlocks={shouldUseBigBlocks}
           />
-        ) : (
+        ) : transactionSteps.currentStep ? (
           <ActionModalFooter
-            currentStep={transactionSteps.currentStep!}
+            currentStep={transactionSteps.currentStep}
             isSuccess={isPoolInitialized}
             returnAction={redirectToPoolPage}
             returnLabel="View pool page"
             urlTxHash={urlTxHash}
           />
-        )}
+        ) : null}
       </ModalContent>
     </Modal>
   )

--- a/packages/lib/modules/pool/actions/create/modal/PoolCreationModal.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/PoolCreationModal.tsx
@@ -181,7 +181,7 @@ export function PoolCreationModal({
           />
         ) : (
           <ActionModalFooter
-            currentStep={transactionSteps.currentStep}
+            currentStep={transactionSteps.currentStep!}
             isSuccess={isPoolInitialized}
             returnAction={redirectToPoolPage}
             returnLabel="View pool page"

--- a/packages/lib/modules/pool/actions/create/modal/cow-amm-steps/useCreateCowSteps.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/cow-amm-steps/useCreateCowSteps.tsx
@@ -24,13 +24,15 @@ export function useCreateCowSteps({ initPoolInput, network, poolType }: UseCreat
   const txConfig = { network, poolType, poolAddress }
 
   // cow pool will always be exactly 2 tokens
+  const [token0, token1] = amountsIn
+
   const { step: bindToken0Step, isLoading: isLoadingBindToken0 } = useBindTokenStep({
-    token: amountsIn[0]!,
+    token: token0!,
     ...txConfig,
   })
 
   const { step: bindToken1Step, isLoading: isLoadingBindToken1 } = useBindTokenStep({
-    token: amountsIn[1]!,
+    token: token1!,
     ...txConfig,
   })
 

--- a/packages/lib/modules/pool/actions/create/modal/cow-amm-steps/useCreateCowSteps.tsx
+++ b/packages/lib/modules/pool/actions/create/modal/cow-amm-steps/useCreateCowSteps.tsx
@@ -25,12 +25,12 @@ export function useCreateCowSteps({ initPoolInput, network, poolType }: UseCreat
 
   // cow pool will always be exactly 2 tokens
   const { step: bindToken0Step, isLoading: isLoadingBindToken0 } = useBindTokenStep({
-    token: amountsIn[0],
+    token: amountsIn[0]!,
     ...txConfig,
   })
 
   const { step: bindToken1Step, isLoading: isLoadingBindToken1 } = useBindTokenStep({
-    token: amountsIn[1],
+    token: amountsIn[1]!,
     ...txConfig,
   })
 

--- a/packages/lib/modules/pool/actions/create/modal/useCreatePoolInput.ts
+++ b/packages/lib/modules/pool/actions/create/modal/useCreatePoolInput.ts
@@ -76,7 +76,7 @@ export function useCreatePoolInput(chainId: number): CreatePoolInput {
       poolCreator,
       tokens: baseInput.tokens.map((token, index) => ({
         ...token,
-        weight: parseUnits(poolTokens[index].weight, PERCENTAGE_DECIMALS),
+        weight: parseUnits(poolTokens[index]?.weight ?? '50', PERCENTAGE_DECIMALS),
       })),
     }
   }

--- a/packages/lib/modules/pool/actions/create/preview/usePreviewEclpLiquidityProfile.ts
+++ b/packages/lib/modules/pool/actions/create/preview/usePreviewEclpLiquidityProfile.ts
@@ -45,13 +45,13 @@ export function usePreviewEclpLiquidityProfile(): ECLPLiquidityProfile {
   )
 
   const data = liquidityData
-    ? (liquidityData
+    ? liquidityData
         .filter(([price]) => price !== 0) // filter out zero price to prevent infinity on reverse
-        .map(([price, liquidity]) => {
+        .map(([price, liquidity]): [number, number] => {
           const displayedPrice = bn(price).div(priceRateRatio).toNumber()
           return isReversed ? [1 / displayedPrice, liquidity] : [displayedPrice, liquidity]
         })
-        .sort((a, b) => a[0]! - b[0]!) as [number, number][])
+        .sort((a, b) => a[0] - b[0])
     : null
 
   const xMin = data ? Math.min(...data.map(([x]) => x)) : 0

--- a/packages/lib/modules/pool/actions/create/preview/usePreviewEclpLiquidityProfile.ts
+++ b/packages/lib/modules/pool/actions/create/preview/usePreviewEclpLiquidityProfile.ts
@@ -51,7 +51,7 @@ export function usePreviewEclpLiquidityProfile(): ECLPLiquidityProfile {
           const displayedPrice = bn(price).div(priceRateRatio).toNumber()
           return isReversed ? [1 / displayedPrice, liquidity] : [displayedPrice, liquidity]
         })
-        .sort((a, b) => a[0] - b[0]) as [number, number][])
+        .sort((a, b) => a[0]! - b[0]!) as [number, number][])
     : null
 
   const xMin = data ? Math.min(...data.map(([x]) => x)) : 0

--- a/packages/lib/modules/pool/actions/create/steps/details/AutoRangeConfiguration.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/AutoRangeConfiguration.tsx
@@ -237,7 +237,7 @@ export function ConfigOptionsGroup<T extends FieldValues = FieldValues>({
             width="full"
           />
         </VStack>
-      ) : isCustom ? (
+      ) : isCustom && options[1] ? (
         <NumberInput
           control={control}
           isPercentage={isPercentage}

--- a/packages/lib/modules/pool/actions/create/steps/details/useAutoRangeConfigurationOptions.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/details/useAutoRangeConfigurationOptions.tsx
@@ -182,10 +182,10 @@ export function useAutoRangeConfigurationOptions(): ConfigOptionsGroupProps<Auto
   // auto-fill config with default values
   useEffect(() => {
     if (isInitialAutoRangeConfig) {
-      const currentPrice = targetPrice.options[1].rawValue
-      const priceRangePercentage = priceRangeBoundaries.options[1].rawValue
-      const centerednessMargin = marginBuffer.options[1].rawValue
-      const priceShiftDailyRate = dailyPriceReadjustmentRate.options[1].rawValue
+      const currentPrice = targetPrice.options[1]?.rawValue ?? ''
+      const priceRangePercentage = priceRangeBoundaries.options[1]?.rawValue ?? ''
+      const centerednessMargin = marginBuffer.options[1]?.rawValue ?? ''
+      const priceShiftDailyRate = dailyPriceReadjustmentRate.options[1]?.rawValue ?? ''
 
       autoRangeConfigForm.setValue('initialTargetPrice', currentPrice, { shouldValidate: true })
 

--- a/packages/lib/modules/pool/actions/create/steps/details/usePoolHooksWhitelist.ts
+++ b/packages/lib/modules/pool/actions/create/steps/details/usePoolHooksWhitelist.ts
@@ -31,14 +31,12 @@ export function usePoolHooksWhitelist(network: GqlChain) {
   const poolHooksWhitelist = useMemo(() => {
     return (
       data
-        ?.filter(hook => Object.keys(hook.addresses).includes(chainId.toString()))
-        .map(hook => {
+        ?.map(hook => {
           const hooksArray = hook.addresses[chainId.toString()]
-          return {
-            label: hook.name,
-            value: hooksArray[hooksArray.length - 1], // use the most recently deployed hook?
-          }
-        }) || []
+          const value = hooksArray?.[hooksArray.length - 1] // use the most recently deployed hook?
+          return value ? { label: hook.name, value } : null
+        })
+        .filter((hook): hook is { label: string; value: Address } => hook !== null) || []
     )
   }, [data, chainId])
 

--- a/packages/lib/modules/pool/actions/create/steps/details/usePoolHooksWhitelist.ts
+++ b/packages/lib/modules/pool/actions/create/steps/details/usePoolHooksWhitelist.ts
@@ -31,10 +31,12 @@ export function usePoolHooksWhitelist(network: GqlChain) {
   const poolHooksWhitelist = useMemo(() => {
     return (
       data
-        ?.map(hook => {
-          const hooksArray = hook.addresses[chainId.toString()]
-          const value = hooksArray?.[hooksArray.length - 1] // use the most recently deployed hook?
-          return value ? { label: hook.name, value } : null
+        ?.filter(hook => Object.keys(hook.addresses).includes(chainId.toString()))
+        .map(hook => {
+          const hooksArray = hook.addresses[chainId.toString()]!
+          const value = hooksArray[hooksArray.length - 1] // use the most recently deployed hook?
+          if (!value) return null
+          return { label: hook.name, value }
         })
         .filter((hook): hook is { label: string; value: Address } => hook !== null) || []
     )

--- a/packages/lib/modules/pool/actions/create/steps/details/usePoolSpotPriceWithoutRate.ts
+++ b/packages/lib/modules/pool/actions/create/steps/details/usePoolSpotPriceWithoutRate.ts
@@ -21,8 +21,8 @@ export function usePoolSpotPriceWithoutRate() {
   const tokenA = poolTokens[0]
   const tokenB = poolTokens[1]
 
-  const priceTokenA = tokenA.usdPrice || priceFor(tokenA?.address || '', network)
-  const priceTokenB = tokenB.usdPrice || priceFor(tokenB?.address || '', network)
+  const priceTokenA = tokenA?.usdPrice || priceFor(tokenA?.address || '', network)
+  const priceTokenB = tokenB?.usdPrice || priceFor(tokenB?.address || '', network)
 
   const { rate: rawRateTokenA, isRatePending: isRateAPending } = useRateProvider(
     tokenA?.rateProvider,

--- a/packages/lib/modules/pool/actions/create/steps/fund/SeedAmountInput.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/fund/SeedAmountInput.tsx
@@ -84,11 +84,11 @@ export function SeedAmountInput({ token, idx, poolType, poolTokens }: TokenAmoun
 
     const otherTokenAmountIdx = sortedAddresses.indexOf(otherToken.address.toLowerCase())
 
+    const initAmount = autoRangeInitAmounts[otherTokenAmountIdx]
+    if (initAmount === undefined) return
+
     // Update the other token's amount using the corresponding value from initAmounts
-    const otherTokenAmount = formatUnits(
-      autoRangeInitAmounts[otherTokenAmountIdx],
-      otherToken.data.decimals
-    )
+    const otherTokenAmount = formatUnits(initAmount, otherToken.data.decimals)
 
     updatePoolToken(otherTokenInputIdx, { amount: otherTokenAmount })
     lastUserUpdatedAmountIdx.current = null

--- a/packages/lib/modules/pool/actions/create/steps/fund/SeedAmountProportions.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/fund/SeedAmountProportions.tsx
@@ -50,7 +50,7 @@ export function SeedAmountProportions({ variant = 'level3', displayAlert = false
   const usdWeights = tokenAmountToUsdWithWeights.map(t => t.usdWeight)
 
   const isAllWeightsCloseToTarget = targetWeights.every((weight, idx) => {
-    const usdWeight = usdWeights[idx]
+    const usdWeight = usdWeights[idx] ?? 0
     return Math.abs(weight - usdWeight) < WEIGHT_DEVIATION_TOLERANCE
   })
 

--- a/packages/lib/modules/pool/actions/create/steps/fund/useGyroEclpInitAmountsRatio.ts
+++ b/packages/lib/modules/pool/actions/create/steps/fund/useGyroEclpInitAmountsRatio.ts
@@ -55,7 +55,7 @@ export function useGyroEclpInitAmountsRatio() {
   return amountTokenA / amountTokenB // the ratio for calculating token init amounts
 }
 
-function getTau(price: number, c: number, s: number, lambda: number) {
+function getTau(price: number, c: number, s: number, lambda: number): [number, number] {
   const dSq = c * c + s * s
   const d = Math.sqrt(dSq)
 

--- a/packages/lib/modules/pool/actions/create/steps/tokens/ConfigureTokenRateProvider.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/ConfigureTokenRateProvider.tsx
@@ -57,7 +57,7 @@ export function ConfigureTokenRateProvider({
 
     if (value === RateProviderOption.Verified) {
       rateProvider = verifiedRateProviderAddress as Address
-      paysYieldFees = !isMarketRateProvider(poolTokens[tokenIndex].data)
+      paysYieldFees = !isMarketRateProvider(poolTokens[tokenIndex]?.data)
     } else if (value === RateProviderOption.Custom) {
       rateProvider = '' // to be updated by user input
     }

--- a/packages/lib/modules/pool/actions/create/steps/tokens/useCoingeckoTokenPrice.ts
+++ b/packages/lib/modules/pool/actions/create/steps/tokens/useCoingeckoTokenPrice.ts
@@ -39,7 +39,7 @@ export function useCoingeckoTokenPrice({ token, network }: Props) {
         throw new Error(`Failed to fetch CoinGecko price for ${token} on ${network}`)
       }
 
-      return token ? data[token.toLowerCase()].usd : undefined
+      return token ? data[token.toLowerCase()]?.usd : undefined
     },
     enabled: !apiPriceForToken && !!token && !!network && !!assetPlatform,
     retry: false, // helps to avoid rate limit when coingecko has no price for token?

--- a/packages/lib/modules/pool/actions/create/steps/type/ChooseNetwork.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/type/ChooseNetwork.tsx
@@ -25,7 +25,7 @@ export function ChooseNetwork({ control }: { control: Control<PoolCreationForm> 
   const protocolNetworks = isCowProtocol(protocol) ? cowSupportedNetworks : supportedNetworks
 
   const networkOptions: RadioCardOption<GqlChain>[] = [
-    protocolNetworks[0]!,
+    protocolNetworks[0],
     ...protocolNetworks.slice(1).sort(),
   ]
     .filter(

--- a/packages/lib/modules/pool/actions/create/steps/type/ChooseNetwork.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/type/ChooseNetwork.tsx
@@ -25,13 +25,13 @@ export function ChooseNetwork({ control }: { control: Control<PoolCreationForm> 
   const protocolNetworks = isCowProtocol(protocol) ? cowSupportedNetworks : supportedNetworks
 
   const networkOptions: RadioCardOption<GqlChain>[] = [
-    protocolNetworks[0],
+    protocolNetworks[0]!,
     ...protocolNetworks.slice(1).sort(),
   ]
     .filter(
-      network =>
+      (network): network is GqlChain =>
         // balancer v3 pool creation not yet supported on these networks
-        !([GqlChainValues.Polygon] as GqlChain[]).includes(network)
+        !!network && !([GqlChainValues.Polygon] as GqlChain[]).includes(network)
     )
     .map(network => ({
       value: network,

--- a/packages/lib/modules/pool/actions/create/steps/type/ChoosePoolType.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/type/ChoosePoolType.tsx
@@ -44,7 +44,7 @@ export function ChoosePoolType({ control }: { control: Control<PoolCreationForm>
               poolCreationForm.reset({
                 ...INITIAL_POOL_CREATION_FORM,
                 network,
-                swapFeePercentage: getSwapFeePercentageOptions(value)[0].value,
+                swapFeePercentage: getSwapFeePercentageOptions(value)[0]!.value,
                 poolType: value,
               })
             }}

--- a/packages/lib/modules/pool/actions/create/steps/type/ChoosePoolType.tsx
+++ b/packages/lib/modules/pool/actions/create/steps/type/ChoosePoolType.tsx
@@ -44,7 +44,7 @@ export function ChoosePoolType({ control }: { control: Control<PoolCreationForm>
               poolCreationForm.reset({
                 ...INITIAL_POOL_CREATION_FORM,
                 network,
-                swapFeePercentage: getSwapFeePercentageOptions(value)[0]!.value,
+                swapFeePercentage: getSwapFeePercentageOptions(value)[0].value,
                 poolType: value,
               })
             }}

--- a/packages/lib/modules/pool/actions/create/useUninitializedPool.ts
+++ b/packages/lib/modules/pool/actions/create/useUninitializedPool.ts
@@ -184,9 +184,14 @@ export function useUninitializedPool() {
     for (let idx = 0; idx < tokenAddresses.length; idx += 1) {
       const address = tokenAddresses[idx]
       const config = tokenConfigs[idx]
+
+      if (!config || !address) {
+        return undefined
+      }
+
       const data = tokenData.find(token => token.address.toLowerCase() === address.toLowerCase())
 
-      if (!config || !data) {
+      if (!data) {
         return undefined
       }
 
@@ -195,7 +200,7 @@ export function useUninitializedPool() {
         rateProvider: config.rateProvider,
         paysYieldFees: config.paysYieldFees,
         amount: '',
-        weight: tokenWeights ? tokenWeights[idx] : '50',
+        weight: tokenWeights ? (tokenWeights[idx] ?? '50') : '50',
         data,
       })
     }


### PR DESCRIPTION
## What

Preparatory migration PR for [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) (refs #1028). Fixes all remaining `noUncheckedIndexedAccess` type errors in `modules/pool/actions/create` and the LBP `MyTransactions` component by replacing unguarded indexed access with guards, intentional defaults, and more precise collection/tuple types.

- Guarded `poolTokens[projectTokenIndex]` / `poolTokens[reserveTokenIndex]` in `LbpDetail/MyTransactions.tsx`
- Guarded event indexed access with destructured `[tokenIn, tokenOut]` in `MyTransactions.tsx`
- Guarded `currentStep`, `poolTokens[index]` updates, swap fee options and uninitialized pool assembly in the pool creation root files
- Guarded transaction step, cow pool `amountsIn` and weighted weights in the pool creation modal
- Guarded and defaulted indexed access in the fund, tokens and type creation steps (incl. 2-tuple typing for `getTau`)

## Why

Issue #1028 asks to activate `noUncheckedIndexedAccess` to avoid future bugs. This PR clears one coherent area (pool creation) using the incremental migration workflow from the issue: guards and accurate types instead of blanket non-null assertions, with the workspace setting still disabled.

## Test Steps

- [ ] `pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit --incremental false --noUncheckedIndexedAccess` reports no errors under `modules/pool/actions/create/`
- [ ] `pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit --incremental false` passes (0 errors)
- [ ] Go to the pool creation page (`/create`), walk through all steps: Choose network, Choose pool type, configure tokens/rate provider, seed amounts — for Weighted, Stable, Gyro ECLP, AutoRange and CoW pools
- [ ] Create a pool end-to-end and confirm the transaction modal footer renders and the pool page loads

## Risks / Breaking Changes

- Touches `packages/lib` shared code; pool creation flow is shared between Balancer and Beets apps via `NEXT_PUBLIC_PROJECT_ID`. Behavior is unchanged — only type guards/defaults were added.
- `useCreateCowSteps` relies on the invariant that CoW pools always have exactly 2 tokens; guarded via existing invariant, no runtime change.

## Other Notes

Preparatory PR — the `noUncheckedIndexedAccess` option remains disabled in `tsconfig.json`. Follow-up PRs will clear the remaining error areas before the option is enabled.
