### PR TITLE
fix(lbp): fix noUncheckedIndexedAccess errors in modules/lbp

### DIFF
--- a/packages/lib/modules/lbp/LbpForm.tsx
+++ b/packages/lib/modules/lbp/LbpForm.tsx
@@ -14,7 +14,7 @@ export function LbpForm() {
   return (
     <VStack align="start" spacing="lg" w="full">
       <VStack spacing="lg" w="full">
-        {canRenderStep && <currentStep.Component />}
+        {canRenderStep && currentStep && <currentStep.Component />}
       </VStack>
     </VStack>
   )

--- a/packages/lib/modules/lbp/pool/usePoolStats.ts
+++ b/packages/lib/modules/lbp/pool/usePoolStats.ts
@@ -27,8 +27,8 @@ export function usePoolStats(pool: LbpV3) {
   )
 
   if (snapshotsAreLoading || metadataIsLoading || snapshots.length === 0) return emptyStats
-  const firstSnapshot = snapshots[0]
-  const lastSnapshot = snapshots[snapshots.length - 1]
+  const firstSnapshot = snapshots[0]!
+  const lastSnapshot = snapshots[snapshots.length - 1]!
   const currentPrice = getCurrentPrice(snapshots)
 
   return {

--- a/packages/lib/modules/lbp/pool/usePriceInfo.ts
+++ b/packages/lib/modules/lbp/pool/usePriceInfo.ts
@@ -121,20 +121,25 @@ function getCurrentSnapshotValue(
   if (snapshots.length === 0) return 0
 
   const currentTime = now()
-  if (isBefore(currentTime, snapshots[0].timestamp)) return selector(snapshots[0])
+  const firstSnapshot = snapshots[0]!
+  const lastSnapshot = snapshots[snapshots.length - 1]!
 
-  if (isAfter(currentTime, snapshots[snapshots.length - 1].timestamp)) {
-    return selector(snapshots[snapshots.length - 1])
+  if (isBefore(currentTime, firstSnapshot.timestamp)) return selector(firstSnapshot)
+
+  if (isAfter(currentTime, lastSnapshot.timestamp)) {
+    return selector(lastSnapshot)
   }
 
   // Find the last snapshot before or at current time
   for (let i = snapshots.length - 1; i >= 0; i--) {
-    if (!isAfter(snapshots[i].timestamp, currentTime)) {
-      return selector(snapshots[i])
+    const snapshot = snapshots[i]
+
+    if (snapshot && !isAfter(snapshot.timestamp, currentTime)) {
+      return selector(snapshot)
     }
   }
 
-  return selector(snapshots[0])
+  return selector(firstSnapshot)
 }
 
 export function min(prices: LbpPrice[]) {

--- a/packages/lib/modules/lbp/steps/WeightAdjustmentTypeInput.tsx
+++ b/packages/lib/modules/lbp/steps/WeightAdjustmentTypeInput.tsx
@@ -78,13 +78,13 @@ export function WeightAdjustmentTypeInput({
         name="weightAdjustmentType"
         render={({ field }) => (
           <SelectInput
-            defaultValue={options[0].value}
+            defaultValue={options[0]!.value}
             id="weight-adjustment-type"
             onChange={newValue => {
               field.onChange(newValue as GqlChain)
             }}
             options={options}
-            value={field.value ?? options[0].value}
+            value={field.value ?? options[0]!.value}
           />
         )}
       />

--- a/packages/lib/modules/lbp/steps/preview/FixedProjectedPrice.tsx
+++ b/packages/lib/modules/lbp/steps/preview/FixedProjectedPrice.tsx
@@ -59,7 +59,7 @@ export function FixedProjectedPrice({
       current = addHours(current, 24)
     }
 
-    if (data.length === 0 || !isEqual(data[data.length - 1].timestamp, end)) {
+    if (data.length === 0 || !isEqual(data[data.length - 1]!.timestamp, end)) {
       data.push({ timestamp: end, projectTokenPrice: Number(launchTokenPriceRaw) })
     }
 

--- a/packages/lib/modules/lbp/useHydrateLbpForm.ts
+++ b/packages/lib/modules/lbp/useHydrateLbpForm.ts
@@ -212,11 +212,11 @@ export function useHydrateLbpForm() {
     const { startWeights, endWeights, projectTokenIndex } = lbpImmutableData.result
 
     const projectTokenStartWeight = +formatUnits(
-      startWeights[projectTokenIndex],
+      startWeights[projectTokenIndex]!,
       PERCENTAGE_DECIMALS
     )
 
-    const projectTokenEndWeight = +formatUnits(endWeights[projectTokenIndex], PERCENTAGE_DECIMALS)
+    const projectTokenEndWeight = +formatUnits(endWeights[projectTokenIndex]!, PERCENTAGE_DECIMALS)
 
     let weightAdjustmentType: WeightAdjustmentType
     let customStartWeight = 90


### PR DESCRIPTION
## What
- Fixed all TS `noUncheckedIndexedAccess` errors in `packages/lib/modules/lbp` (6 files, 17 errors) to prepare for enabling the compiler flag (#1028).
- Used non-null assertions only where an index is guaranteed by an explicit guard or invariant: guarded `first`/`last` snapshot indexes, tuple token-index weights, and a statically-known options array.
- Added a runtime guard in the downward snapshot loop in `getCurrentSnapshotValue` where the index is dynamic.
- Guarded `currentStep` before rendering its component in `LbpForm`.

## Why
Preparatory migration for issue #1028 (activate `noUncheckedIndexedAccess`). This PR resolves the module locally; the flag itself stays disabled in `tsconfig` until the whole workspace is clean.

## Test Steps
- [ ] Run `pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit --incremental false --noUncheckedIndexedAccess` — no errors in `modules/lbp`
- [ ] Run `pnpm --filter @repo/lib exec vitest run modules/lbp` — 3 files / 10 tests pass
- [ ] Run `pnpm --filter @repo/lib exec vitest run -c ./vitest.config.integration.ts modules/lbp/LbpFormProvider.integration.spec.tsx` — 3 tests pass

## Risks / Breaking Changes
- Brainless type-only safety guards: no behavioral/runtime change. `packages/lib` serves both Balancer and Beets apps; guards are project-agnostic.
- Low risk; verified by normal typecheck and unit + integration tests.

Ref: #1028