### PR TITLE
fix(test): force Shanghai hardfork on Polygon anvil fork

### DIFF
--- a/packages/test/anvil/anvil-global-setup.ts
+++ b/packages/test/anvil/anvil-global-setup.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url'
 
 import { ANVIL_NETWORKS, getForkUrl } from './anvil-setup'
 import { testChains } from './testWagmiConfig'
+import { polygon } from 'viem/chains'
 
 const currentDir = dirname(fileURLToPath(import.meta.url))
 
@@ -71,6 +72,11 @@ export async function setup() {
         forkUrl,
         forkBlockNumber: ANVIL_NETWORKS[chain.id].forkBlockNumber,
         mnemonic: process.env.TEST_ACCOUNT_MNEMONIC,
+        // anvil >= 1.8.0 fails every eth_call on Polygon forks with
+        // "Excess blob gas not set" (Polygon headers have no excessBlobGas
+        // field). Pinning the EVM spec below Cancun avoids the blob-gas
+        // code path. See https://github.com/balancer/frontend-monorepo/issues/2717
+        ...(chain.id === polygon.id ? { hardfork: 'Shanghai' as const } : {}),
       }),
     })
 


### PR DESCRIPTION
## What

- Added `hardfork: 'Shanghai'` to the Polygon anvil instance in `packages/test/anvil/anvil-global-setup.ts` (prool passes it through as `--hardfork Shanghai`). All other chains are unchanged.

## Why

The `Integration-Test` job has been failing consistently since Aug 27 ~12:40 UTC with `ContractFunctionExecutionError: Invalid parameters were provided to the RPC method. Details: Excess blob gas not set.` on the Polygon anvil proxy (port 8745), breaking the gyro add-liquidity and mixed mainnet/polygon multicall integration specs.

`checks.yml` installs foundry with `version: stable` (no pin). Foundry 1.8.0 was released Aug 26 and CI floated to it between runs — the last green run (33069996809, Aug 27 12:01) was on 1.7.1, the first red run (33073101823, Aug 27 12:41) was on 1.8.0, with identical failures across unrelated branch commits.

Root cause, reproduced locally against anvil 1.8.0: Polygon (Bor) block headers carry no `excessBlobGas` field, but anvil 1.8.0's post-Prague EVM spec requires it when building the env for `eth_call`. Every `eth_call` on a Polygon fork fails with `-32602: Excess blob gas not set` — not just the multicall3 → POL precompile (`0x...1010`) path; a plain WPOL `balanceOf` fails too. It reproduces on both the latest fork and the pinned `forkBlockNumber: 67867894n`, so the block number is irrelevant. Forcing the EVM spec below Cancun avoids the blob-gas code path entirely: `--hardfork cancun` still fails, `--hardfork Shanghai` makes all calls succeed.

Fixes #2717

## Test Steps

- [ ] Requires foundry >= 1.8.0 locally (`anvil --version`) — that's the version that exhibits the bug
- [ ] `pnpm test:integration` — Polygon-backed specs (e.g. `ProportionalAddLiquidity.handler.integration.spec.ts` gyro cases, `useMulticall.integration.spec.ts`) should pass instead of failing with `Excess blob gas not set`
- [ ] Sanity check without the fix: `anvil --fork-url https://polygon.drpc.org --fork-block-number 67867894` then `cast call 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270 "balanceOf(address)(uint256)" 0x625Ac6ECB5FE349398368e468cA037E3cC19592A` → `Excess blob gas not set`; same command with `--hardfork Shanghai` appended → returns a balance

## Risks / Breaking Changes

- Test-infra only — no runtime code touched, no impact on either app via `NEXT_PUBLIC_PROJECT_ID`.
- The Polygon fork now runs under the Shanghai spec: opcodes/behavior introduced in Cancun or later (blobs, `TSTORE`/`TLOAD`, `MCOPY`, etc.) are unavailable in Polygon integration tests. No current test uses them, but a future test that needs them would need this revisited (by then anvil should have fixed the header validation for Bor chains).

## Other Notes

- Deliberately did **not** pin the foundry version in `.github/workflows/checks.yml` — the hardfork flag fixes the failure on 1.8.0 while letting `stable` keep floating. If a future foundry release breaks another chain's fork, pinning is the fallback lever.