### PR TITLE
Remove Fraxtal pool from debug/pools page

### DIFF
--- a/.cursor/hooks/lint-staged.sh
+++ b/.cursor/hooks/lint-staged.sh
@@ -3,10 +3,10 @@
 # pre-commit never runs on `git commit`. This hook re-applies the same gate:
 # run lint-staged on the staged files, then block the commit if it fails.
 # lint-staged re-stages its fixes, so the following `git commit` picks them up.
-# Send lint-staged to stderr so stdout stays JSON. Did it run? tail /tmp/cursor-lint-staged-hook.log
+# Send lint-staged to stderr so stdout stays JSON.
 
 # Consume stdin (hook input JSON) so the shell doesn't wait on it.
-echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $(cat)" >> /tmp/cursor-lint-staged-hook.log
+cat >/dev/null
 
 if git diff --cached --quiet; then
   echo '{"permission": "deny", "user_message": "Stage files in a separate Shell call before git commit.", "agent_message": "Stage files in a separate Shell call before git commit. This hook runs before the command, so lint-staged cannot see files added in the same call."}'

--- a/apps/frontend-v3/app/(app)/debug/pools/page.tsx
+++ b/apps/frontend-v3/app/(app)/debug/pools/page.tsx
@@ -121,12 +121,6 @@ export default function DebugPools() {
           </Link>
           <Link
             as={NextLink}
-            href="/pools/fraxtal/v2/0x33251abecb0364df98a27a8d5d7b5ccddc774c42000000000000000000000008"
-          >
-            Frax with Merkl APR items
-          </Link>
-          <Link
-            as={NextLink}
             href="/pools/ethereum/v2/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe"
           >
             Old mainnet boosted pool with issues
@@ -142,11 +136,6 @@ export default function DebugPools() {
       </HStack>
     </FadeInOnView>
   )
-    const unusedDebugVar = 'debug'
-    const unusedDebugArray = [
-      'one',
-      'two',
-    ]
 }
 
 function PoolExampleLinks({ poolExamples }: { poolExamples: PoolExample[] }) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Removed the Fraxtal V2 reference pool link ("Frax with Merkl APR items") from `/debug/pools`
- Removed unreachable unused debug variables that were causing `lint-staged` (`--max-warnings 0`) to fail on this file
- Removed temporary debug logging from `.cursor/hooks/lint-staged.sh` (still consumes hook stdin)

## Why

Fraxtal is being sunset on Balancer. The debug pools page still listed a Fraxtal chain pool, which should no longer appear there. The lint-staged hook debug log was leftover instrumentation and is no longer needed.

## Test Steps

- [ ] Open `/debug/pools`
- [ ] In the "V2 reference pools" column, confirm there is no "Frax with Merkl APR items" / Fraxtal link
- [ ] Confirm the surrounding V2 reference links (e.g. Mainnet COMPOSABLE_STABLE Bricked, Old mainnet boosted pool) still render
- [ ] Confirm `.cursor/hooks/lint-staged.sh` no longer writes to `/tmp/cursor-lint-staged-hook.log`

## Risks / Breaking Changes

- Low risk: debug-only page in `apps/frontend-v3`; no shared `packages/lib` changes, so Beets is unaffected
- Hook still consumes stdin via `cat >/dev/null` so commit gating behavior is unchanged aside from dropping the log write
- No production pool listing or routing changes

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://balancerecosystem.slack.com/archives/C02F9EMRKQA/p1787219885931599?thread_ts=1787219885.931599&cid=C02F9EMRKQA)

<div><a href="https://cursor.com/agents/bc-427494b4-a9b3-5492-aa96-03c20200e88b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-427494b4-a9b3-5492-aa96-03c20200e88b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

