### PR TITLE
test(analytics): add unit tests to balancer-analytics

### DIFF
--- a/apps/balancer-analytics/app/_components/format.spec.ts
+++ b/apps/balancer-analytics/app/_components/format.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { usd } from './format'
+
+describe('usd', () => {
+  it('formats large values compactly', () => {
+    expect(usd(5_400_000_000)).toBe('$5.4B')
+  })
+
+  it('formats zero as $0', () => {
+    expect(usd(0)).toBe('$0')
+  })
+
+  it('formats negative values', () => {
+    expect(usd(-1_200_000)).toBe('-$1.2M')
+  })
+})

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/formatEventArgs.spec.ts
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/formatEventArgs.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { formatEventArgValue } from './formatEventArgs'
+
+describe('formatEventArgValue', () => {
+  it('renders null/undefined as an em dash', () => {
+    expect(formatEventArgValue('x', null)).toBe('—')
+    expect(formatEventArgValue('x', undefined)).toBe('—')
+  })
+
+  it('renders booleans as true/false', () => {
+    expect(formatEventArgValue('paused', true)).toBe('true')
+    expect(formatEventArgValue('paused', false)).toBe('false')
+  })
+
+  it('formats 1e18-scaled percentages as %', () => {
+    expect(formatEventArgValue('swapFeePercentage', '100000000000000000')).toBe('10%')
+    expect(formatEventArgValue('aggregateSwapFeePercentage', '50000000000000000')).toBe('5%')
+  })
+
+  it('formats amp values scaled by 1000 as decimals', () => {
+    expect(formatEventArgValue('startValue', '2000')).toBe('2')
+    expect(formatEventArgValue('endValue', '5000')).toBe('5')
+  })
+
+  it('formats unix-second timestamps as locale dates', () => {
+    const out = formatEventArgValue('startTime', '1700000000')
+    expect(out).not.toBe('1700000000')
+    expect(out).toMatch(/\d{1,2}:\d{2}/)
+  })
+
+  it('falls back to String(value) for unknown keys', () => {
+    expect(formatEventArgValue('someOther', '123')).toBe('123')
+    expect(formatEventArgValue('someOther', 42)).toBe('42')
+  })
+})

--- a/apps/balancer-analytics/lib/drpc/block-timestamps.spec.ts
+++ b/apps/balancer-analytics/lib/drpc/block-timestamps.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveBlockTimestamps } from './block-timestamps'
+
+type MockClient = {
+  getBlock: ReturnType<typeof vi.fn>
+}
+
+function makeClient(): MockClient {
+  return { getBlock: vi.fn() }
+}
+
+describe('resolveBlockTimestamps', () => {
+  it('resolves timestamps for each unique block', async () => {
+    const client = makeClient()
+
+    client.getBlock.mockImplementation(async ({ blockNumber }) => ({
+      number: blockNumber,
+      timestamp: BigInt(Number(blockNumber) * 1000),
+    }))
+
+    const map = await resolveBlockTimestamps(client as never, 'MAINNET' as never, [1n, 2n, 3n])
+    expect(map.get(1n)).toBe(1000)
+    expect(map.get(2n)).toBe(2000)
+    expect(map.get(3n)).toBe(3000)
+    expect(client.getBlock).toHaveBeenCalledTimes(3)
+  })
+
+  it('dedupes repeated blocks into a single RPC call', async () => {
+    const client = makeClient()
+
+    client.getBlock.mockImplementation(async ({ blockNumber }) => ({
+      number: blockNumber,
+      timestamp: 1000n,
+    }))
+
+    const map = await resolveBlockTimestamps(client as never, 'MAINNET' as never, [1n, 1n, 1n, 2n])
+    expect(map.size).toBe(2)
+    expect(client.getBlock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns an empty map for no blocks', async () => {
+    const client = makeClient()
+    const map = await resolveBlockTimestamps(client as never, 'MAINNET' as never, [])
+    expect(map.size).toBe(0)
+    expect(client.getBlock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/balancer-analytics/lib/drpc/get-logs.spec.ts
+++ b/apps/balancer-analytics/lib/drpc/get-logs.spec.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { chunkedGetLogs } from './get-logs'
+import type { DecodedLog } from './get-logs'
+
+type MockClient = {
+  getLogs: ReturnType<typeof vi.fn>
+}
+
+function makeClient(): MockClient {
+  return { getLogs: vi.fn() }
+}
+
+function log(blockNumber: bigint): DecodedLog {
+  return {
+    address: '0xpool',
+    blockHash: '0xhash',
+    blockNumber,
+    data: '0x',
+    logIndex: 0,
+    transactionHash: '0xabc',
+    transactionIndex: 0,
+    removed: false,
+    topics: ['0xabc'],
+    eventName: 'SwapFeePercentageChanged',
+    args: {},
+  } as DecodedLog
+}
+
+function rangeError(message: string): Error {
+  const err = new Error(message)
+
+  ;(err as { shortMessage?: string }).shortMessage = message
+  return err
+}
+
+describe('chunkedGetLogs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns [] when toBlock is before fromBlock', async () => {
+    const client = makeClient()
+    const logs = await chunkedGetLogs(client as never, { fromBlock: 10n, toBlock: 5n })
+    expect(logs).toEqual([])
+    expect(client.getLogs).not.toHaveBeenCalled()
+  })
+
+  it('fetches a single chunk and returns its logs', async () => {
+    const client = makeClient()
+    client.getLogs.mockResolvedValue([log(1n), log(2n)])
+    const logs = await chunkedGetLogs(client as never, { fromBlock: 1n, toBlock: 2n })
+    expect(logs).toHaveLength(2)
+    expect(client.getLogs).toHaveBeenCalledTimes(1)
+  })
+
+  it('splits a wide range into multiple chunks', async () => {
+    const client = makeClient()
+    client.getLogs.mockImplementation(async ({ fromBlock }) => [log(fromBlock)])
+
+    const logs = await chunkedGetLogs(client as never, {
+      fromBlock: 1n,
+      toBlock: 100_000n,
+      chunkSize: 50_000n,
+    })
+
+    // 1..50000, 50001..100000 → two chunks
+    expect(logs).toHaveLength(2)
+    expect(client.getLogs).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries transient errors in place then succeeds', async () => {
+    const client = makeClient()
+
+    client.getLogs
+      .mockRejectedValueOnce(rangeError('temporary internal error'))
+      .mockResolvedValueOnce([log(1n)])
+
+    const p = chunkedGetLogs(client as never, { fromBlock: 1n, toBlock: 2n })
+    // Advance fake timers so the transient backoff resolves.
+    let settled = false
+
+    p.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+
+    while (!settled) await vi.advanceTimersByTimeAsync(10_000)
+    const logs = await p
+    expect(logs).toHaveLength(1)
+    expect(client.getLogs).toHaveBeenCalledTimes(2)
+  })
+
+  it('splits a range in half on a range-too-large error', async () => {
+    const client = makeClient()
+
+    // MIN_CHUNK_SIZE is 1000 blocks; ranges above that split, below succeed.
+    client.getLogs.mockImplementation(async (params: { fromBlock: bigint; toBlock: bigint }) => {
+      const { fromBlock, toBlock } = params
+      if (toBlock - fromBlock + 1n > 1000n) throw rangeError('block range too large')
+      return [log(fromBlock)]
+    })
+
+    const logs = await chunkedGetLogs(client as never, {
+      fromBlock: 1n,
+      toBlock: 5000n,
+      chunkSize: 5000n,
+    })
+
+    // Splits until each sub-range is ≤ 1000 blocks, then returns one log each.
+    expect(logs.length).toBeGreaterThan(1)
+  })
+
+  it('rethrows a non-transient, non-range error', async () => {
+    const client = makeClient()
+    client.getLogs.mockRejectedValue(new Error('boom'))
+
+    await expect(
+      chunkedGetLogs(client as never, { fromBlock: 1n, toBlock: 2n, chunkSize: 2n })
+    ).rejects.toThrow('boom')
+  })
+})

--- a/apps/balancer-analytics/lib/dune/fetch-labels.spec.ts
+++ b/apps/balancer-analytics/lib/dune/fetch-labels.spec.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchAllDuneLabels } from './fetch-labels'
+
+function duneResponse(rows: unknown[], nextUri?: string) {
+  return new Response(
+    JSON.stringify({ result: { rows }, ...(nextUri ? { next_uri: nextUri } : {}) }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  )
+}
+
+describe('fetchAllDuneLabels', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    process.env.NEXT_PRIVATE_DUNE_API_KEY = 'test-key'
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete process.env.NEXT_PRIVATE_DUNE_API_KEY
+  })
+
+  it('throws when the API key is missing', async () => {
+    delete process.env.NEXT_PRIVATE_DUNE_API_KEY
+    await expect(fetchAllDuneLabels()).rejects.toThrow('NEXT_PRIVATE_DUNE_API_KEY')
+  })
+
+  it('returns rows from a single page', async () => {
+    fetchMock.mockResolvedValue(
+      duneResponse([{ address: '0xaaa', name: '1Inch', blockchain: 'ethereum' }])
+    )
+
+    const { rows, pages } = await fetchAllDuneLabels()
+    expect(rows).toHaveLength(1)
+    expect(pages).toBe(1)
+  })
+
+  it('follows next_uri across pages', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        duneResponse([{ address: '0xaaa', name: 'A', blockchain: 'ethereum' }], 'https://next/2')
+      )
+      .mockResolvedValueOnce(
+        duneResponse([{ address: '0xbbb', name: 'B', blockchain: 'ethereum' }])
+      )
+
+    const { rows, pages } = await fetchAllDuneLabels()
+    expect(rows).toHaveLength(2)
+    expect(pages).toBe(2)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops when a page has no rows', async () => {
+    fetchMock.mockResolvedValue(duneResponse([]))
+    const { rows, pages } = await fetchAllDuneLabels()
+    expect(rows).toHaveLength(0)
+    expect(pages).toBe(1)
+  })
+
+  it('throws on a Dune error payload', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'boom' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    await expect(fetchAllDuneLabels()).rejects.toThrow('dune error')
+  })
+})

