### PR TITLE
fix(cursor): make lint-staged hook deny actually stick

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -4,7 +4,8 @@
     "beforeShellExecution": [
       {
         "command": ".cursor/hooks/lint-staged.sh",
-        "matcher": "git commit "
+        "matcher": "git commit ",
+        "failClosed": true
       }
     ]
   }

--- a/.cursor/hooks/lint-staged.sh
+++ b/.cursor/hooks/lint-staged.sh
@@ -6,6 +6,11 @@
 # has an empty index here. Deny that case and tell the agent to add first
 # (docs: agent_message). Do not re-run git add from this script.
 #
+# stdout must be JSON only. lint-staged prints to stdout; if that mixes with
+# {"permission":"deny"}, Cursor treats it as invalid JSON and fail-opens
+# (exit 0 + bad JSON = allow). Send lint-staged to stderr, and use exit 2
+# to deny (docs: exit 2 == permission deny even without JSON).
+#
 # Did this hook run?  tail /tmp/cursor-lint-staged-hook.log
 
 LOG=/tmp/cursor-lint-staged-hook.log
@@ -17,10 +22,10 @@ log "ran ${input}"
 if git diff --cached --quiet; then
   log "deny empty-index"
   echo '{"permission":"deny","agent_message":"Stage files in a separate Shell call before git commit. This hook runs before the command, so lint-staged cannot see files added in the same call."}'
-  exit 0
+  exit 2
 fi
 
-if pnpm lint-staged; then
+if pnpm lint-staged >&2; then
   log "allow"
   echo '{"permission":"allow"}'
   exit 0
@@ -28,4 +33,4 @@ fi
 
 log "deny lint-staged"
 echo '{"permission":"deny","user_message":"lint-staged failed. Fix the reported issues and retry the commit."}'
-exit 0
+exit 2

--- a/.cursor/hooks/lint-staged.sh
+++ b/.cursor/hooks/lint-staged.sh
@@ -1,64 +1,22 @@
-#!/usr/bin/env bash
-# Cursor Cloud Agent overrides core.hooksPath, so the repo's husky/lint-staged
-# pre-commit never runs on `git commit`. This beforeShellExecution hook
-# re-applies the same gate.
+#!/bin/bash
+# Cloud Agents override core.hooksPath, so husky's pre-commit never runs.
+# This beforeShellExecution hook is the same gate: pnpm lint-staged.
 #
-# Important: beforeShellExecution runs BEFORE the whole shell command. Agents
-# often send `git add … && git commit …` in one call, so nothing is staged yet
-# when this hook starts. We apply safe staging subcommands from that compound
-# command first, then run lint-staged. If there is still nothing staged, deny.
+# The hook fires BEFORE the shell command, so `git add && git commit` still
+# has an empty index here. Deny that case and tell the agent to add first
+# (docs: agent_message). Do not re-run git add from this script.
 
-set -euo pipefail
-
-INPUT="$(cat)"
-COMMAND="$(printf '%s' "$INPUT" | jq -r '.command // empty')"
-
-# Apply `git add|rm|mv` segments that appear before `git commit` in && / ;
-# chained commands so lint-staged sees the files about to be committed.
-if [[ -n "$COMMAND" ]]; then
-  COMMAND="$COMMAND" python3 - <<'PY'
-import os, re, shlex, subprocess
-
-cmd = os.environ.get("COMMAND", "")
-parts = re.split(r"\s*(?:&&|;)\s*", cmd)
-staging: list[str] = []
-for part in parts:
-    stripped = part.strip()
-    if not stripped:
-        continue
-    if re.match(r"git\s+commit\b", stripped):
-        break
-    if re.match(r"git\s+(add|rm|mv)\b", stripped):
-        staging.append(stripped)
-
-for segment in staging:
-    try:
-        argv = shlex.split(segment)
-    except ValueError:
-        continue
-    if len(argv) < 2 or argv[0] != "git" or argv[1] not in ("add", "rm", "mv"):
-        continue
-    subprocess.run(argv, check=False)
-PY
-fi
+cat > /dev/null
 
 if git diff --cached --quiet; then
-  jq -n '{
-    permission: "deny",
-    user_message: "Commit blocked: no staged files when the lint-staged hook ran.",
-    agent_message: "beforeShellExecution ran lint-staged before anything was staged. Stage files first (separate `git add` Shell call, or include `git add` before `git commit` in the same command), fix any lint-staged failures, then commit."
-  }'
+  echo '{"permission":"deny","agent_message":"Stage files in a separate Shell call before git commit. This hook runs before the command, so lint-staged cannot see files added in the same call."}'
   exit 0
 fi
 
 if pnpm lint-staged; then
-  jq -n '{permission: "allow"}'
-  exit 0
-else
-  jq -n '{
-    permission: "deny",
-    user_message: "lint-staged failed. Fix the reported issues and retry the commit.",
-    agent_message: "pnpm lint-staged failed on staged files. Fix the lint/typecheck/format issues, re-stage, and retry `git commit`."
-  }'
+  echo '{"permission":"allow"}'
   exit 0
 fi
