### PR TITLE
Remove Fraxtal pool from debug/pools page

### DIFF
--- a/apps/frontend-v3/app/(app)/debug/pools/page.tsx
+++ b/apps/frontend-v3/app/(app)/debug/pools/page.tsx
@@ -121,12 +121,6 @@ export default function DebugPools() {
           </Link>
           <Link
             as={NextLink}
-            href="/pools/fraxtal/v2/0x33251abecb0364df98a27a8d5d7b5ccddc774c42000000000000000000000008"
-          >
-            Frax with Merkl APR items
-          </Link>
-          <Link
-            as={NextLink}
             href="/pools/ethereum/v2/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe"
           >
             Old mainnet boosted pool with issues


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Removed the Fraxtal V2 reference pool link ("Frax with Merkl APR items") from the `/debug/pools` page.

## Why

Fraxtal is being sunset on Balancer (see BIP-906). The debug pools page should no longer surface a Fraxtal chain pool example.

## Test Steps

- [ ] Run the Balancer frontend (`apps/frontend-v3`) locally
- [ ] Navigate to `/debug/pools`
- [ ] Confirm the "Frax with Merkl APR items" link is no longer listed under "V2 reference pools"
- [ ] Confirm other V2 reference pool links still render and navigate correctly

## Risks / Breaking Changes

- App-specific change in `apps/frontend-v3` only; no impact on Beets or shared `packages/lib` behavior.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://balancerecosystem.slack.com/archives/C02F9EMRKQA/p1787133665920469?thread_ts=1787133665.920469&cid=C02F9EMRKQA)

<div><a href="https://cursor.com/agents/bc-e3207c5e-584e-5f79-91c8-ce2793d7f418?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3207c5e-584e-5f79-91c8-ce2793d7f418&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