--- a/apps/balancer-analytics/lib/dune/fetch-vebal-holders.spec.ts
+++ b/apps/balancer-analytics/lib/dune/fetch-vebal-holders.spec.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchVeBalHoldersSnapshot } from './fetch-vebal-holders'
+
+function duneResponse(rows: unknown[]) {
+  return new Response(JSON.stringify({ result: { rows } }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('fetchVeBalHoldersSnapshot', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    process.env.NEXT_PRIVATE_DUNE_API_KEY = 'test-key'
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete process.env.NEXT_PRIVATE_DUNE_API_KEY
+  })
+
+  it('throws when the API key is missing', async () => {
+    delete process.env.NEXT_PRIVATE_DUNE_API_KEY
+    await expect(fetchVeBalHoldersSnapshot()).rejects.toThrow('NEXT_PRIVATE_DUNE_API_KEY')
+  })
+
+  it('returns the latest day only, sorted by pct descending', async () => {
+    fetchMock.mockResolvedValue(
+      duneResponse([
+        {
+          day: '2026-06-04 00:00:00',
+          wallet_address: '0xaaa',
+          provider: 'Aura',
+          vebal_balance: 100,
+          pct: 0.1,
+        },
+        {
+          day: '2026-06-05 00:00:00',
+          wallet_address: '0xbbb',
+          provider: 'Humpy',
+          vebal_balance: 500,
+          pct: 0.5,
+        },
+        {
+          day: '2026-06-05 00:00:00',
+          wallet_address: '0xccc',
+          provider: '0xccc',
+          vebal_balance: 200,
+          pct: 0.2,
+        },
+      ])
+    )
+
+    const snap = await fetchVeBalHoldersSnapshot()
+    expect(snap.day).toBe('2026-06-05 00:00:00')
+    expect(snap.rows).toHaveLength(2)
+    expect(snap.rows[0].provider).toBe('Humpy')
+    expect(snap.rows[0].pct).toBe(0.5)
+    expect(snap.rows[1].provider).toBe('0xccc')
+  })
+
+  it('lowercases wallet addresses and coerces numeric strings', async () => {
+    fetchMock.mockResolvedValue(
+      duneResponse([
+        {
+          day: '2026-06-05 00:00:00',
+          wallet_address: '0xABC',
+          provider: 'Aura',
+          vebal_balance: '100',
+          pct: '0.1',
+        },
+      ])
+    )
+
+    const snap = await fetchVeBalHoldersSnapshot()
+    expect(snap.rows[0].walletAddress).toBe('0xabc')
+    expect(snap.rows[0].veBalBalance).toBe(100)
+    expect(snap.rows[0].pct).toBe(0.1)
+  })
+
+  it('returns empty rows when the result set is empty', async () => {
+    fetchMock.mockResolvedValue(duneResponse([]))
+    const snap = await fetchVeBalHoldersSnapshot()
+    expect(snap.day).toBe('')
+    expect(snap.rows).toHaveLength(0)
+  })
+})