+
+echo '{"permission":"deny","user_message":"lint-staged failed. Fix the reported issues and retry the commit."}'
+exit 0

--- a/.cursor/hooks/lint-staged.sh
+++ b/.cursor/hooks/lint-staged.sh
@@ -1,36 +1,22 @@
 #!/bin/bash
-# Cloud Agents override core.hooksPath, so husky's pre-commit never runs.
-# This beforeShellExecution hook is the same gate: pnpm lint-staged.
-#
-# The hook fires BEFORE the shell command, so `git add && git commit` still
-# has an empty index here. Deny that case and tell the agent to add first
-# (docs: agent_message). Do not re-run git add from this script.
-#
-# stdout must be JSON only. lint-staged prints to stdout; if that mixes with
-# {"permission":"deny"}, Cursor treats it as invalid JSON and fail-opens
-# (exit 0 + bad JSON = allow). Send lint-staged to stderr, and use exit 2
-# to deny (docs: exit 2 == permission deny even without JSON).
-#
-# Did this hook run?  tail /tmp/cursor-lint-staged-hook.log
+# Cursor Cloud Agent overrides core.hooksPath, so the repo's husky/lint-staged
+# pre-commit never runs on `git commit`. This hook re-applies the same gate:
+# run lint-staged on the staged files, then block the commit if it fails.
+# lint-staged re-stages its fixes, so the following `git commit` picks them up.
+# Send lint-staged to stderr so stdout stays JSON. Did it run? tail /tmp/cursor-lint-staged-hook.log
 
-LOG=/tmp/cursor-lint-staged-hook.log
-log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG" >&2; }
-
-input=$(cat)
-log "ran ${input}"
+# Consume stdin (hook input JSON) so the shell doesn't wait on it.
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $(cat)" >> /tmp/cursor-lint-staged-hook.log
 
 if git diff --cached --quiet; then
-  log "deny empty-index"
-  echo '{"permission":"deny","agent_message":"Stage files in a separate Shell call before git commit. This hook runs before the command, so lint-staged cannot see files added in the same call."}'
-  exit 2
-fi
-
-if pnpm lint-staged >&2; then
-  log "allow"
-  echo '{"permission":"allow"}'
+  echo '{"permission": "deny", "user_message": "Stage files in a separate Shell call before git commit."}'
   exit 0
 fi
 
-log "deny lint-staged"
-echo '{"permission":"deny","user_message":"lint-staged failed. Fix the reported issues and retry the commit."}'
-exit 2
+if pnpm lint-staged >&2; then
+  echo '{"permission": "allow"}'
+  exit 0
+else
+  echo '{"permission": "deny", "user_message": "lint-staged failed. Fix the reported issues and retry the commit."}'
+  exit 0
+fi

--- a/.cursor/hooks/lint-staged.sh
+++ b/.cursor/hooks/lint-staged.sh
@@ -5,18 +5,27 @@
 # The hook fires BEFORE the shell command, so `git add && git commit` still
 # has an empty index here. Deny that case and tell the agent to add first
 # (docs: agent_message). Do not re-run git add from this script.
+#
+# Did this hook run?  tail /tmp/cursor-lint-staged-hook.log
 
-cat > /dev/null
+LOG=/tmp/cursor-lint-staged-hook.log
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG" >&2; }
+
+input=$(cat)
+log "ran ${input}"
 
 if git diff --cached --quiet; then
+  log "deny empty-index"
   echo '{"permission":"deny","agent_message":"Stage files in a separate Shell call before git commit. This hook runs before the command, so lint-staged cannot see files added in the same call."}'
   exit 0
 fi
 
 if pnpm lint-staged; then
+  log "allow"
   echo '{"permission":"allow"}'
   exit 0
 fi
 
+log "deny lint-staged"
 echo '{"permission":"deny","user_message":"lint-staged failed. Fix the reported issues and retry the commit."}'
 exit 0

--- a/.cursor/hooks/lint-staged.sh
+++ b/.cursor/hooks/lint-staged.sh
@@ -1,16 +1,64 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Cursor Cloud Agent overrides core.hooksPath, so the repo's husky/lint-staged
-# pre-commit never runs on `git commit`. This hook re-applies the same gate:
-# run lint-staged on the staged files, then block the commit if it fails.
-# lint-staged re-stages its fixes, so the following `git commit` picks them up.
+# pre-commit never runs on `git commit`. This beforeShellExecution hook
+# re-applies the same gate.
+#
+# Important: beforeShellExecution runs BEFORE the whole shell command. Agents
+# often send `git add … && git commit …` in one call, so nothing is staged yet
+# when this hook starts. We apply safe staging subcommands from that compound
+# command first, then run lint-staged. If there is still nothing staged, deny.
 
