### PR TITLE
fix(portfolio): fix noUncheckedIndexedAccess errors in modules/portfolio

### DIFF
--- a/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/ClaimNetworkPools/ClaimNetworkPools.tsx
@@ -128,11 +128,14 @@ export function ClaimNetworkPools() {
     const items = []
 
     poolsWithChain.forEach(([, pools]) => {
-      if (pools[0] && totalFiatClaimableBalanceByChain[pools[0].chain].toNumber() > 0) {
+      const firstPool = pools[0]
+      const chainBalance = firstPool ? totalFiatClaimableBalanceByChain[firstPool.chain] : undefined
+
+      if (firstPool && chainBalance && chainBalance.toNumber() > 0) {
         items.push({
           type: 'chain',
-          chain: pools[0].chain,
-          amount: totalFiatClaimableBalanceByChain[pools[0].chain].toNumber(),
+          chain: firstPool.chain,
+          amount: chainBalance.toNumber(),
         })
       }
     })

--- a/packages/lib/modules/portfolio/PortfolioClaim/recovered-funds/ClaimRecoveredFundsModal.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/recovered-funds/ClaimRecoveredFundsModal.tsx
@@ -38,7 +38,9 @@ export function ClaimRecoveredFundsModal({ isOpen, onClose }: Props) {
   const [maxHeight, setMaxHeight] = useState(0)
 
   const { steps } = useRecoveredFundsClaims()
-  const isSuccess = steps.isLastStep(steps.currentStepIndex) && steps.currentStep.isComplete()
+
+  const isSuccess =
+    steps.isLastStep(steps.currentStepIndex) && (steps.currentStep?.isComplete() ?? false)
 
   const txHash =
     isSuccess && steps.currentTransaction
@@ -57,7 +59,7 @@ export function ClaimRecoveredFundsModal({ isOpen, onClose }: Props) {
     if (node !== null) {
       const observer = new ResizeObserver(entries => {
         if (entries[0]) {
-          setMaxHeight(entries[0].borderBoxSize[0].blockSize)
+          setMaxHeight(entries[0].borderBoxSize[0]?.blockSize ?? 0)
         }
       })
 

--- a/packages/lib/modules/portfolio/PortfolioClaim/recovered-funds/RecoveredFundsClaimsProvider.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/recovered-funds/RecoveredFundsClaimsProvider.tsx
@@ -13,8 +13,7 @@ const UseRecoveredFundsClaimsContext = createContext<UseRecoveredFundsClaimsResp
 function useRecoveredFundsClaimsLogic() {
   const { claims } = useRecoveredFunds()
 
-  const signatureChain =
-    claims.length > 0 ? claims[0].chainId : getChainId(PROJECT_CONFIG.defaultNetwork)
+  const signatureChain = claims[0]?.chainId ?? getChainId(PROJECT_CONFIG.defaultNetwork)
 
   const { signatureStep, hasAcceptedDisclaimer, setHasAcceptedDisclaimer } =
     useSignatureStep(signatureChain)

--- a/packages/lib/modules/portfolio/PortfolioClaim/recovered-funds/useRecoveredFunds.ts
+++ b/packages/lib/modules/portfolio/PortfolioClaim/recovered-funds/useRecoveredFunds.ts
@@ -52,7 +52,7 @@ export function useRecoveredFunds() {
           .flatMap(chain => chain.rewards)
           .map(toRecoveredTokenClaim)
           .filter(claim =>
-            NORMALIZED_WRAPPER_TOKENS[claim.chainId].includes(
+            (NORMALIZED_WRAPPER_TOKENS[claim.chainId] ?? []).includes(
               claim.amount.tokenAddress.toLowerCase()
             )
           )

--- a/packages/lib/modules/portfolio/PortfolioClaim/recovered-funds/wrapper-tokens.ts
+++ b/packages/lib/modules/portfolio/PortfolioClaim/recovered-funds/wrapper-tokens.ts
@@ -48,10 +48,9 @@ const WRAPPER_TOKENS: Record<number, string[]> = {
 
 const normalize = (address: string) => address.toLowerCase()
 
-export const NORMALIZED_WRAPPER_TOKENS: Record<number, string[]> = {
-  1: WRAPPER_TOKENS[1].map(normalize),
-  42161: WRAPPER_TOKENS[42161].map(normalize),
-  8453: WRAPPER_TOKENS[8453].map(normalize),
-  137: WRAPPER_TOKENS[137].map(normalize),
-  10: WRAPPER_TOKENS[10].map(normalize),
-}
+export const NORMALIZED_WRAPPER_TOKENS: Record<number, string[]> = Object.fromEntries(
+  Object.entries(WRAPPER_TOKENS).map(([chainId, addresses]) => [
+    Number(chainId),
+    addresses.map(normalize),
+  ])
+)

--- a/packages/lib/modules/portfolio/PortfolioClaim/useBalRewards.spec.tsx
+++ b/packages/lib/modules/portfolio/PortfolioClaim/useBalRewards.spec.tsx
@@ -75,7 +75,7 @@ describe('useBalTokenRewards', () => {
 
     await waitFor(() => expect(result.current.balRewardsData).toHaveLength(1))
 
-    const reward = result.current.balRewardsData[0]
+    const reward = result.current.balRewardsData[0]!
     expect(reward.gaugeAddress).toBe(GAUGE_ADDRESS)
     expect(reward.humanBalance).toBe('1')
     expect(reward.tokenAddress).toBe(mainnetBalAddress)

--- a/packages/lib/modules/portfolio/PortfolioProvider.tsx
+++ b/packages/lib/modules/portfolio/PortfolioProvider.tsx
@@ -153,26 +153,28 @@ export function usePortfolioLogic() {
       const balReward = balRewardsData.find(r => r.pool.id === pool.id)
       const claimableReward = claimableRewardsByPoolMap[pool.id]
 
-      acc[pool.id] = {
+      const poolRewardsData: PoolRewardsData = {
         ...pool,
       }
+
+      acc[pool.id] = poolRewardsData
 
       let totalFiatClaimableBalance = bn(0)
 
       if (balReward) {
-        acc[pool.id].balReward = balReward
+        poolRewardsData.balReward = balReward
         totalFiatClaimableBalance = totalFiatClaimableBalance.plus(balReward.fiatBalance)
       }
 
       if (claimableReward) {
-        acc[pool.id].claimableRewards = claimableReward
+        poolRewardsData.claimableRewards = claimableReward
 
         claimableReward.forEach(
           r => (totalFiatClaimableBalance = totalFiatClaimableBalance.plus(r.fiatBalance))
         )
       }
 
-      acc[pool.id].totalFiatClaimBalance = totalFiatClaimableBalance
+      poolRewardsData.totalFiatClaimBalance = totalFiatClaimableBalance
       return acc
     }, {})
   }, [portfolioData.stakedPools, balRewardsData, claimableRewardsByPoolMap])
@@ -181,16 +183,16 @@ export function usePortfolioLogic() {
     return portfolioData.stakedPools?.reduce((acc: Record<string, PoolRewardsData[]>, pool) => {
       const poolReward = poolRewardsMap[pool.id]
       const poolRewards = poolReward ? [poolReward] : []
-      if (!acc[pool.chain]) acc[pool.chain] = []
-      acc[pool.chain].push(...poolRewards)
+      const chainRewards = acc[pool.chain] ?? []
+      acc[pool.chain] = [...chainRewards, ...poolRewards]
       return acc
     }, {})
   }, [portfolioData.stakedPools, poolRewardsMap])
 
   const poolsByChainMap = useMemo(() => {
     return portfolioData.stakedPools?.reduce((acc: Record<string, Pool[]>, pool) => {
-      if (!acc[pool.chain]) acc[pool.chain] = []
-      acc[pool.chain].push(pool)
+      const chainPools = acc[pool.chain] ?? []
+      acc[pool.chain] = [...chainPools, pool]
       return acc
     }, {})
   }, [portfolioData.stakedPools])

--- a/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
+++ b/packages/lib/modules/portfolio/PortfolioTable/PortfolioTable.tsx
@@ -87,7 +87,7 @@ export function PortfolioTable() {
         .sort(
           (a, b) => (b.userBalance?.totalBalanceUsd || 0) - (a.userBalance?.totalBalanceUsd || 0)
         )
-        .filter((item, pos, ary) => !pos || item.id !== ary[pos - 1].id), // deduplication
+        .filter((item, pos, ary) => !pos || item.id !== ary[pos - 1]?.id), // deduplication
     [sortedPools, needsMigration]
   )
 


### PR DESCRIPTION
## What

- Guarded `Record` index mutation in `PortfolioProvider` reducers (`poolRewardsMap`, `rewardsByChainMap`, `poolsByChainMap`) by building a local `poolRewardsData` object and accumulating with `?? []` spreads.
- Hoisted `pools[0]` into `firstPool` and guarded the chain-balance lookup in `ClaimNetworkPools`; used `ary[pos - 1]?.id` in the `PortfolioTable` dedup filter.
- Rebuilt `NORMALIZED_WRAPPER_TOKENS` via `Object.fromEntries` instead of hardcoded `WRAPPER_TOKENS[n]` index access; guarded the wrapper lookup with `?? []`; used `claims[0]?.chainId ?? default`; optional-chained `currentStep.isComplete()` and `borderBoxSize[0]` in the recovered-funds claim flow.
- Asserted non-null `balRewardsData[0]!` in the `useBalRewards` spec (length asserted to be 1 immediately prior).

## Why

Preparatory migration for noUncheckedIndexedAccess activation (issue #1028). This PR fixes all noUncheckedIndexedAccess errors in `packages/lib/modules/portfolio` so the option can eventually be enabled workspace-wide. It does **not** activate the rule — that happens once every module is clean.

## Test Steps

- [ ] Run `pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit --incremental false --noUncheckedIndexedAccess` and confirm zero errors under `modules/portfolio`.
- [ ] Run `pnpm --filter @repo/lib typecheck` and confirm it passes.
- [ ] Run `pnpm --filter @repo/lib exec vitest run modules/portfolio/PortfolioClaim/useBalRewards.spec.tsx` and confirm 3/3 pass.
- [ ] Visit `/portfolio` and confirm the claimable-incentives grid, portfolio table, and recovered-funds modal render and behave as before.

## Risks / Breaking Changes

- Touches shared `packages/lib` code that also serves the Beets app (`NEXT_PUBLIC_PROJECT_ID`). The changes are behavior-preserving guards/defaults — no logic or data-shape changes. `NORMALIZED_WRAPPER_TOKENS` is now derived from `WRAPPER_TOKENS` via `Object.fromEntries`; the resulting map is identical to the previous hardcoded one.
- No migration, no feature flag, no dependency changes.

## Other Notes

Errors in other modules (swap, pool, tokens, web3, etc.) remain and are expected during this preparatory phase — they are assigned to their own PRs.