--- a/apps/balancer-analytics/lib/dune/normalize.spec.ts
+++ b/apps/balancer-analytics/lib/dune/normalize.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { GqlChainValues } from '@repo/lib/shared/services/api/graphql-enums'
+import { duneChainToGqlChain, nameToCategory, nameToSourceId, normalizeDuneRow } from './normalize'
+
+describe('duneChainToGqlChain', () => {
+  it('maps known Dune blockchain strings to GqlChain', () => {
+    expect(duneChainToGqlChain('ethereum')).toBe(GqlChainValues.Mainnet)
+    expect(duneChainToGqlChain('arbitrum')).toBe(GqlChainValues.Arbitrum)
+    expect(duneChainToGqlChain('base')).toBe(GqlChainValues.Base)
+    expect(duneChainToGqlChain('optimism')).toBe(GqlChainValues.Optimism)
+    expect(duneChainToGqlChain('polygon')).toBe(GqlChainValues.Polygon)
+    expect(duneChainToGqlChain('gnosis')).toBe(GqlChainValues.Gnosis)
+    expect(duneChainToGqlChain('avalanche_c')).toBe(GqlChainValues.Avalanche)
+    expect(duneChainToGqlChain('avalanche')).toBe(GqlChainValues.Avalanche)
+    expect(duneChainToGqlChain('monad')).toBe(GqlChainValues.Monad)
+    expect(duneChainToGqlChain('fantom')).toBe(GqlChainValues.Fantom)
+    expect(duneChainToGqlChain('sonic')).toBe(GqlChainValues.Sonic)
+  })
+
+  it('is case-insensitive', () => {
+    expect(duneChainToGqlChain('Ethereum')).toBe(GqlChainValues.Mainnet)
+    expect(duneChainToGqlChain('ARBITRUM')).toBe(GqlChainValues.Arbitrum)
+  })
+
+  it('returns null for unknown chains', () => {
+    expect(duneChainToGqlChain('solana')).toBeNull()
+    expect(duneChainToGqlChain('')).toBeNull()
+  })
+})
+
+describe('nameToSourceId', () => {
+  it('collapses known brands onto their canonical id', () => {
+    expect(nameToSourceId('1Inch')).toBe('1inch')
+    expect(nameToSourceId('Paraswap')).toBe('paraswap')
+    expect(nameToSourceId('Uniswap X')).toBe('uniswap-x')
+    expect(nameToSourceId('Uniswap V3')).toBe('uniswap-v3')
+    expect(nameToSourceId('Uniswap v2')).toBe('uniswap-v2')
+    expect(nameToSourceId('Matcha')).toBe('0x')
+    expect(nameToSourceId('TraderJoe')).toBe('lfj')
+    expect(nameToSourceId('LFJ')).toBe('lfj')
+  })
+
+  it('slugifies unknown names', () => {
+    expect(nameToSourceId('Some Random Router')).toBe('some-random-router')
+    expect(nameToSourceId('  padded  ')).toBe('padded')
+  })
+
+  it('falls back to "unknown" for an empty slug', () => {
+    expect(nameToSourceId('!!!')).toBe('unknown')
+  })
+})
+
+describe('nameToCategory', () => {
+  it('classifies MEV bots before generic routes', () => {
+    expect(nameToCategory('MEV Bot')).toBe('mev_bot')
+    expect(nameToCategory('Arbitrage Bot')).toBe('mev_bot')
+    expect(nameToCategory('Searcher')).toBe('mev_bot')
+    expect(nameToCategory('Jared')).toBe('mev_bot')
+  })
+
+  it('classifies bridges', () => {
+    expect(nameToCategory('LayerZero')).toBe('bridge')
+    expect(nameToCategory('Stargate')).toBe('bridge')
+    expect(nameToCategory('Across')).toBe('bridge')
+    expect(nameToCategory('Wormhole')).toBe('bridge')
+  })
+
+  it('classifies intent venues', () => {
+    expect(nameToCategory('CowSwap')).toBe('intent')
+    expect(nameToCategory('Uniswap X')).toBe('intent')
+    expect(nameToCategory('Bebop')).toBe('intent')
+  })
+
+  it('classifies market makers', () => {
+    expect(nameToCategory('Wintermute')).toBe('market_maker')
+    expect(nameToCategory('Jane Street')).toBe('market_maker')
+    expect(nameToCategory('SomeMM')).toBe('market_maker')
+  })
+
+  it('classifies Balancer routers as direct', () => {
+    expect(nameToCategory('Balancer Vault')).toBe('direct')
+    expect(nameToCategory('balancer router')).toBe('direct')
+  })
+
+  it('defaults to aggregator', () => {
+    expect(nameToCategory('Some DEX Router')).toBe('aggregator')
+  })
+})
+
+describe('normalizeDuneRow', () => {
+  const valid = {
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+    name: '1Inch',
+    blockchain: 'ethereum',
+  }
+
+  it('normalizes a valid row', () => {
+    const row = normalizeDuneRow(valid)
+    expect(row).not.toBeNull()
+    expect(row!.chain).toBe(GqlChainValues.Mainnet)
+    expect(row!.address).toBe(valid.address)
+    expect(row!.sourceId).toBe('1inch')
+    expect(row!.category).toBe('aggregator')
+  })
+
+  it('lowercases the address', () => {
+    const row = normalizeDuneRow({ ...valid, address: valid.address.toUpperCase() })
+    expect(row!.address).toBe(valid.address)
+  })
+
+  it('returns null for non-string fields', () => {
+    expect(normalizeDuneRow({ address: 123, name: 'x', blockchain: 'ethereum' })).toBeNull()
+
+    expect(
+      normalizeDuneRow({ address: valid.address, name: null, blockchain: 'ethereum' })
+    ).toBeNull()
+
+    expect(
+      normalizeDuneRow({ address: valid.address, name: 'x', blockchain: undefined })
+    ).toBeNull()
+  })
+
+  it('returns null for unsupported chains', () => {
+    expect(normalizeDuneRow({ ...valid, blockchain: 'solana' })).toBeNull()
+  })
+
+  it('returns null for malformed addresses', () => {
+    expect(normalizeDuneRow({ ...valid, address: '0x123' })).toBeNull()
+    expect(normalizeDuneRow({ ...valid, address: 'not-an-address' })).toBeNull()
+  })
+})

