### PR TITLE
fix(lib): noUncheckedIndexedAccess in remaining packages/lib modules

### DIFF
--- a/packages/lib/config/networks/plasma.ts
+++ b/packages/lib/config/networks/plasma.ts
@@ -16,13 +16,13 @@ const chain = CHAINS[chainId]
 
 const networkConfig: NetworkConfig = {
   chainId,
-  name: chain.name,
-  shortName: chain.name,
+  name: chain!.name,
+  shortName: chain!.name,
   chain: GqlChainValues.Plasma,
   iconPath: '/images/chains/PLASMA.svg',
   blockExplorer: {
-    baseUrl: chain.blockExplorers!.default.url,
-    name: chain.blockExplorers!.default.name,
+    baseUrl: chain!.blockExplorers!.default.url,
+    name: chain!.blockExplorers!.default.name,
   },
   tokens: {
     addresses: {

--- a/packages/lib/modules/autorange/useAutoRangeData.ts
+++ b/packages/lib/modules/autorange/useAutoRangeData.ts
@@ -84,8 +84,8 @@ export function useAutoRangeData(): AutoRangeData {
       .toNumber()
 
     // only scale back if token has rate but not an erc4626
-    const tokenA = pool.poolTokens[0]
-    const tokenB = pool.poolTokens[1]
+    const tokenA = pool.poolTokens[0]!
+    const tokenB = pool.poolTokens[1]!
     const tokenAHasRate = tokenA.priceRate !== DEFAULT_PRICE_RATE
     const tokenBHasRate = tokenB.priceRate !== DEFAULT_PRICE_RATE
     const shouldScaleBackTokenA = tokenAHasRate && !tokenA.isErc4626

--- a/packages/lib/modules/autorange/weightedMath.ts
+++ b/packages/lib/modules/autorange/weightedMath.ts
@@ -17,24 +17,24 @@ export function calculateOutGivenIn(params: {
   })
 
   const newBalances = [...params.balances]
-  newBalances[params.tokenInIndex] = params.balances[params.tokenInIndex] + params.swapAmountIn
+  newBalances[params.tokenInIndex] = params.balances[params.tokenInIndex]! + params.swapAmountIn
 
   const denominator = newBalances.reduce((acc, balance, index) => {
     if (index === params.tokenOutIndex) {
       return acc
     }
 
-    return acc * Math.pow(balance, params.weights[index])
+    return acc * Math.pow(balance, params.weights[index]!)
   }, 1)
 
   return (
-    params.balances[params.tokenOutIndex] -
-    Math.pow(invariant / denominator, 1 / params.weights[params.tokenOutIndex])
+    params.balances[params.tokenOutIndex]! -
+    Math.pow(invariant / denominator, 1 / params.weights[params.tokenOutIndex]!)
   )
 }
 
 export function calculateInvariant(params: { balances: number[]; weights: number[] }) {
   return params.balances.reduce((acc, balance, index) => {
-    return acc * Math.pow(balance, params.weights[index])
+    return acc * Math.pow(balance, params.weights[index]!)
   }, 1)
 }

--- a/packages/lib/modules/chains/ChainSelect.tsx
+++ b/packages/lib/modules/chains/ChainSelect.tsx
@@ -80,7 +80,7 @@ export function ChainSelect({ value, onChange, chains = PROJECT_CONFIG.supported
   const connectedChain = chainId ? getGqlChain(chainId) : undefined
   const nativeBalances = useNativeTokenBalances(chains)
 
-  const sortedChains = [...chains].sort((a, b) => nativeBalances[b] - nativeBalances[a])
+  const sortedChains = [...chains].sort((a, b) => nativeBalances[b]! - nativeBalances[a]!)
   const firstChainWithoutBalance = sortedChains.find(chain => nativeBalances[chain] === 0)
   const hasChainsWithBalance = sortedChains.find(chain => nativeBalances[chain] !== 0) !== undefined
 

--- a/packages/lib/modules/chains/useNativeTokenBalances.ts
+++ b/packages/lib/modules/chains/useNativeTokenBalances.ts
@@ -61,7 +61,7 @@ export function useNativeTokenBalancesValues(
     ? {}
     : Object.fromEntries(
         balanceQueries.map(({ data }, index) => {
-          const chain = chains[index]
+          const chain = chains[index]!
           const networkConfig = getNetworkConfig(chain)
           const tokenPrice = priceFor(networkConfig.tokens.nativeAsset.address, chain) ?? 0
 

--- a/packages/lib/modules/cow/cow.utils.ts
+++ b/packages/lib/modules/cow/cow.utils.ts
@@ -4,8 +4,8 @@ import type { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 
 export function buildCowSwapUrlFromPool(pool: Pool): string {
   // All CoW AMM pools have 2 tokens
-  const tokenInAddress = pool.poolTokens[0].address
-  const tokenOutAddress = pool.poolTokens[1].address
+  const tokenInAddress = pool.poolTokens[0]!.address
+  const tokenOutAddress = pool.poolTokens[1]!.address
 
   return buildCowSwapUrl({
     chain: pool.chain,

--- a/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
+++ b/packages/lib/modules/eclp/hooks/useGetECLPLiquidityProfile.tsx
@@ -36,7 +36,7 @@ export function useGetECLPLiquidityProfile(): ECLPLiquidityProfile {
   const tokenRateScalingFactorString = useMemo(() => {
     if (!tokenRates) return
 
-    return bn(tokenRates[0]).div(bn(tokenRates[1])).toString()
+    return bn(tokenRates[0]!).div(bn(tokenRates[1]!)).toString()
   }, [tokenRates])
 
   const liquidityData = useMemo(() => {
@@ -83,7 +83,7 @@ export function useGetECLPLiquidityProfile(): ECLPLiquidityProfile {
         return isReversed ? [1 / displayedPrice, liquidity] : [displayedPrice, liquidity]
       })
 
-    return transformedData.sort((a, b) => a[0] - b[0]) as [number, number][]
+    return transformedData.sort((a, b) => a[0]! - b[0]!) as [number, number][]
   }, [liquidityData, isReversed, priceRateRatio])
 
   const xMin = useMemo(() => (data ? Math.min(...data.map(([x]) => x)) : 0), [data])

--- a/packages/lib/modules/featured-pools/PoolCarousel.tsx
+++ b/packages/lib/modules/featured-pools/PoolCarousel.tsx
@@ -36,7 +36,7 @@ export function PoolCarousel({ featuredPools, getGraphic, ...rest }: Props & Box
     setCurrentIndex(index)
   }
 
-  const currentPool = featuredPools[currentIndex].pool as Pool
+  const currentPool = featuredPools[currentIndex]!.pool as Pool
 
   return (
     <Box {...swipeHandlers} {...rest} zIndex={9999}>
@@ -70,7 +70,7 @@ export function PoolCarousel({ featuredPools, getGraphic, ...rest }: Props & Box
           carouselDirection={direction}
           carouselIndex={currentIndex}
           chain={currentPool.chain}
-          featuredReason={featuredPools[currentIndex].description}
+          featuredReason={featuredPools[currentIndex]!.description}
           graphic={getGraphic(currentIndex)}
           isCarousel
           isSmall

--- a/packages/lib/modules/hooks/stable-surge/useStableSurgeMetrics.ts
+++ b/packages/lib/modules/hooks/stable-surge/useStableSurgeMetrics.ts
@@ -23,12 +23,12 @@ function calculateMedian(percentages: number[]) {
   const sortedPercentages = [...percentages].sort((a, b) => a - b)
   const mid = Math.floor(sortedPercentages.length / 2)
   return sortedPercentages.length % 2 === 0
-    ? (sortedPercentages[mid - 1] + sortedPercentages[mid]) / 2
-    : sortedPercentages[mid]
+    ? (sortedPercentages[mid - 1]! + sortedPercentages[mid]!) / 2
+    : sortedPercentages[mid]!
 }
 
 function calculateTotalImbalance(percentages: number[]) {
   const median = calculateMedian(percentages)
 
-  return percentages.reduce((sum, percentage) => sum + Math.abs(percentage - median), 0)
+  return percentages.reduce((sum, percentage) => sum + Math.abs(percentage - median!), 0)
 }

--- a/packages/lib/modules/marketing/useEcosystemPoolActivity.tsx
+++ b/packages/lib/modules/marketing/useEcosystemPoolActivity.tsx
@@ -166,7 +166,7 @@ const getDefaultPoolActivityChartOptions = (
       enterable: true,
       hideDelay: 300,
       position: function (point: number[]) {
-        return [point[0] + 5, point[1] - 5]
+        return [point[0]! + 5, point[1]! - 5]
       },
       extraCssText: `padding-right:2rem;border: none;${toolTipTheme.container};pointer-events: auto!important`,
       formatter: (params: any) => {
@@ -299,7 +299,7 @@ export function useEcosystemPoolActivityChart() {
   const { isMobile, is2xl } = useBreakpoints()
   const { getToken } = useTokens()
   const { toCurrency } = useCurrency()
-  const [activeTab, setActiveTab] = useState<PoolActivityChartTypeTab>(tabsList[0])
+  const [activeTab, setActiveTab] = useState<PoolActivityChartTypeTab>(tabsList[0]!)
   const [activeNetwork, setActiveNetwork] = useState<GqlChain | 'all'>('all')
   const theme = useChakraTheme()
   const now = useCurrentDate()
@@ -375,7 +375,7 @@ export function useEcosystemPoolActivityChart() {
     const elapsedMinutes = Math.floor(
       secondsToMinutes(
         millisecondsToSeconds(now.getTime()) -
-          response.poolEvents[response.poolEvents.length - 1].timestamp
+          response.poolEvents[response.poolEvents.length - 1]!.timestamp
       )
     )
 

--- a/packages/lib/modules/web3/ChainConfig.tsx
+++ b/packages/lib/modules/web3/ChainConfig.tsx
@@ -98,5 +98,5 @@ export const chains: readonly [Chain, ...Chain[]] = [
 export const chainsByKey = keyBy(chains, 'id')
 
 export function getDefaultRpcUrl(chainId: number) {
-  return chainsByKey[chainId].rpcUrls.default.http[0]
+  return chainsByKey[chainId]!.rpcUrls.default.http[0]!
 }

--- a/packages/lib/modules/web3/WagmiConfig.ts
+++ b/packages/lib/modules/web3/WagmiConfig.ts
@@ -52,7 +52,7 @@ if (isBrowser()) {
   https://github.com/rainbow-me/rainbowkit/issues/2232
 */
   if (!isConnectedToWC()) {
-    const lastConnector = connectors[connectors.length - 1]
+    const lastConnector = connectors[connectors.length - 1]!
 
     if (lastConnector({} as any).id !== 'walletConnect') {
       connectors.push(

--- a/packages/lib/modules/web3/contracts/useMulticall.integration.spec.ts
+++ b/packages/lib/modules/web3/contracts/useMulticall.integration.spec.ts
@@ -82,7 +82,7 @@ describe('Performs multicall in multiple chains', () => {
 
     await waitForChainData(mainnet.id, 'mainnet')
 
-    expect(result.current.results[mainnet.id].data).toMatchInlineSnapshot(`
+    expect(result.current.results[mainnet.id]!.data).toMatchInlineSnapshot(`
       {
         "daiBalanceOnMainnet": {
           "result": 1n,
@@ -93,7 +93,7 @@ describe('Performs multicall in multiple chains', () => {
 
     await waitForChainData(base.id, 'base')
 
-    expect(result.current.results[base.id].data).toMatchInlineSnapshot(`
+    expect(result.current.results[base.id]!.data).toMatchInlineSnapshot(`
       {
         "ghoBalanceOnBase": {
           "result": 7702n,
@@ -104,7 +104,7 @@ describe('Performs multicall in multiple chains', () => {
 
     await waitForChainData(polygon.id, 'polygon')
 
-    expect(result.current.results[polygon.id].data).toMatchInlineSnapshot(`
+    expect(result.current.results[polygon.id]!.data).toMatchInlineSnapshot(`
     {
       "polBalanceOnPolygon": {
         "result": 721n,

--- a/packages/lib/modules/web3/contracts/useMulticall.ts
+++ b/packages/lib/modules/web3/contracts/useMulticall.ts
@@ -39,7 +39,7 @@ export function useMulticall(
 
   const multicallResults = useQueries({
     queries: suppliedChains.map(chain => {
-      const multicalls = multicallsPerChain[chain]
+      const multicalls = multicallsPerChain[chain]!
       return {
         queryFn: async () => {
           const results = await multicall(config, {
@@ -50,7 +50,7 @@ export function useMulticall(
 
           // map the result to its id based on the call index
           const idMappedResults = results
-            .map((result, i) => ({ ...result, id: multicalls[i].id }))
+            .map((result, i) => ({ ...result, id: multicalls[i]!.id }))
             .reduce((o, { id, ...rest }) => set(o, id, rest), {})
 
           return idMappedResults

--- a/packages/lib/modules/web3/impersonation/useImpersonateAccount.ts
+++ b/packages/lib/modules/web3/impersonation/useImpersonateAccount.ts
@@ -74,7 +74,7 @@ export function useImpersonateAccount() {
     })
 
     // if you don't pass chainId you will be prompted to switch chain (check if it uses mainnet by default)
-    await connectAsync({ connector: connectors[connectors.length - 1], chainId })
+    await connectAsync({ connector: connectors[connectors.length - 1]!, chainId })
   }
 
   async function reset() {

--- a/packages/lib/shared/components/alerts/TxBatchAlert.tsx
+++ b/packages/lib/shared/components/alerts/TxBatchAlert.tsx
@@ -9,7 +9,7 @@ type Props = AlertProps & { steps: TransactionStep[] }
 
 export function TxBatchAlert({ steps, ...alertProps }: Props) {
   const { isMobile } = useBreakpoints()
-  const lastStep = steps[steps.length - 1]
+  const lastStep = steps[steps.length - 1]!
   const { isStepWithTxBatch } = useStepWithTxBatch(lastStep)
 
   if (isStepWithTxBatch && !isMobile) {

--- a/packages/lib/shared/hooks/useAprTooltip.spec.tsx
+++ b/packages/lib/shared/hooks/useAprTooltip.spec.tsx
@@ -29,7 +29,7 @@ describe('useAprTooltip', () => {
     expect(result.current.swapFeesDisplayed.toFixed()).toBe('0.0007')
     expect(fNum('apr', result.current.swapFeesDisplayed)).toBe('0.07%')
 
-    const yieldBearingTokensApr = result.current.yieldBearingTokensDisplayed[0].apr
+    const yieldBearingTokensApr = result.current.yieldBearingTokensDisplayed[0]!.apr
     expect(yieldBearingTokensApr.toFixed()).toBe('0.0068')
     expect(fNum('apr', yieldBearingTokensApr)).toBe('0.68%')
 

--- a/packages/lib/shared/utils/query-errors.spec.ts
+++ b/packages/lib/shared/utils/query-errors.spec.ts
@@ -27,7 +27,7 @@ Sentry.init({
 
 async function getSentryReport() {
   await waitFor(() => expect(testkit.reports()).toHaveLength(1))
-  return testkit.reports()[0]
+  return testkit.reports()[0]!
 }
 
 describe('Captures sentry error', () => {

--- a/packages/lib/test/vitest/assertions.ts
+++ b/packages/lib/test/vitest/assertions.ts
@@ -6,5 +6,5 @@ import { Mock } from 'vitest'
 export function firstMockCallParams<TArgs extends any[] = any[]>(
   mock: Mock<(...args: TArgs) => any>
 ): TArgs[0] {
-  return mock.mock.calls[0][0]
+  return mock.mock.calls[0]![0]!
 }

--- a/packages/lib/test/vitest/setup-integration.ts
+++ b/packages/lib/test/vitest/setup-integration.ts
@@ -36,7 +36,7 @@ vi.mock('@repo/lib/modules/web3/transports', async importOriginal => {
   return {
     ...originalModule,
     getRpcUrl: (chainId: number) => {
-      const { rpcUrl } = getTestRpcSetup(chainsByKey[chainId].id as ChainIdWithFork)
+      const { rpcUrl } = getTestRpcSetup(chainsByKey[chainId]!.id as ChainIdWithFork)
       return rpcUrl
     },
   }


### PR DESCRIPTION
## What

- Added non-null assertions for noUncheckedIndexedAccess across the remaining packages/lib modules not covered by the portfolio, token, and lbp PRs.
- Updated index-access sites in config, autorange, chains, pools, hooks, web3, and shared/test utils to satisfy the strict flag.

## Why

Preparatory migration for #1028 (activate noUncheckedIndexedAccess). The flag is currently disabled because enabling it produces hundreds of errors; this PR clears the remaining errors in packages/lib so the workspace can eventually enable the option. All fixes use non-null assertions on genuinely-guaranteed invariants (2-token pools, non-empty arrays, indexed lookups) — no behavioral change.

## Test Steps

- [ ] Run the strict typecheck: pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit --incremental false --noUncheckedIndexedAccess — expect 0 errors in the covered scope
- [ ] Run the normal workspace typecheck: pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit --incremental false — expect exit 0
- [ ] Confirm pre-commit hooks (eslint, prettier, typecheck) pass on each commit

## Risks / Breaking Changes

- Touches shared packages/lib code that also serves the Beets app via NEXT_PUBLIC_PROJECT_ID. All changes are type-only (non-null assertions on existing invariants); no runtime behavior or project-specific values changed.
- No token decimals/balances handling, migrations, or feature flags affected.

## Other Notes

- The portfolio, token, and lbp modules have their own PRs and are intentionally excluded here.
- Once every inheriting workspace is clean, noUncheckedIndexedAccess can be enabled in packages/typescript-config/base.json (tracked in #1028).

Refs #1028
