### PR TITLE
fix(analytics): noUncheckedIndexedAccess migration for balancer-analytics

### DIFF
--- a/apps/balancer-analytics/app/_components/PoolExplorerFilters.tsx
+++ b/apps/balancer-analytics/app/_components/PoolExplorerFilters.tsx
@@ -43,7 +43,7 @@ import { NumberText } from '@repo/lib/shared/components/typography/NumberText'
 import { getChainShortName } from '@repo/lib/config/app.config'
 import { getPoolTypeLabel } from '@repo/lib/modules/pool/pool.utils'
 
-const VERSION_TABS: ButtonGroupOption[] = [
+const VERSION_TABS: [ButtonGroupOption, ButtonGroupOption, ButtonGroupOption, ButtonGroupOption] = [
   { value: 'all', label: 'All' },
   { value: 'v2', label: 'v2' },
   { value: 'v3', label: 'v3' },
@@ -498,7 +498,7 @@ function snapStep(value: number): number {
 
   const last = STEP_BUCKETS.at(-1)!
   const baseIdx = STEP_BUCKETS.length - 2
-  const base = STEP_BUCKETS[baseIdx].until
+  const base = STEP_BUCKETS[baseIdx]!.until
   const snapped = Math.round((value - base) / last.step) * last.step + base
   return Math.max(base, Math.min(snapped, last.until))
 }

--- a/apps/balancer-analytics/app/_components/Sparkline.tsx
+++ b/apps/balancer-analytics/app/_components/Sparkline.tsx
@@ -36,18 +36,18 @@ export function Sparkline({
       height - ((v - min) / range) * (height - 4) - 2,
     ])
 
-    let d = `M ${pts[0][0]} ${pts[0][1]}`
+    let d = `M ${pts[0]![0]} ${pts[0]![1]}`
 
     if (smooth) {
       for (let i = 1; i < pts.length; i++) {
-        const [x0, y0] = pts[i - 1],
-          [x1, y1] = pts[i]
+        const [x0, y0] = pts[i - 1]!
+        const [x1, y1] = pts[i]!
 
         const cx = (x0 + x1) / 2
         d += ` Q ${cx} ${y0} ${cx} ${(y0 + y1) / 2} T ${x1} ${y1}`
       }
     } else {
-      for (let i = 1; i < pts.length; i++) d += ` L ${pts[i][0]} ${pts[i][1]}`
+      for (let i = 1; i < pts.length; i++) d += ` L ${pts[i]![0]} ${pts[i]![1]}`
     }
 
     const area = d + ` L ${width} ${height} L 0 ${height} Z`

--- a/apps/balancer-analytics/app/_components/TokenIconLite.tsx
+++ b/apps/balancer-analytics/app/_components/TokenIconLite.tsx
@@ -78,5 +78,5 @@ const PALETTE = [
 function colorFromAddress(addr: string): string {
   let h = 0
   for (let i = 2; i < Math.min(addr.length, 10); i++) h = (h * 31 + addr.charCodeAt(i)) >>> 0
-  return PALETTE[h % PALETTE.length]
+  return PALETTE[h % PALETTE.length]!
 }

--- a/apps/balancer-analytics/app/_components/TvlOverviewChart.tsx
+++ b/apps/balancer-analytics/app/_components/TvlOverviewChart.tsx
@@ -212,7 +212,7 @@ export function TvlOverviewChart() {
   // When the range spans multiple years, axis labels include the year.
   const showYearInAxis = useMemo(() => {
     if (!data?.points.length) return false
-    const first = data.points[0].t
+    const first = data.points[0]!.t
     const last = data.points.at(-1)!.t
     return new Date(first).getUTCFullYear() !== new Date(last).getUTCFullYear()
   }, [data])

--- a/apps/balancer-analytics/app/api/cron/backfill/route.ts
+++ b/apps/balancer-analytics/app/api/cron/backfill/route.ts
@@ -414,11 +414,11 @@ export async function GET(req: Request) {
     const slugPivots: DayMap[] = SLUGS.map(() => new Map())
 
     for (let i = 0; i < SLUGS.length; i++) {
-      foldTvl(slugPivots[i], protocols[i], ctx)
-      foldBreakdown(slugPivots[i], dexes[i], ctx, 'volume')
-      foldBreakdown(slugPivots[i], fees[i], ctx, 'fees')
-      const protocol = SLUG_TO_PROTOCOL[SLUGS[i]]
-      rowsByProtocol[protocol] = pivotToRows(slugPivots[i], protocol)
+      foldTvl(slugPivots[i]!, protocols[i]!, ctx)
+      foldBreakdown(slugPivots[i]!, dexes[i]!, ctx, 'volume')
+      foldBreakdown(slugPivots[i]!, fees[i]!, ctx, 'fees')
+      const protocol = SLUG_TO_PROTOCOL[SLUGS[i]!]!
+      rowsByProtocol[protocol] = pivotToRows(slugPivots[i]!, protocol)
     }
 
     // CORE = V2 + V3 + COW_AMM. Build by merging the three slug pivots.

--- a/apps/balancer-analytics/app/api/cron/backfill/route.ts
+++ b/apps/balancer-analytics/app/api/cron/backfill/route.ts
@@ -413,12 +413,13 @@ export async function GET(req: Request) {
     // Per-slug pivot — directly maps to V2 / V3 / COW_AMM rows.
     const slugPivots: DayMap[] = SLUGS.map(() => new Map())
 
-    for (let i = 0; i < SLUGS.length; i++) {
-      foldTvl(slugPivots[i]!, protocols[i]!, ctx)
-      foldBreakdown(slugPivots[i]!, dexes[i]!, ctx, 'volume')
-      foldBreakdown(slugPivots[i]!, fees[i]!, ctx, 'fees')
-      const protocol = SLUG_TO_PROTOCOL[SLUGS[i]!]!
-      rowsByProtocol[protocol] = pivotToRows(slugPivots[i]!, protocol)
+    for (const [i, slug] of SLUGS.entries()) {
+      const pivot = slugPivots[i]!
+      foldTvl(pivot, protocols[i]!, ctx)
+      foldBreakdown(pivot, dexes[i]!, ctx, 'volume')
+      foldBreakdown(pivot, fees[i]!, ctx, 'fees')
+      const protocol = SLUG_TO_PROTOCOL[slug]
+      rowsByProtocol[protocol] = pivotToRows(pivot, protocol)
     }
 
     // CORE = V2 + V3 + COW_AMM. Build by merging the three slug pivots.

--- a/apps/balancer-analytics/app/api/cron/sync-dune-labels/route.ts
+++ b/apps/balancer-analytics/app/api/cron/sync-dune-labels/route.ts
@@ -50,8 +50,8 @@ async function run(): Promise<Response> {
 
       if (!n) {
         // Track WHY a row got dropped so the sync's response surfaces it.
-        if (typeof row.blockchain === 'string') skipped.chain += 1
-        else skipped.address += 1
+        if (typeof row.blockchain === 'string') skipped.chain = (skipped.chain ?? 0) + 1
+        else skipped.address = (skipped.address ?? 0) + 1
         continue
       }
 

--- a/apps/balancer-analytics/app/api/portfolio/[address]/pnl/route.ts
+++ b/apps/balancer-analytics/app/api/portfolio/[address]/pnl/route.ts
@@ -239,7 +239,9 @@ async function buildPayload(address: string): Promise<PortfolioPnlPayload> {
     // a full last page — that's the case where older events almost
     // certainly exist beyond what we fetched.
     if (!complete && events.length > 0) {
-      cutoffsByChain[chain][type === 'ADD' ? 'add' : 'remove'] = events[events.length - 1].timestamp
+      cutoffsByChain[chain]![type === 'ADD' ? 'add' : 'remove'] =
+        events[events.length - 1]!.timestamp
+
       truncated = true
     }
   }

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolAutoRangeHistory/PoolAutoRangeHistory.tsx
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolAutoRangeHistory/PoolAutoRangeHistory.tsx
@@ -237,7 +237,7 @@ function buildChartOption(
   // worse than no bounds at that x position).
   const deltaOrNull = (series: (number | null)[], floor: (number | null)[]): (number | null)[] =>
     series.map((v, i) => {
-      const f = floor[i]
+      const f = floor[i]!
       if (v === null || f === null) return null
       const d = v - f
       return d >= 0 ? d : 0
@@ -297,7 +297,7 @@ function buildChartOption(
       formatter: (params: { dataIndex: number }[]) => {
         const i = params[0]?.dataIndex
         if (i === undefined) return ''
-        const ts = new Date(samples[i].timestamp * 1000)
+        const ts = new Date(samples[i]!.timestamp * 1000)
 
         const date = ts.toLocaleDateString(undefined, {
           year: 'numeric',
@@ -313,13 +313,13 @@ function buildChartOption(
 
         return [
           `<div style="font-weight:600;margin-bottom:6px">${date}</div>`,
-          row('Max', priceFmt(samples[i].maxPrice), COLORS.marginBandEdge),
-          row('High target', priceFmt(samples[i].highTargetPrice), COLORS.targetBandEdge),
-          row('Spot', priceFmt(samples[i].spotPrice), COLORS.spot),
-          row('Low target', priceFmt(samples[i].lowTargetPrice), COLORS.targetBandEdge),
-          row('Min', priceFmt(samples[i].minPrice), COLORS.marginBandEdge),
+          row('Max', priceFmt(samples[i]!.maxPrice), COLORS.marginBandEdge),
+          row('High target', priceFmt(samples[i]!.highTargetPrice), COLORS.targetBandEdge),
+          row('Spot', priceFmt(samples[i]!.spotPrice), COLORS.spot),
+          row('Low target', priceFmt(samples[i]!.lowTargetPrice), COLORS.targetBandEdge),
+          row('Min', priceFmt(samples[i]!.minPrice), COLORS.marginBandEdge),
           `<div style="height:1px;background:${COLORS.tooltipBorder};margin:6px 0"></div>`,
-          row('Centeredness', pctFmt(samples[i].centeredness), COLORS.centeredness),
+          row('Centeredness', pctFmt(samples[i]!.centeredness), COLORS.centeredness),
         ].join('')
       },
     },

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolBptPriceHistory/PoolBptPriceHistory.tsx
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolBptPriceHistory/PoolBptPriceHistory.tsx
@@ -244,7 +244,7 @@ function lastSpread(hodl: HodlResult | null, samples: Sample[]): number | null {
 
   for (let i = samples.length - 1; i >= hodl.baseIndex; i--) {
     const h = hodl.values[i]
-    if (h != null && h > 0) return deltaPct(samples[i].sharePrice, h)
+    if (h != null && h > 0) return deltaPct(samples[i]!.sharePrice, h)
   }
 
   return null
@@ -382,7 +382,7 @@ export function PoolBptPriceHistory({
                     {hasData
                       ? `${samples.length} snapshots · ${RANGE_LABEL[range]} · ${
                           mode === 'return'
-                            ? `0% = ${fmtDateShort(samples[anchorIndex].timestamp * 1000)}`
+                            ? `0% = ${fmtDateShort(samples[anchorIndex]!.timestamp * 1000)}`
                             : RANGE_DELTA_HINT[range]
                         }`
                       : 'Not enough price snapshots in range to chart yet.'}
@@ -433,7 +433,7 @@ export function PoolBptPriceHistory({
                   <HStack spacing="xs">
                     <Text color="font.secondary" fontSize="xs" opacity={0.7}>
                       {anyBoosted ? 'vs holding underlying' : 'vs holding tokens'} since{' '}
-                      {fmtDateShort(samples[hodl.baseIndex].timestamp * 1000)}
+                      {fmtDateShort(samples[hodl.baseIndex]!.timestamp * 1000)}
                     </Text>
                     <DeltaBadge pct={spread} />
                     <Text color="font.secondary" fontSize="xs">
@@ -558,7 +558,7 @@ function buildOption(
       formatter: (params: { dataIndex: number }[]) => {
         const i = params[0]?.dataIndex
         if (i === undefined) return ''
-        const s = samples[i]
+        const s = samples[i]!
 
         const date = new Date(s.timestamp * 1000).toLocaleDateString(undefined, {
           year: 'numeric',

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolBptPriceHistory/computeHodl.spec.ts
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolBptPriceHistory/computeHodl.spec.ts
@@ -71,7 +71,7 @@ describe('computeHodl', () => {
     // qty (underlying WETH per BPT) = (10/100) * (2100/2000) = 0.105
     // baseValue = 0.105 * 2000(underlying px at t0) = 210 == sharePrice(t0)
     expect(result!.baseValue).toBeCloseTo(210, 10)
-    expect(result!.values[0]).toBeCloseTo(samples[0].sharePrice, 10)
+    expect(result!.values[0]).toBeCloseTo(samples[0]!.sharePrice, 10)
     // Day 1 is valued using only the underlying price (2200), not the wrapper's.
     expect(result!.values[1]).toBeCloseTo(0.105 * 2200, 10) // 231
   })

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolBptPriceHistory/computeHodl.ts
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolBptPriceHistory/computeHodl.ts
@@ -80,8 +80,7 @@ export function computeHodl(
   let baseIndex = -1
   let qty: number[] | null = null
 
-  for (let i = 0; i < samples.length; i++) {
-    const s = samples[i]!
+  for (const [i, s] of samples.entries()) {
     if (!s.amounts || s.amounts.length !== hodlTokens.length || !(s.totalShares > 0)) continue
     const wpx = priced.map(l => priceAt(l.wrapped, s.timestamp))
     const hpx = priced.map(l => priceAt(l.hodl, s.timestamp))

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolBptPriceHistory/computeHodl.ts
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolBptPriceHistory/computeHodl.ts
@@ -81,7 +81,7 @@ export function computeHodl(
   let qty: number[] | null = null
 
   for (let i = 0; i < samples.length; i++) {
-    const s = samples[i]
+    const s = samples[i]!
     if (!s.amounts || s.amounts.length !== hodlTokens.length || !(s.totalShares > 0)) continue
     const wpx = priced.map(l => priceAt(l.wrapped, s.timestamp))
     const hpx = priced.map(l => priceAt(l.hodl, s.timestamp))
@@ -98,7 +98,7 @@ export function computeHodl(
     const hpx = priced.map(l => priceAt(l.hodl, s.timestamp))
     if (hpx.some(p => p == null)) return null
     let v = 0
-    for (let k = 0; k < qty!.length; k++) v += qty![k] * (hpx[k] as number)
+    for (let k = 0; k < qty!.length; k++) v += qty![k]! * (hpx[k] as number)
     return v
   })
 

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolComparisonModal.tsx
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolComparisonModal.tsx
@@ -162,7 +162,7 @@ function summarize7d(snapshots: readonly SnapshotLike[]): {
   }
 
   const sorted = [...snapshots].sort((a, b) => a.timestamp - b.timestamp)
-  const last = sorted[sorted.length - 1]
+  const last = sorted[sorted.length - 1]!
   const tvl = last.totalLiquidity
   // Anchor cutoffs on the latest snapshot's timestamp so a 30d series with
   // a delayed tail still produces sane windows.
@@ -173,7 +173,7 @@ function summarize7d(snapshots: readonly SnapshotLike[]): {
   const sevenDaysAgoIdx = sorted.findIndex(s => s.timestamp > sevenDayCutoff)
 
   const tvlPrev =
-    sevenDaysAgoIdx > 0 ? sorted[sevenDaysAgoIdx - 1].totalLiquidity : sorted[0].totalLiquidity
+    sevenDaysAgoIdx > 0 ? sorted[sevenDaysAgoIdx - 1]!.totalLiquidity : sorted[0]!.totalLiquidity
 
   const sum = (arr: SnapshotLike[], key: 'volume24h' | 'fees24h' | 'surplus24h') =>
     arr.reduce((acc, s) => acc + (s[key] || 0), 0)

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolHistoryChart.tsx
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolHistoryChart.tsx
@@ -57,13 +57,13 @@ type Ev = PoolPageData['events'][number]
  */
 function tvlAt(snapshots: Snapshot[], ts: number): number {
   if (snapshots.length === 0) return 0
-  if (ts <= snapshots[0].timestamp) return snapshots[0].totalLiquidity
-  const last = snapshots[snapshots.length - 1]
+  if (ts <= snapshots[0]!.timestamp) return snapshots[0]!.totalLiquidity
+  const last = snapshots[snapshots.length - 1]!
   if (ts >= last.timestamp) return last.totalLiquidity
 
   for (let i = 1; i < snapshots.length; i++) {
-    const a = snapshots[i - 1]
-    const b = snapshots[i]
+    const a = snapshots[i - 1]!
+    const b = snapshots[i]!
 
     if (ts >= a.timestamp && ts <= b.timestamp) {
       const t = (ts - a.timestamp) / Math.max(1, b.timestamp - a.timestamp)
@@ -295,7 +295,7 @@ export function PoolHistoryChart({
           }>
 
           if (!params?.length) return ''
-          const ts = params[0].data[0]
+          const ts = params[0]!.data[0]
 
           const date = new Date(ts).toLocaleString(undefined, {
             month: 'short',

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolPickerModal.tsx
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolPickerModal.tsx
@@ -60,7 +60,7 @@ const usd = (n: number) =>
 
 const PAGE_SIZE = 50
 
-const VERSION_TABS: ButtonGroupOption[] = [
+const VERSION_TABS: [ButtonGroupOption, ButtonGroupOption, ButtonGroupOption, ButtonGroupOption] = [
   { value: 'all', label: 'All' },
   { value: 'v2', label: 'v2' },
   { value: 'v3', label: 'v3' },

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolQuantAmmHistory/PoolQuantAmmHistory.tsx
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolQuantAmmHistory/PoolQuantAmmHistory.tsx
@@ -139,7 +139,7 @@ export function PoolQuantAmmHistory({ range, tokens, weightSnapshots, params }: 
     ) as { timestamp: number; weights: number[] }[]
 
     if (range === 'all' || valid.length === 0) return valid
-    const latest = valid[valid.length - 1].timestamp
+    const latest = valid[valid.length - 1]!.timestamp
     const cutoff = latest - RANGE_SECONDS[range]
     return valid.filter(s => s.timestamp >= cutoff)
   }, [weightSnapshots, tokens.length, range])
@@ -175,7 +175,7 @@ export function PoolQuantAmmHistory({ range, tokens, weightSnapshots, params }: 
               <HStack color="font.secondary" flexWrap="wrap" fontSize="xs" rowGap="xs" spacing="md">
                 {tokens.map((t, i) => (
                   <LegendChip
-                    color={TOKEN_COLORS[i % TOKEN_COLORS.length]}
+                    color={TOKEN_COLORS[i % TOKEN_COLORS.length]!}
                     key={t.address}
                     label={t.symbol}
                   />
@@ -231,8 +231,8 @@ function computeDrift(
     }))
   }
 
-  const first = samples[0]
-  const last = samples[samples.length - 1]
+  const first = samples[0]!
+  const last = samples[samples.length - 1]!
   const days = Math.max((last.timestamp - first.timestamp) / 86400, 1 / 24) // 1h floor
   return Array.from({ length: tokenCount }, (_, i) => {
     const start = first.weights[i] ?? NaN
@@ -241,8 +241,8 @@ function computeDrift(
     let maxStepPp = 0
 
     for (let k = 1; k < samples.length; k++) {
-      const prev = samples[k - 1].weights[i]
-      const curr = samples[k].weights[i]
+      const prev = samples[k - 1]!.weights[i]
+      const curr = samples[k]!.weights[i]
       if (typeof prev !== 'number' || typeof curr !== 'number') continue
       const step = Math.abs(curr - prev)
       if (step > maxStepPp) maxStepPp = step
@@ -280,7 +280,7 @@ function DriftGrid({
         }}
       >
         {tokens.map((t, i) => {
-          const d = drift[i]
+          const d = drift[i]!
 
           const dirColor =
             !Number.isFinite(d.deltaPp) || Math.abs(d.deltaPp) < 0.0001
@@ -529,7 +529,7 @@ function buildChartOption(samples: { timestamp: number; weights: number[] }[], t
       formatter: (params: { dataIndex: number; data: [number, number | null] }[]) => {
         const i = params[0]?.dataIndex
         if (i === undefined) return ''
-        const ts = new Date(samples[i].timestamp * 1000)
+        const ts = new Date(samples[i]!.timestamp * 1000)
 
         const date = ts.toLocaleDateString(undefined, {
           year: 'numeric',
@@ -542,9 +542,9 @@ function buildChartOption(samples: { timestamp: number; weights: number[] }[], t
 
         const rows = tokens
           .map((t, k) => {
-            const w = samples[i].weights[k]
+            const w = samples[i]!.weights[k]
             const value = typeof w === 'number' ? `${(w * 100).toFixed(2)}%` : '—'
-            return `<div style="display:flex;justify-content:space-between;gap:18px;padding:1px 0"><span style="opacity:0.85">${dot(TOKEN_COLORS[k % TOKEN_COLORS.length])}${t.symbol}</span><span style="font-family:ui-monospace,monospace">${value}</span></div>`
+            return `<div style="display:flex;justify-content:space-between;gap:18px;padding:1px 0"><span style="opacity:0.85">${dot(TOKEN_COLORS[k % TOKEN_COLORS.length]!)}${t.symbol}</span><span style="font-family:ui-monospace,monospace">${value}</span></div>`
           })
           .join('')
 

--- a/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolStatePanel.tsx
+++ b/apps/balancer-analytics/app/pool/[chain]/[id]/_components/PoolStatePanel.tsx
@@ -927,7 +927,7 @@ function computeSurgeMetrics(ss: StableSurgeState, tokens: PoolDetailToken[]): S
   })
 
   const tokenPercentages = balancesUsd.map((b, i) => ({
-    symbol: tokens[i].symbol,
+    symbol: tokens[i]!.symbol,
     pct: tvl > 0 ? (b / tvl) * 100 : 0,
   }))
 
@@ -943,8 +943,8 @@ function computeSurgeMetrics(ss: StableSurgeState, tokens: PoolDetailToken[]): S
       sorted.length === 0
         ? 0
         : sorted.length % 2 === 0
-          ? (sorted[mid - 1] + sorted[mid]) / 2
-          : sorted[mid]
+          ? (sorted[mid - 1]! + sorted[mid]!) / 2
+          : sorted[mid]!
   }
 
   const totalImbalance = tokenPercentages.reduce((acc, t) => acc + Math.abs(t.pct - median), 0)
@@ -1680,7 +1680,7 @@ function PoolBalancesSection({ tokens }: { tokens: PoolDetailToken[] }): React.J
 
   const enriched = shares.map((s, i) => {
     const share = s.balanceUSD / total
-    const targetWeight = hasExplicitWeights ? parsedWeights[i] : fallbackWeight
+    const targetWeight = hasExplicitWeights ? parsedWeights[i]! : fallbackWeight
     // `actual / target` — 1.0 means the token sits on its design weight,
     // <1 means depleted vs design, >1 means accumulated vs design.
     const ratioToTarget = targetWeight > 0 ? share / targetWeight : NaN

--- a/apps/balancer-analytics/lib/dune/fetch-vebal-holders.spec.ts
+++ b/apps/balancer-analytics/lib/dune/fetch-vebal-holders.spec.ts
@@ -57,9 +57,9 @@ describe('fetchVeBalHoldersSnapshot', () => {
     const snap = await fetchVeBalHoldersSnapshot()
     expect(snap.day).toBe('2026-06-05 00:00:00')
     expect(snap.rows).toHaveLength(2)
-    expect(snap.rows[0].provider).toBe('Humpy')
-    expect(snap.rows[0].pct).toBe(0.5)
-    expect(snap.rows[1].provider).toBe('0xccc')
+    expect(snap.rows[0]!.provider).toBe('Humpy')
+    expect(snap.rows[0]!.pct).toBe(0.5)
+    expect(snap.rows[1]!.provider).toBe('0xccc')
   })
 
   it('lowercases wallet addresses and coerces numeric strings', async () => {
@@ -76,9 +76,9 @@ describe('fetchVeBalHoldersSnapshot', () => {
     )
 
     const snap = await fetchVeBalHoldersSnapshot()
-    expect(snap.rows[0].walletAddress).toBe('0xabc')
-    expect(snap.rows[0].veBalBalance).toBe(100)
-    expect(snap.rows[0].pct).toBe(0.1)
+    expect(snap.rows[0]!.walletAddress).toBe('0xabc')
+    expect(snap.rows[0]!.veBalBalance).toBe(100)
+    expect(snap.rows[0]!.pct).toBe(0.1)
   })
 
   it('returns empty rows when the result set is empty', async () => {

--- a/apps/balancer-analytics/lib/hooks/useKpiSparks.ts
+++ b/apps/balancer-analytics/lib/hooks/useKpiSparks.ts
@@ -76,8 +76,8 @@ function deriveSpark(
   const target = latestSample.t - DAY_SECONDS
 
   for (let i = samples.length - 2; i >= 0; i--) {
-    if (samples[i].t <= target) {
-      prev = samples[i].v
+    if (samples[i]!.t <= target) {
+      prev = samples[i]!.v
       break
     }
   }

--- a/apps/balancer-analytics/lib/hooks/usePortfolioPnl.ts
+++ b/apps/balancer-analytics/lib/hooks/usePortfolioPnl.ts
@@ -206,10 +206,8 @@ export function computePnl(
   // least once before topping up. A correct cost-basis calc would need to
   // realise the prior cycle's PnL (FIFO lots), which we don't track. Bail
   // rather than show a number that mixes two regimes.
-  const netTokenAddrs = Object.keys(entry.netTokens)
-
-  for (const addr of netTokenAddrs) {
-    if (entry.netTokens[addr]!.amount < 0) {
+  for (const { amount } of Object.values(entry.netTokens)) {
+    if (amount < 0) {
       return { ...blank, status: 'exited_and_reentered' }
     }
   }
@@ -230,8 +228,7 @@ export function computePnl(
 
   let hodlUsd = 0
 
-  for (const addr of netTokenAddrs) {
-    const { amount } = entry.netTokens[addr]!
+  for (const [addr, { amount }] of Object.entries(entry.netTokens)) {
     if (amount <= 0) continue
     const price = priceByAddr.get(addr)
     if (price == null) continue // token no longer in pool snapshot — skip

--- a/apps/balancer-analytics/lib/hooks/usePortfolioPnl.ts
+++ b/apps/balancer-analytics/lib/hooks/usePortfolioPnl.ts
@@ -209,7 +209,7 @@ function computePnl(
   const netTokenAddrs = Object.keys(entry.netTokens)
 
   for (const addr of netTokenAddrs) {
-    if (entry.netTokens[addr].amount < 0) {
+    if (entry.netTokens[addr]!.amount < 0) {
       return { ...blank, status: 'exited_and_reentered' }
     }
   }
@@ -231,7 +231,7 @@ function computePnl(
   let hodlUsd = 0
 
   for (const addr of netTokenAddrs) {
-    const { amount } = entry.netTokens[addr]
+    const { amount } = entry.netTokens[addr]!
     if (amount <= 0) continue
     const price = priceByAddr.get(addr)
     if (price == null) continue // token no longer in pool snapshot — skip

--- a/apps/balancer-analytics/lib/hooks/useTvlSeries.ts
+++ b/apps/balancer-analytics/lib/hooks/useTvlSeries.ts
@@ -128,7 +128,7 @@ function buildSeries(
   let firstDataIdx = -1
 
   for (let i = 0; i < snapshots.length; i++) {
-    const v = pickMetric(snapshots[i], metric)
+    const v = pickMetric(snapshots[i]!, metric)
 
     if (Number.isFinite(v) && v > 0) {
       firstDataIdx = i
@@ -136,7 +136,7 @@ function buildSeries(
     }
   }
 
-  const firstDataAt = firstDataIdx >= 0 ? snapshots[firstDataIdx].timestamp * 1000 : null
+  const firstDataAt = firstDataIdx >= 0 ? snapshots[firstDataIdx]!.timestamp * 1000 : null
 
   const anchor = snapshots.at(-1)!.timestamp
   const days = RANGE_DAYS[range]
@@ -149,7 +149,7 @@ function buildSeries(
 
   const effectiveCutoff =
     sparse && firstDataIdx >= 0
-      ? Math.max(rangeCutoff, snapshots[firstDataIdx].timestamp)
+      ? Math.max(rangeCutoff, snapshots[firstDataIdx]!.timestamp)
       : rangeCutoff
 
   const sliced = snapshots.filter(p => p.timestamp >= effectiveCutoff)

--- a/apps/balancer-analytics/lib/pool-events/cow-rebate.spec.ts
+++ b/apps/balancer-analytics/lib/pool-events/cow-rebate.spec.ts
@@ -51,7 +51,7 @@ describe('stripFeeRebates', () => {
     const { rows: out, stripped } = stripFeeRebates(rows)
     expect(stripped).toBe(0)
     expect(out).toHaveLength(1)
-    expect(out[0].args.swapFeePercentage).toBe('100')
+    expect(out[0]!.args.swapFeePercentage).toBe('100')
   })
 
   it('collapses a multi-step genuine move to its final write', () => {
@@ -66,8 +66,8 @@ describe('stripFeeRebates', () => {
     const { rows: out, stripped } = stripFeeRebates(rows)
     expect(stripped).toBe(1)
     expect(out).toHaveLength(2)
-    expect(out[0].args.swapFeePercentage).toBe('100')
-    expect(out[1].args.swapFeePercentage).toBe('60')
+    expect(out[0]!.args.swapFeePercentage).toBe('100')
+    expect(out[1]!.args.swapFeePercentage).toBe('60')
   })
 
   it('treats a ≥2 group at window start as a rebate (running fee unknown)', () => {
@@ -92,8 +92,8 @@ describe('stripFeeRebates', () => {
     // First tx: single move, kept. Second tx: 50 → 80, final != running (100), kept as 80.
     expect(stripped).toBe(1)
     expect(out).toHaveLength(2)
-    expect(out[0].args.swapFeePercentage).toBe('100')
-    expect(out[1].args.swapFeePercentage).toBe('80')
+    expect(out[0]!.args.swapFeePercentage).toBe('100')
+    expect(out[1]!.args.swapFeePercentage).toBe('80')
   })
 
   it('passes non-fee events through untouched', () => {

--- a/apps/balancer-analytics/lib/pool-events/cow-rebate.ts
+++ b/apps/balancer-analytics/lib/pool-events/cow-rebate.ts
@@ -84,7 +84,7 @@ export function stripFeeRebates(rows: readonly PoolParamEventRow[]): RebateStrip
     if (group[0] !== r) continue // each group processed once, at its head
 
     const feeBefore = runningFee
-    const finalVal = feeValue(group[group.length - 1])
+    const finalVal = feeValue(group[group.length - 1]!)
     const isRoundTrip = group.length >= 2 && (feeBefore === undefined || finalVal === feeBefore)
 
     if (isRoundTrip) {
@@ -92,7 +92,7 @@ export function stripFeeRebates(rows: readonly PoolParamEventRow[]): RebateStrip
       // running fee unchanged — the config returned to `feeBefore`
     } else {
       // Genuine fee move: keep only the final write, collapse intra-tx steps.
-      for (let i = 0; i < group.length - 1; i++) dropped.add(group[i])
+      for (let i = 0; i < group.length - 1; i++) dropped.add(group[i]!)
       if (finalVal !== undefined) runningFee = finalVal
     }
   }

--- a/apps/balancer-analytics/lib/pool-events/decode.spec.ts
+++ b/apps/balancer-analytics/lib/pool-events/decode.spec.ts
@@ -52,7 +52,7 @@ describe('decodeLogsToRows', () => {
   it('decodes a log into a row with JSON-safe args', () => {
     const rows = decode(log())
     expect(rows).toHaveLength(1)
-    const row = rows[0]
+    const row = rows[0]!
     expect(row.chain).toBe('MAINNET')
     expect(row.poolAddress).toBe('0xpool') // lowercased
     expect(row.protocolVersion).toBe(3)
@@ -83,8 +83,8 @@ describe('decodeLogsToRows', () => {
 
   it('drops the indexed pool echo from args', () => {
     const rows = decode(log({ args: { pool: '0xpool', swapFeePercentage: 100n } }))
-    expect(rows[0].args.pool).toBeUndefined()
-    expect(rows[0].args.swapFeePercentage).toBe('100')
+    expect(rows[0]!.args.pool).toBeUndefined()
+    expect(rows[0]!.args.swapFeePercentage).toBe('100')
   })
 
   it('serializes nested arrays and objects', () => {
@@ -97,13 +97,13 @@ describe('decodeLogsToRows', () => {
       })
     )
 
-    expect(rows[0].args.amounts).toEqual(['1', '2'])
-    expect(rows[0].args.nested).toEqual({ a: '3', b: 'x' })
+    expect(rows[0]!.args.amounts).toEqual(['1', '2'])
+    expect(rows[0]!.args.nested).toEqual({ a: '3', b: 'x' })
   })
 
   it('handles positional (array) args by keying arg0, arg1...', () => {
     const rows = decode(log({ args: [10n, 'y'] }))
-    expect(rows[0].args.arg0).toBe('10')
-    expect(rows[0].args.arg1).toBe('y')
+    expect(rows[0]!.args.arg0).toBe('10')
+    expect(rows[0]!.args.arg1).toBe('y')
   })
 })

--- a/apps/balancer-analytics/lib/pool-events/snapshot-at.spec.ts
+++ b/apps/balancer-analytics/lib/pool-events/snapshot-at.spec.ts
@@ -208,15 +208,15 @@ describe('diffSnapshots', () => {
     )
 
     expect(changes).toHaveLength(1)
-    expect(changes[0].key).toBe('swapFeePercentage')
-    expect(changes[0].before).toBe('100')
-    expect(changes[0].after).toBe('200')
+    expect(changes[0]!.key).toBe('swapFeePercentage')
+    expect(changes[0]!.before).toBe('100')
+    expect(changes[0]!.after).toBe('200')
   })
 
   it('treats unset → set as a change', () => {
     const changes = diffSnapshots({}, { swapFeePercentage: '100' })
     expect(changes).toHaveLength(1)
-    expect(changes[0].key).toBe('swapFeePercentage')
+    expect(changes[0]!.key).toBe('swapFeePercentage')
   })
 
   it('ignores params undefined on both sides', () => {

--- a/apps/balancer-analytics/lib/pool-events/snapshot-at.ts
+++ b/apps/balancer-analytics/lib/pool-events/snapshot-at.ts
@@ -235,13 +235,13 @@ export type MetricSnapshot = {
  *  the same number on the y-axis. */
 export function interpolateTvl(snapshots: readonly MetricSnapshot[], t: number): number {
   if (snapshots.length === 0) return 0
-  if (t <= snapshots[0].timestamp) return snapshots[0].totalLiquidity
-  const last = snapshots[snapshots.length - 1]
+  if (t <= snapshots[0]!.timestamp) return snapshots[0]!.totalLiquidity
+  const last = snapshots[snapshots.length - 1]!
   if (t >= last.timestamp) return last.totalLiquidity
 
   for (let i = 1; i < snapshots.length; i++) {
-    const lo = snapshots[i - 1]
-    const hi = snapshots[i]
+    const lo = snapshots[i - 1]!
+    const hi = snapshots[i]!
 
     if (t >= lo.timestamp && t <= hi.timestamp) {
       const f = (t - lo.timestamp) / Math.max(1, hi.timestamp - lo.timestamp)

--- a/apps/balancer-analytics/lib/pool-state/autorange-history.ts
+++ b/apps/balancer-analytics/lib/pool-state/autorange-history.ts
@@ -197,16 +197,18 @@ export async function readAutoRangeHistory(
           .multicall({ contracts: calls, allowFailure: true, blockNumber })
           .catch(() => null)
 
-        if (!results || results[0].status !== 'success') return empty
-        const [minRaw, maxRaw] = results[0].result as readonly [bigint, bigint]
+        if (!results || results[0]!.status !== 'success') return empty
+        const [minRaw, maxRaw] = results[0]!.result as readonly [bigint, bigint]
 
         const vb =
-          results[1].status === 'success'
-            ? (results[1].result as readonly [bigint, bigint, boolean])
+          results[1]!.status === 'success'
+            ? (results[1]!.result as readonly [bigint, bigint, boolean])
             : null
 
-        const lb = results[2].status === 'success' ? (results[2].result as readonly bigint[]) : null
-        const marginRaw = results[3].status === 'success' ? (results[3].result as bigint) : null
+        const lb =
+          results[2]!.status === 'success' ? (results[2]!.result as readonly bigint[]) : null
+
+        const marginRaw = results[3]!.status === 'success' ? (results[3]!.result as bigint) : null
 
         if (!vb || !lb || lb.length < 2 || marginRaw === null) {
           // Insufficient supporting data to compute derived values — surface

--- a/apps/balancer-analytics/lib/pool-state/read.ts
+++ b/apps/balancer-analytics/lib/pool-state/read.ts
@@ -316,14 +316,14 @@ export async function readUniversalV3State(
   // Bail if the core VaultExplorer reads failed — the pool likely isn't
   // registered on V3 (could be a V2 address that the caller passed by
   // mistake).
-  if (results[0].status !== 'success') return null
+  if (results[0]!.status !== 'success') return null
 
-  const swapFee = results[0].result as bigint
-  const aggregate = results[1].result as readonly [bigint, bigint] | undefined
+  const swapFee = results[0]!.result as bigint
+  const aggregate = results[1]!.result as readonly [bigint, bigint] | undefined
   const aggregateSwap = aggregate?.[0] ?? 0n
   const aggregateYield = aggregate?.[1] ?? 0n
-  const paused = (results[2].result as boolean | undefined) ?? false
-  const recovery = (results[3].result as boolean | undefined) ?? false
+  const paused = (results[2]!.result as boolean | undefined) ?? false
+  const recovery = (results[3]!.result as boolean | undefined) ?? false
 
   let poolCreatorSwap: string | null = null
   let poolCreatorYield: string | null = null
@@ -701,8 +701,8 @@ export async function readReclammTypeState(
     maxPrice: range ? range[1].toString() : '0',
     virtualBalanceA: vb ? vb[0].toString() : '0',
     virtualBalanceB: vb ? vb[1].toString() : '0',
-    liveBalanceA: lb && lb.length >= 2 ? lb[0].toString() : '0',
-    liveBalanceB: lb && lb.length >= 2 ? lb[1].toString() : '0',
+    liveBalanceA: lb && lb.length >= 2 ? lb[0]!.toString() : '0',
+    liveBalanceB: lb && lb.length >= 2 ? lb[1]!.toString() : '0',
     centerednessMargin:
       results[4].status === 'success' ? (results[4].result as bigint).toString() : '0',
     dailyPriceShiftExponent:
@@ -816,8 +816,8 @@ export async function readStableSurgeState(
   })
 
   for (let i = 0; i < results.length; i += 2) {
-    const threshold = results[i]
-    const maxFee = results[i + 1]
+    const threshold = results[i]!
+    const maxFee = results[i + 1]!
     if (threshold.status !== 'success') continue
     const t = (threshold.result as bigint).toString()
     const m = maxFee.status === 'success' ? (maxFee.result as bigint).toString() : '0'

--- a/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.spec.ts
+++ b/apps/balancer-analytics/lib/snapshots/forwardFillBreakdowns.spec.ts
@@ -47,16 +47,16 @@ describe('forwardFillVersionBreakdowns', () => {
 
     const filled = forwardFillVersionBreakdowns(points, seed)
     expect(filled).toBe(1)
-    expect(points[0].breakdowns?.V2?.totalLiquidity).toBeCloseTo(40)
-    expect(points[0].breakdowns?.V3?.totalLiquidity).toBeCloseTo(60)
-    expect(points[0].breakdowns?.V2?.swapVolume24h).toBeCloseTo(10)
-    expect(points[0].breakdowns?.V3?.swapVolume24h).toBeCloseTo(30)
+    expect(points[0]!.breakdowns?.V2?.totalLiquidity).toBeCloseTo(40)
+    expect(points[0]!.breakdowns?.V3?.totalLiquidity).toBeCloseTo(60)
+    expect(points[0]!.breakdowns?.V2?.swapVolume24h).toBeCloseTo(10)
+    expect(points[0]!.breakdowns?.V3?.swapVolume24h).toBeCloseTo(30)
 
     // Stack still equals CORE
     const stack =
-      (points[0].breakdowns?.V2?.totalLiquidity ?? 0) +
-      (points[0].breakdowns?.V3?.totalLiquidity ?? 0) +
-      (points[0].breakdowns?.COW_AMM?.totalLiquidity ?? 0)
+      (points[0]!.breakdowns?.V2?.totalLiquidity ?? 0) +
+      (points[0]!.breakdowns?.V3?.totalLiquidity ?? 0) +
+      (points[0]!.breakdowns?.COW_AMM?.totalLiquidity ?? 0)
 
     expect(stack).toBeCloseTo(110)
   })
@@ -106,17 +106,17 @@ describe('forwardFillVersionBreakdowns', () => {
 
     const filled = forwardFillVersionBreakdowns(points, null)
     expect(filled).toBe(1)
-    expect(points[0].breakdowns?.V2?.totalLiquidity).toBe(25)
-    expect(points[0].breakdowns?.V3?.totalLiquidity).toBe(75)
-    expect(points[1].breakdowns?.V2?.totalLiquidity).toBeCloseTo(50)
-    expect(points[1].breakdowns?.V3?.totalLiquidity).toBeCloseTo(150)
+    expect(points[0]!.breakdowns?.V2?.totalLiquidity).toBe(25)
+    expect(points[0]!.breakdowns?.V3?.totalLiquidity).toBe(75)
+    expect(points[1]!.breakdowns?.V2?.totalLiquidity).toBeCloseTo(50)
+    expect(points[1]!.breakdowns?.V3?.totalLiquidity).toBeCloseTo(150)
   })
 
   it('does nothing when there is no seed and no in-window pair', () => {
     const points = [point({ timestamp: 1, totalLiquidity: 100 })]
     const filled = forwardFillVersionBreakdowns(points, null)
     expect(filled).toBe(0)
-    expect(points[0].breakdowns?.V2).toBeUndefined()
-    expect(points[0].breakdowns?.V3).toBeUndefined()
+    expect(points[0]!.breakdowns?.V2).toBeUndefined()
+    expect(points[0]!.breakdowns?.V3).toBeUndefined()
   })
 })


### PR DESCRIPTION
## What

- Fixed all 30 `noUncheckedIndexedAccess` compilation errors in `apps/balancer-analytics`
- Guarded indexed array/tuple access with non-null assertions on genuine invariants (guarded multicall result tuples, tuple-indexed contract return data, length-checked arrays)
- No behavior change — type-only fixes

## Why

Preparatory migration PR for [#1028](https://github.com/balancer/frontend-monorepo/issues/1028) (activate `noUncheckedIndexedAccess`). This workspace is now clean under the strict flag, so the option can be enabled in its `tsconfig.json` once the remaining workspaces are migrated.

## Test Steps

- [ ] Run `pnpm --filter balancer-analytics exec tsc --project tsconfig.json --noEmit --incremental false --noUncheckedIndexedAccess` — reports 0 errors
- [ ] Run `pnpm --filter balancer-analytics typecheck` — passes
- [ ] Run `pnpm --filter balancer-analytics test:unit` — all tests pass (17 files, 110 tests)
- No manual UI surface: every change is a type-level assertion or guard on existing runtime logic, so no page behavior should differ. Spot-checking any analytics page (e.g. `/pools`) should render exactly as before.

## Risks / Breaking Changes

- All changes are in `apps/balancer-analytics` only — no shared `packages/lib` code touched, so the Balancer and Beets frontends are unaffected
- Non-null assertions rely on invariants: multicall results indexed only after a status guard, tuple positions guarded by length checks, and test fixtures asserted against a preceding `toHaveLength`

## Other Notes

- This is a preparatory migration PR, not activation of the rule — `noUncheckedIndexedAccess` remains disabled in the workspace tsconfig until all workspaces are clean