--- a/apps/balancer-analytics/lib/hooks/usePortfolioPnl.spec.ts
+++ b/apps/balancer-analytics/lib/hooks/usePortfolioPnl.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { computePnl } from './usePortfolioPnl'
+import type { PortfolioPosition } from './usePortfolioByAddress'
+import type { PortfolioPnlPoolEntry } from '@analytics/app/api/portfolio/[address]/pnl/route'
+
+function position(overrides: Partial<PortfolioPosition> = {}): PortfolioPosition {
+  return {
+    pool: {
+      type: 'WEIGHTED',
+      poolTokens: [
+        { address: '0xweth', balance: '1', balanceUSD: '2000' },
+        { address: '0xusdc', balance: '2000', balanceUSD: '2000' },
+      ],
+    } as PortfolioPosition['pool'],
+    chain: 'MAINNET' as PortfolioPosition['chain'],
+    positionUsd: 4000,
+    walletUsd: 4000,
+    stakedUsd: 0,
+    shareOfPool: 0.01,
+    totalApr: 0,
+    feeApr: 0,
+    yieldApr: 0,
+    rewardApr: 0,
+    dailyFeesUsd: 0,
+    dailyYieldUsd: 0,
+    dailyRewardsUsd: 0,
+    aprBreakdown: [],
+    stakingType: null,
+    ...overrides,
+  }
+}
+
+function entry(overrides: Partial<PortfolioPnlPoolEntry> = {}): PortfolioPnlPoolEntry {
+  return {
+    poolId: '0xpool',
+    chain: 'MAINNET' as PortfolioPnlPoolEntry['chain'],
+    costBasisUsd: 3000,
+    netTokens: {
+      '0xweth': { amount: 1, valueUsdAtDeposit: 2000 },
+      '0xusdc': { amount: 2000, valueUsdAtDeposit: 2000 },
+    },
+    firstEventAt: 1000,
+    addCount: 2,
+    removeCount: 0,
+    ...overrides,
+  }
+}
+
+describe('computePnl', () => {
+  it('computes P&L and IL for a normal position', () => {
+    const result = computePnl(position(), entry(), null, null)
+    expect(result.status).toBe('computed')
+    // currentUsd 4000, costBasis 3000 → netPnl 1000
+    expect(result.netPnlUsd).toBe(1000)
+    expect(result.netPnlPct).toBeCloseTo(1000 / 3000)
+    // hodl = 1*2000 + 2000*1 = 4000 → il = 4000 - 4000 = 0
+    expect(result.hodlUsd).toBe(4000)
+    expect(result.ilUsd).toBe(0)
+  })
+
+  it('marks pegged-asset pools as stable (IL suppressed)', () => {
+    const result = computePnl(
+      position({ pool: { type: 'STABLE' } as PortfolioPosition['pool'] }),
+      entry(),
+      null,
+      null
+    )
+
+    expect(result.status).toBe('stable')
+  })
+
+  it('marks a position with no events as no_history', () => {
+    const result = computePnl(position(), null, null, null)
+    expect(result.status).toBe('no_history')
+  })
+
+  it('marks a no-event position as truncated when a cutoff exists', () => {
+    const result = computePnl(position(), null, 500, null)
+    expect(result.status).toBe('truncated')
+  })
+
+  it('marks a position whose earliest event sits at the cutoff as truncated', () => {
+    const result = computePnl(position(), entry({ firstEventAt: 1000 }), 1000, null)
+    expect(result.status).toBe('truncated')
+  })
+
+  it('marks a re-entered position (negative net token) as exited_and_reentered', () => {
+    const result = computePnl(
+      position(),
+      entry({ netTokens: { '0xweth': { amount: -1, valueUsdAtDeposit: 2000 } } }),
+      null,
+      null
+    )
+
+    expect(result.status).toBe('exited_and_reentered')
+  })
+})

