### PR TITLE
Fix hooks matcher to use JS regex for git commit

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -4,7 +4,7 @@
     "beforeShellExecution": [
       {
         "command": ".cursor/hooks/lint-staged.sh",
-        "matcher": "git commit[[:space:]]"
+        "matcher": "git commit "
       }
     ]
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Updated the `beforeShellExecution` matcher in `.cursor/hooks.json` from `git commit[[:space:]]` to `git commit `.

## Why

Cursor hook matchers use JavaScript regular expressions, not POSIX/grep syntax. The previous `[[:space:]]` character class does not work in JS regex, so the lint-staged hook was not matching `git commit` commands.

## Test Steps

- No manual UI surface. The change is a one-line config fix; verify the matcher string in `.cursor/hooks.json` is `git commit ` and that a Cloud Agent `git commit` triggers the lint-staged hook.

## Risks / Breaking Changes

- Low risk. Only affects when the lint-staged hook runs for Cloud Agent commits; no impact on Balancer or Beets app runtime.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bfb6231-38de-4714-9bf8-325cc2aa168c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bfb6231-38de-4714-9bf8-325cc2aa168c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