-# Consume stdin (hook input JSON) so the shell doesn't wait on it.
-cat > /dev/null
+set -euo pipefail
+
+INPUT="$(cat)"
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.command // empty')"
+
+# Apply `git add|rm|mv` segments that appear before `git commit` in && / ;
+# chained commands so lint-staged sees the files about to be committed.
+if [[ -n "$COMMAND" ]]; then
+  COMMAND="$COMMAND" python3 - <<'PY'
+import os, re, shlex, subprocess
+
+cmd = os.environ.get("COMMAND", "")
+parts = re.split(r"\s*(?:&&|;)\s*", cmd)
+staging: list[str] = []
+for part in parts:
+    stripped = part.strip()
+    if not stripped:
+        continue
+    if re.match(r"git\s+commit\b", stripped):
+        break
+    if re.match(r"git\s+(add|rm|mv)\b", stripped):
+        staging.append(stripped)
+
+for segment in staging:
+    try:
+        argv = shlex.split(segment)
+    except ValueError:
+        continue
+    if len(argv) < 2 or argv[0] != "git" or argv[1] not in ("add", "rm", "mv"):
+        continue
+    subprocess.run(argv, check=False)
+PY
+fi
+
+if git diff --cached --quiet; then
+  jq -n '{
+    permission: "deny",
+    user_message: "Commit blocked: no staged files when the lint-staged hook ran.",
+    agent_message: "beforeShellExecution ran lint-staged before anything was staged. Stage files first (separate `git add` Shell call, or include `git add` before `git commit` in the same command), fix any lint-staged failures, then commit."
+  }'
+  exit 0
+fi
 
 if pnpm lint-staged; then
-  echo '{"permission": "allow"}'
+  jq -n '{permission: "allow"}'
   exit 0
 else
-  echo '{"permission": "deny", "user_message": "lint-staged failed. Fix the reported issues and retry the commit."}'
+  jq -n '{
+    permission: "deny",
+    user_message: "lint-staged failed. Fix the reported issues and retry the commit.",
+    agent_message: "pnpm lint-staged failed on staged files. Fix the lint/typecheck/format issues, re-stage, and retry `git commit`."
+  }'
   exit 0
 fi

--- a/.cursor/hooks/lint-staged.sh
+++ b/.cursor/hooks/lint-staged.sh
@@ -9,14 +9,14 @@
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $(cat)" >> /tmp/cursor-lint-staged-hook.log
 
 if git diff --cached --quiet; then
-  echo '{"permission": "deny", "user_message": "Stage files in a separate Shell call before git commit."}'
-  exit 0
+  echo '{"permission": "deny", "user_message": "Stage files in a separate Shell call before git commit.", "agent_message": "Stage files in a separate Shell call before git commit. This hook runs before the command, so lint-staged cannot see files added in the same call."}'
+  exit 2
 fi
 
 if pnpm lint-staged >&2; then
   echo '{"permission": "allow"}'
   exit 0
 else
-  echo '{"permission": "deny", "user_message": "lint-staged failed. Fix the reported issues and retry the commit."}'
-  exit 0
+  echo '{"permission": "deny", "user_message": "lint-staged failed. Fix the reported issues and retry the commit.", "agent_message": "pnpm lint-staged failed. Fix the reported issues, re-stage, and retry git commit."}'
+  exit 2
 fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Keep the original allow/deny JSON shape (`"permission": "allow"` / `"permission": "deny"`).
- Deny empty index and lint-staged failure with `exit 2` plus `user_message` and `agent_message`.
- Run `pnpm lint-staged >&2` so eslint/tsc cannot mix with that JSON.
- Log each run to `/tmp/cursor-lint-staged-hook.log`.
- `failClosed: true` so crash/timeout/invalid JSON blocks instead of fail-open.

## Why

Cloud Agents override `core.hooksPath`, so Husky never runs. `beforeShellExecution` is the lint gate, but it runs before the whole command, and lint-staged writes to stdout. Mixed stdout made Cursor ignore `permission: deny` (invalid JSON → fail-open).

## Test Steps

- [x] Empty index → deny JSON with `agent_message`, process exit `2`
- [x] Combined `git add && git commit` Shell call → blocked by hook
- [x] Staged hook file then commit-only → `{"permission": "allow"}`, process exit `0` (`02a561541`)

Debug: `tail /tmp/cursor-lint-staged-hook.log`

## Risks / Breaking Changes

- Agents that `git add && git commit` in one Shell call will be denied and asked to `git add` first.
- Hook failures block commits (`failClosed: true`).
- Cursor tooling only (`.cursor/`); does not affect Balancer or Beets runtime.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://balancerecosystem.slack.com/archives/C02F9EMRKQA/p1787152169315989?thread_ts=1787152169.315989&cid=C02F9EMRKQA)

<div><a href="https://cursor.com/agents/bc-22bfe856-6315-5c51-be4d-82f8c7f3f488?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22bfe856-6315-5c51-be4d-82f8c7f3f488&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