--- a/apps/balancer-analytics/lib/hooks/usePortfolioPnl.ts
+++ b/apps/balancer-analytics/lib/hooks/usePortfolioPnl.ts
@@ -150,7 +150,7 @@ export function usePortfolioPnl(
  * cutoff is potentially missing older events. Pools strictly after the
  * cutoff are unaffected.
  */
-function computePnl(
+export function computePnl(
   position: PortfolioPosition,
   entry: PortfolioPnlPoolEntry | null,
   addCutoffTs: number | null,

--- a/apps/balancer-analytics/lib/networks/chain-info.spec.ts
+++ b/apps/balancer-analytics/lib/networks/chain-info.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { GqlChainValues } from '@repo/lib/shared/services/api/graphql-enums'
+import type { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
+import { blocksPerSecond, secondsPerBlock } from './chain-info'
+
+describe('secondsPerBlock', () => {
+  it('returns the configured value per chain', () => {
+    expect(secondsPerBlock(GqlChainValues.Mainnet)).toBe(12)
+    expect(secondsPerBlock(GqlChainValues.Arbitrum)).toBe(0.26)
+    expect(secondsPerBlock(GqlChainValues.Base)).toBe(2)
+  })
+
+  it('falls back to 12s for unknown chains', () => {
+    expect(secondsPerBlock('UNKNOWN' as GqlChain)).toBe(12)
+  })
+})
+
+describe('blocksPerSecond', () => {
+  it('is the inverse of secondsPerBlock', () => {
+    expect(blocksPerSecond(GqlChainValues.Mainnet)).toBeCloseTo(1 / 12)
+    expect(blocksPerSecond(GqlChainValues.Arbitrum)).toBeCloseTo(1 / 0.26)
+  })
+})

--- a/apps/balancer-analytics/lib/pool-events/cow-rebate.spec.ts
+++ b/apps/balancer-analytics/lib/pool-events/cow-rebate.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { stripFeeRebates } from './cow-rebate'
+import type { PoolParamEventRow } from '@analytics/lib/db'
+
+function feeRow(
+  overrides: Partial<PoolParamEventRow> & { blockNumber: number; logIndex: number; txHash: string }
+): PoolParamEventRow {
+  return {
+    chain: 'MAINNET' as PoolParamEventRow['chain'],
+    poolAddress: '0xpool',
+    protocolVersion: 2,
+    blockTimestamp: 0,
+    eventName: 'SwapFeePercentageChanged',
+    args: { swapFeePercentage: '100000000000000000' },
+    ...overrides,
+  }
+}
+
+function nonFeeRow(
+  overrides: Partial<PoolParamEventRow> & { blockNumber: number; logIndex: number; txHash: string }
+): PoolParamEventRow {
+  return {
+    chain: 'MAINNET' as PoolParamEventRow['chain'],
+    poolAddress: '0xpool',
+    protocolVersion: 2,
+    blockTimestamp: 0,
+    eventName: 'PausedStateChanged',
+    args: { paused: true },
+    ...overrides,
+  }
+}
+
+describe('stripFeeRebates', () => {
+  it('drops a lower-then-restore pair in the same tx (round-trip)', () => {
+    const rows = [
+      feeRow({ blockNumber: 1, logIndex: 0, txHash: '0xa', args: { swapFeePercentage: '100' } }),
+      feeRow({ blockNumber: 1, logIndex: 1, txHash: '0xa', args: { swapFeePercentage: '50' } }),
+      feeRow({ blockNumber: 1, logIndex: 2, txHash: '0xa', args: { swapFeePercentage: '100' } }),
+    ]
+
+    const { rows: out, stripped } = stripFeeRebates(rows)
+    expect(stripped).toBe(3)
+    expect(out).toHaveLength(0)
+  })
+
+  it('keeps a genuine single fee move', () => {
+    const rows = [
+      feeRow({ blockNumber: 1, logIndex: 0, txHash: '0xa', args: { swapFeePercentage: '100' } }),
+    ]
+
+    const { rows: out, stripped } = stripFeeRebates(rows)
+    expect(stripped).toBe(0)
+    expect(out).toHaveLength(1)
+    expect(out[0].args.swapFeePercentage).toBe('100')
+  })
+
+  it('collapses a multi-step genuine move to its final write', () => {
+    // Establish a running fee with a single move first, then a multi-step
+    // group that ends at a different value — a genuine move, not a rebate.
+    const rows = [
+      feeRow({ blockNumber: 1, logIndex: 0, txHash: '0xa', args: { swapFeePercentage: '100' } }),
+      feeRow({ blockNumber: 2, logIndex: 0, txHash: '0xb', args: { swapFeePercentage: '80' } }),
+      feeRow({ blockNumber: 2, logIndex: 1, txHash: '0xb', args: { swapFeePercentage: '60' } }),
+    ]
+
+    const { rows: out, stripped } = stripFeeRebates(rows)
+    expect(stripped).toBe(1)
+    expect(out).toHaveLength(2)
+    expect(out[0].args.swapFeePercentage).toBe('100')
+    expect(out[1].args.swapFeePercentage).toBe('60')
+  })
+
+  it('treats a ≥2 group at window start as a rebate (running fee unknown)', () => {
+    const rows = [
+      feeRow({ blockNumber: 1, logIndex: 0, txHash: '0xa', args: { swapFeePercentage: '50' } }),
+      feeRow({ blockNumber: 1, logIndex: 1, txHash: '0xa', args: { swapFeePercentage: '100' } }),
+    ]
+
+    const { rows: out, stripped } = stripFeeRebates(rows)
+    expect(stripped).toBe(2)
+    expect(out).toHaveLength(0)
+  })
+
+  it('keeps a genuine move that does not return to the running fee', () => {
+    const rows = [
+      feeRow({ blockNumber: 1, logIndex: 0, txHash: '0xa', args: { swapFeePercentage: '100' } }),
+      feeRow({ blockNumber: 2, logIndex: 0, txHash: '0xb', args: { swapFeePercentage: '50' } }),
+      feeRow({ blockNumber: 2, logIndex: 1, txHash: '0xb', args: { swapFeePercentage: '80' } }),
+    ]
+
+    const { rows: out, stripped } = stripFeeRebates(rows)
+    // First tx: single move, kept. Second tx: 50 → 80, final != running (100), kept as 80.
+    expect(stripped).toBe(1)
+    expect(out).toHaveLength(2)
+    expect(out[0].args.swapFeePercentage).toBe('100')
+    expect(out[1].args.swapFeePercentage).toBe('80')
+  })
+
+  it('passes non-fee events through untouched', () => {
+    const rows = [
+      nonFeeRow({ blockNumber: 1, logIndex: 0, txHash: '0xa' }),
+      feeRow({ blockNumber: 1, logIndex: 1, txHash: '0xa', args: { swapFeePercentage: '100' } }),
+      nonFeeRow({ blockNumber: 1, logIndex: 2, txHash: '0xa' }),
+    ]
+
+    const { rows: out, stripped } = stripFeeRebates(rows)
+    expect(stripped).toBe(0)
+    expect(out).toHaveLength(3)
+  })
+
+  it('sorts unsorted input chronologically before processing', () => {
+    const rows = [
+      feeRow({ blockNumber: 2, logIndex: 0, txHash: '0xb', args: { swapFeePercentage: '50' } }),
+      feeRow({ blockNumber: 1, logIndex: 0, txHash: '0xa', args: { swapFeePercentage: '100' } }),
+    ]
+
+    const { rows: out } = stripFeeRebates(rows)
+    expect(out.map(r => r.blockNumber)).toEqual([1, 2])
+  })
+})

--- a/apps/balancer-analytics/lib/pool-events/decode.spec.ts
+++ b/apps/balancer-analytics/lib/pool-events/decode.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { decodeLogsToRows, type DecodeContext } from './decode'
+
+type TestLog = {
+  eventName?: string
+  address: `0x${string}`
+  blockHash: `0x${string}`
+  blockNumber: bigint | null
+  data: `0x${string}`
+  logIndex: number | null
+  transactionHash: string | null
+  transactionIndex: number
+  removed: boolean
+  args?: Record<string, unknown> | readonly unknown[]
+}
+
+const ctx: DecodeContext = {
+  chain: 'MAINNET' as DecodeContext['chain'],
+  poolAddress: '0xPOOL',
+  protocolVersion: 3,
+  blockTimestamps: new Map([
+    [1n, 1000],
+    [2n, 2000],
+  ]),
+}
+
+function log(overrides: Partial<TestLog> = {}): TestLog {
+  return {
+    eventName: 'SwapFeePercentageChanged',
+    address: '0xpool',
+    blockHash: '0xhash',
+    blockNumber: 1n,
+    data: '0x',
+    logIndex: 0,
+    transactionHash: '0xabc',
+    transactionIndex: 0,
+    removed: false,
+    args: { swapFeePercentage: 1000000000000000000n },
+    ...overrides,
+  }
+}
+
+// `decodeLogsToRows` types its input as the full viem `Log` (non-nullable
+// blockNumber/logIndex/txHash), but the function itself guards against nulls
+// at runtime. Our fixtures intentionally exercise those null paths, so cast
+// through the looser `TestLog` shape.
+function decode(...logs: TestLog[]) {
+  return decodeLogsToRows(logs as never, ctx)
+}
+
+describe('decodeLogsToRows', () => {
+  it('decodes a log into a row with JSON-safe args', () => {
+    const rows = decode(log())
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row.chain).toBe('MAINNET')
+    expect(row.poolAddress).toBe('0xpool') // lowercased
+    expect(row.protocolVersion).toBe(3)
+    expect(row.blockNumber).toBe(1)
+    expect(row.blockTimestamp).toBe(1000)
+    expect(row.logIndex).toBe(0)
+    expect(row.txHash).toBe('0xabc')
+    expect(row.eventName).toBe('SwapFeePercentageChanged')
+    // BigInt serialized to decimal string
+    expect(row.args.swapFeePercentage).toBe('1000000000000000000')
+  })
+
+  it('skips logs without an eventName', () => {
+    const rows = decode(log({ eventName: undefined }))
+    expect(rows).toHaveLength(0)
+  })
+
+  it('skips logs with null blockNumber/logIndex/transactionHash', () => {
+    expect(decode(log({ blockNumber: null }))).toHaveLength(0)
+    expect(decode(log({ logIndex: null }))).toHaveLength(0)
+    expect(decode(log({ transactionHash: null }))).toHaveLength(0)
+  })
+
+  it('skips logs whose block timestamp is unresolved', () => {
+    const rows = decode(log({ blockNumber: 99n }))
+    expect(rows).toHaveLength(0)
+  })
+
+  it('drops the indexed pool echo from args', () => {
+    const rows = decode(log({ args: { pool: '0xpool', swapFeePercentage: 100n } }))
+    expect(rows[0].args.pool).toBeUndefined()
+    expect(rows[0].args.swapFeePercentage).toBe('100')
+  })
+
+  it('serializes nested arrays and objects', () => {
+    const rows = decode(
+      log({
+        args: {
+          amounts: [1n, 2n],
+          nested: { a: 3n, b: 'x' },
+        },
+      })
+    )
+
+    expect(rows[0].args.amounts).toEqual(['1', '2'])
+    expect(rows[0].args.nested).toEqual({ a: '3', b: 'x' })
+  })
+
+  it('handles positional (array) args by keying arg0, arg1...', () => {
+    const rows = decode(log({ args: [10n, 'y'] }))
+    expect(rows[0].args.arg0).toBe('10')
+    expect(rows[0].args.arg1).toBe('y')
+  })
+})

--- a/apps/balancer-analytics/lib/pool-events/initial-cap.spec.ts
+++ b/apps/balancer-analytics/lib/pool-events/initial-cap.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { GqlChainValues } from '@repo/lib/shared/services/api/graphql-enums'
+import { ninetyDayFromBlock, thirtyDayFromBlock } from './initial-cap'
+
+describe('ninetyDayFromBlock', () => {
+  it('returns head minus the 90-day window in blocks', () => {
+    // Mainnet: 12s/block → 90 days = 648000 blocks
+    const from = ninetyDayFromBlock(GqlChainValues.Mainnet, 1_000_000n)
+    expect(from).toBe(1_000_000n - 648_000n)
+  })
+
+  it('never goes below 0', () => {
+    expect(ninetyDayFromBlock(GqlChainValues.Mainnet, 100n)).toBe(0n)
+  })
+})
+
+describe('thirtyDayFromBlock', () => {
+  it('returns head minus the 30-day window in blocks', () => {
+    // Mainnet: 12s/block → 30 days = 216000 blocks
+    const from = thirtyDayFromBlock(GqlChainValues.Mainnet, 1_000_000n)
+    expect(from).toBe(1_000_000n - 216_000n)
+  })
+
+  it('never goes below 0', () => {
+    expect(thirtyDayFromBlock(GqlChainValues.Mainnet, 100n)).toBe(0n)
+  })
+})

--- a/apps/balancer-analytics/lib/pool-events/snapshot-at.spec.ts
+++ b/apps/balancer-analytics/lib/pool-events/snapshot-at.spec.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeParamSnapshot,
+  diffSnapshots,
+  interpolateTvl,
+  sumWindow,
+  type MetricSnapshot,
+} from './snapshot-at'
+import type { PoolParamEvent } from './types'
+
+function event(
+  overrides: Partial<PoolParamEvent> & { eventName: string; blockTimestamp: number }
+): PoolParamEvent {
+  return {
+    chain: 'MAINNET' as PoolParamEvent['chain'],
+    poolAddress: '0xpool',
+    protocolVersion: 3,
+    blockNumber: 0,
+    logIndex: 0,
+    txHash: '0x',
+    args: {},
+    ...overrides,
+  }
+}
+
+describe('computeParamSnapshot', () => {
+  it('tracks the latest swap fee percentage', () => {
+    const events = [
+      event({
+        eventName: 'SwapFeePercentageChanged',
+        blockTimestamp: 10,
+        args: { swapFeePercentage: '100000000000000000' },
+      }),
+      event({
+        eventName: 'SwapFeePercentageChanged',
+        blockTimestamp: 20,
+        args: { swapFeePercentage: '200000000000000000' },
+      }),
+    ]
+
+    const snap = computeParamSnapshot(events, 30)
+    expect(snap.swapFeePercentage).toBe('200000000000000000')
+  })
+
+  it('ignores events after the target timestamp', () => {
+    const events = [
+      event({
+        eventName: 'SwapFeePercentageChanged',
+        blockTimestamp: 10,
+        args: { swapFeePercentage: '100000000000000000' },
+      }),
+      event({
+        eventName: 'SwapFeePercentageChanged',
+        blockTimestamp: 50,
+        args: { swapFeePercentage: '200000000000000000' },
+      }),
+    ]
+
+    const snap = computeParamSnapshot(events, 30)
+    expect(snap.swapFeePercentage).toBe('100000000000000000')
+  })
+
+  it('uses InitialPool* events only as a t0 seed', () => {
+    const events = [
+      event({
+        eventName: 'InitialPoolAggregateSwapFeePercentage',
+        blockTimestamp: 1,
+        args: { aggregateSwapFeePercentage: '100000000000000000' },
+      }),
+      event({
+        eventName: 'AggregateSwapFeePercentageChanged',
+        blockTimestamp: 2,
+        args: { aggregateSwapFeePercentage: '200000000000000000' },
+      }),
+    ]
+
+    const snap = computeParamSnapshot(events, 10)
+    expect(snap.aggregateSwapFeePercentage).toBe('200000000000000000')
+  })
+
+  it('tracks paused and recovery mode state', () => {
+    const events = [
+      event({ eventName: 'PoolPausedStateChanged', blockTimestamp: 1, args: { paused: true } }),
+      event({
+        eventName: 'PoolRecoveryModeStateChanged',
+        blockTimestamp: 2,
+        args: { recoveryMode: true },
+      }),
+    ]
+
+    const snap = computeParamSnapshot(events, 10)
+    expect(snap.paused).toBe(true)
+    expect(snap.recoveryMode).toBe(true)
+  })
+
+  it('interpolates amp value inside an active ramp', () => {
+    const events = [
+      event({
+        eventName: 'AmpUpdateStarted',
+        blockTimestamp: 1,
+        args: {
+          startValue: '1000',
+          endValue: '2000',
+          startTime: '100',
+          endTime: '200',
+        },
+      }),
+    ]
+
+    // t = 150 → halfway between 100 and 200 → amp = 1500
+    const snap = computeParamSnapshot(events, 150)
+    expect(snap.ampValue).toBe('1500')
+    expect(snap.ampIsRamping).toBe(true)
+  })
+
+  it('uses ramp end value after the ramp completes', () => {
+    const events = [
+      event({
+        eventName: 'AmpUpdateStarted',
+        blockTimestamp: 1,
+        args: {
+          startValue: '1000',
+          endValue: '2000',
+          startTime: '100',
+          endTime: '200',
+        },
+      }),
+    ]
+
+    const snap = computeParamSnapshot(events, 250)
+    expect(snap.ampValue).toBe('2000')
+    expect(snap.ampIsRamping).toBe(false)
+  })
+
+  it('clears the ramp on AmpUpdateStopped', () => {
+    const events = [
+      event({
+        eventName: 'AmpUpdateStarted',
+        blockTimestamp: 1,
+        args: {
+          startValue: '1000',
+          endValue: '2000',
+          startTime: '100',
+          endTime: '200',
+        },
+      }),
+      event({
+        eventName: 'AmpUpdateStopped',
+        blockTimestamp: 2,
+        args: { currentValue: '1500' },
+      }),
+    ]
+
+    const snap = computeParamSnapshot(events, 150)
+    expect(snap.ampValue).toBe('1500')
+    expect(snap.ampIsRamping).toBeUndefined()
+  })
+})
+
+describe('interpolateTvl', () => {
+  const snapshots: MetricSnapshot[] = [
+    { timestamp: 0, totalLiquidity: 100, volume24h: 0, fees24h: 0 },
+    { timestamp: 10, totalLiquidity: 200, volume24h: 0, fees24h: 0 },
+  ]
+
+  it('returns 0 for an empty series', () => {
+    expect(interpolateTvl([], 5)).toBe(0)
+  })
+
+  it('clamps to the first value before the series', () => {
+    expect(interpolateTvl(snapshots, -5)).toBe(100)
+  })
+
+  it('clamps to the last value after the series', () => {
+    expect(interpolateTvl(snapshots, 50)).toBe(200)
+  })
+
+  it('linearly interpolates between buckets', () => {
+    expect(interpolateTvl(snapshots, 5)).toBe(150)
+  })
+})
+
+describe('sumWindow', () => {
+  const snapshots: MetricSnapshot[] = [
+    { timestamp: 0, totalLiquidity: 0, volume24h: 10, fees24h: 1 },
+    { timestamp: 10, totalLiquidity: 0, volume24h: 20, fees24h: 2 },
+    { timestamp: 20, totalLiquidity: 0, volume24h: 30, fees24h: 3 },
+  ]
+
+  it('sums a field over an inclusive window', () => {
+    expect(sumWindow(snapshots, 5, 15, 'volume24h')).toBe(20)
+  })
+
+  it('handles a reversed window', () => {
+    expect(sumWindow(snapshots, 15, 5, 'volume24h')).toBe(20)
+  })
+
+  it('sums fees', () => {
+    expect(sumWindow(snapshots, 0, 20, 'fees24h')).toBe(6)
+  })
+})
+
+describe('diffSnapshots', () => {
+  it('reports only changed params', () => {
+    const changes = diffSnapshots(
+      { swapFeePercentage: '100', paused: false },
+      { swapFeePercentage: '200', paused: false }
+    )
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0].key).toBe('swapFeePercentage')
+    expect(changes[0].before).toBe('100')
+    expect(changes[0].after).toBe('200')
+  })
+
+  it('treats unset → set as a change', () => {
+    const changes = diffSnapshots({}, { swapFeePercentage: '100' })
+    expect(changes).toHaveLength(1)
+    expect(changes[0].key).toBe('swapFeePercentage')
+  })
+
+  it('ignores params undefined on both sides', () => {
+    const changes = diffSnapshots({}, {})
+    expect(changes).toHaveLength(0)
+  })
+})

--- a/apps/balancer-analytics/lib/upstream/fetch-retry.spec.ts
+++ b/apps/balancer-analytics/lib/upstream/fetch-retry.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchWithRetry } from './fetch-retry'
+
+function response(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(null, { status, headers })
+}
+
+describe('fetchWithRetry', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  async function runWithTimers<T>(promise: Promise<T>): Promise<T> {
+    // Advance fake timers until the promise settles (backoff sleeps resolve).
+    let settled = false
+
+    // Attach both handlers so a rejection is consumed here and the caller's
+    // own `await expect(...).rejects` handles it without an unhandled error.
+    promise.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+
+    while (!settled) {
+      await vi.advanceTimersByTimeAsync(10_000)
+    }
+
+    return promise
+  }
+
+  it('returns the response on first success', async () => {
+    fetchMock.mockResolvedValue(response(200))
+    const res = await fetchWithRetry('https://x')
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries transient 503 then succeeds', async () => {
+    fetchMock.mockResolvedValueOnce(response(503)).mockResolvedValueOnce(response(200))
+    const p = fetchWithRetry('https://x')
+    const res = await runWithTimers(p)
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up after exhausting retries and returns the last response', async () => {
+    fetchMock.mockResolvedValue(response(503))
+    const p = fetchWithRetry('https://x', { retries: 2 })
+    const res = await runWithTimers(p)
+    expect(res.status).toBe(503)
+    expect(fetchMock).toHaveBeenCalledTimes(3) // initial + 2 retries
+  })
+
+  it('does not retry non-transient errors (e.g. 404)', async () => {
+    fetchMock.mockResolvedValue(response(404))
+    const res = await fetchWithRetry('https://x')
+    expect(res.status).toBe(404)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors Retry-After on 429 up to the ceiling', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(429, { 'retry-after': '2' }))
+      .mockResolvedValueOnce(response(200))
+
+    const p = fetchWithRetry('https://x')
+    const res = await runWithTimers(p)
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows network errors after retries are exhausted', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+    const p = fetchWithRetry('https://x', { retries: 1 })
+    await expect(runWithTimers(p)).rejects.toThrow('network down')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows AbortError immediately without retrying', async () => {
+    const abortErr = new Error('Aborted')
+    abortErr.name = 'AbortError'
+    fetchMock.mockRejectedValue(abortErr)
+    await expect(fetchWithRetry('https://x', { retries: 3 })).rejects.toThrow('Aborted')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/balancer-analytics/lib/upstream/request-cache.spec.ts
+++ b/apps/balancer-analytics/lib/upstream/request-cache.spec.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { dedupedLoad, peekCached } from './request-cache'
+
+describe('request-cache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('caches the settled value within the TTL', async () => {
+    const load = vi.fn().mockResolvedValue('data')
+    const a = await dedupedLoad('k1', 1000, load)
+    const b = await dedupedLoad('k1', 1000, load)
+    expect(a).toBe('data')
+    expect(b).toBe('data')
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it('folds concurrent callers onto a single in-flight promise', async () => {
+    let resolveLoad: (v: string) => void = () => {}
+
+    const load = vi.fn().mockImplementation(
+      () =>
+        new Promise<string>(resolve => {
+          resolveLoad = resolve
+        })
+    )
+
+    const p1 = dedupedLoad('k2', 1000, load)
+    const p2 = dedupedLoad('k2', 1000, load)
+    expect(load).toHaveBeenCalledTimes(1)
+
+    resolveLoad('data')
+    await expect(p1).resolves.toBe('data')
+    await expect(p2).resolves.toBe('data')
+  })
+
+  it('re-fetches after the TTL expires', async () => {
+    const load = vi.fn().mockResolvedValue('data')
+    await dedupedLoad('k3', 1000, load)
+    await vi.advanceTimersByTimeAsync(1001)
+    await dedupedLoad('k3', 1000, load)
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('evicts the entry on error so the next call retries', async () => {
+    const load = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce('ok')
+    await expect(dedupedLoad('k4', 1000, load)).rejects.toThrow('boom')
+    const res = await dedupedLoad('k4', 1000, load)
+    expect(res).toBe('ok')
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('peekCached returns fresh data or null', async () => {
+    expect(peekCached('k5', 1000)).toBeNull()
+    await dedupedLoad('k5', 1000, vi.fn().mockResolvedValue('data'))
+    expect(peekCached('k5', 1000)).toBe('data')
+    await vi.advanceTimersByTimeAsync(1001)
+    expect(peekCached('k5', 1000)).toBeNull()
+  })
+})

--- a/apps/balancer-analytics/test/stubs/server-only.ts
+++ b/apps/balancer-analytics/test/stubs/server-only.ts
@@ -1,0 +1,4 @@
+// Vitest stub for Next.js's `server-only` virtual module, which only exists
+// during a Next build. Modules that `import 'server-only'` (e.g. the dune
+// fetchers) can't resolve it under vitest, so we alias it here to a no-op.
+export {}

--- a/apps/balancer-analytics/vitest.config.ts
+++ b/apps/balancer-analytics/vitest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
     alias: {
       ...(baseConfig.resolve?.alias as Record<string, string>),
       '~': resolve(__dirname, './lib'),
+      // Mirrors the `@analytics/*` path mapping in tsconfig.json so specs
+      // can import app modules the same way the source does.
+      '@analytics': resolve(__dirname, '.'),
     },
   },
   test: {

--- a/apps/balancer-analytics/vitest.config.ts
+++ b/apps/balancer-analytics/vitest.config.ts
@@ -18,5 +18,11 @@ export default defineConfig({
   test: {
     ...baseConfig.test,
     passWithNoTests: true,
+    // `@repo/lib/config/app.config.ts` throws at import when this is unset,
+    // which breaks every spec that transitively imports `@repo/lib`. Provide
+    // it here so the suite runs without a local `.env.local`.
+    env: {
+      NEXT_PUBLIC_BALANCER_API_URL: 'https://api-v3.balancer.fi/graphql',
+    },
   },
 })

--- a/apps/balancer-analytics/vitest.config.ts
+++ b/apps/balancer-analytics/vitest.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
       // Mirrors the `@analytics/*` path mapping in tsconfig.json so specs
       // can import app modules the same way the source does.
       '@analytics': resolve(__dirname, '.'),
+      // Next.js's `server-only` is a build-time virtual module; alias it to
+      // a no-op stub so server-only modules are testable under vitest.
+      'server-only': resolve(__dirname, './test/stubs/server-only.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## What

- Added 13 unit-test specs to `apps/balancer-analytics`, covering the app's pure-logic modules: dune normalization, CoW fee-rebate stripping, pool param snapshots, event-log decoding, fetch retry, request cache, portfolio P&L, veBAL holder snapshot, Dune label pagination, formatters, block-window helpers, and drpc log chunking / block timestamps.
- Fixed the analytics vitest config so the suite runs standalone: set `NEXT_PUBLIC_BALANCER_API_URL` in `test.env` (was throwing at import via `@repo/lib/config/app.config.ts`), added the `@analytics` path alias, and aliased Next's `server-only` virtual module to a no-op stub.
- Exported `computePnl` in `lib/hooks/usePortfolioPnl.ts` (previously internal) so its P&L/IL logic is unit-testable.

## Why

- Issue #2710 requested meaningful tests for `balancer-analytics`. The app had only 2 spec files, and both failed to collect because the vitest config didn't provide the env vars `@repo/lib` requires at import. The suite now runs green with 17 files / 110 tests.

## Test Steps

- [ ] `pnpm --filter balancer-analytics test:unit` — all 17 files / 110 tests pass
- [ ] `pnpm --filter balancer-analytics typecheck` — clean
- [ ] `pnpm --filter balancer-analytics lint` — clean

## Risks / Breaking Changes

- `computePnl` is now exported from `usePortfolioPnl.ts` — additive, no behavior change.
- Vitest config changes are test-only; no runtime impact on the app.
- Does not touch `packages/lib`, so no impact on the Balancer/Beets apps.

## Other Notes

- Integration tests (sync orchestrator, API routes) and additional e2e smoke tests were deliberately deferred — the app is read-only and the repo's anvil-based integration harness is a poor fit; the pure logic underneath is already unit-tested.