### PR TITLE
chore(ts): activate noUncheckedIndexedAccess monorepo-wide

### DIFF
--- a/packages/e2e-tests/helpers/create-lbp.helpers.ts
+++ b/packages/e2e-tests/helpers/create-lbp.helpers.ts
@@ -12,7 +12,7 @@ export type LbpConfig = {
   }
 }
 
-export const LBP_CONFIGS: LbpConfig[] = [
+export const LBP_CONFIGS: [LbpConfig, ...LbpConfig[]] = [
   {
     saleType: 'seedless',
     saleToken: {
@@ -37,7 +37,11 @@ export const LBP_CONFIGS: LbpConfig[] = [
 ]
 
 export const BASE_URL = 'http://localhost:3000/lbp/create'
-export const stepUrl = (index: number) => `${BASE_URL}/${LBP_FORM_STEPS[index].id}`
+export const stepUrl = (index: number) => {
+  const step = LBP_FORM_STEPS[index]
+  if (!step) throw new Error(`Missing LBP form step at index ${index}`)
+  return `${BASE_URL}/${step.id}`
+}
 
 export async function mockCreateLbpMetadata(page: Page) {
   await page.route('**/graphql', async route => {

--- a/packages/e2e-tests/helpers/create-pool.helpers.ts
+++ b/packages/e2e-tests/helpers/create-pool.helpers.ts
@@ -10,15 +10,16 @@ import { POOL_CREATION_FORM_STEPS } from '@repo/lib/modules/pool/actions/create/
 import { POOL_TYPES } from '@repo/lib/modules/pool/actions/create/constants'
 import { PoolType } from '@balancer/sdk'
 import { isPoolCreatorEnabled } from '@repo/lib/modules/pool/actions/create/helpers'
+import { SupportedPoolTypes } from '@repo/lib/modules/pool/actions/create/types'
 
 const BASE_URL = 'http://localhost:3000/create'
 
 export type PoolCreationConfig = {
-  type: PoolType
+  type: SupportedPoolTypes
   tokens: { symbol: string; amount: string | undefined }[]
 }
 
-export const POOL_CREATION_CONFIGS: PoolCreationConfig[] = [
+export const POOL_CREATION_CONFIGS: [PoolCreationConfig, ...PoolCreationConfig[]] = [
   {
     type: PoolType.Stable,
     tokens: [
@@ -64,13 +65,19 @@ export const POOL_CREATION_CONFIGS: PoolCreationConfig[] = [
   },
 ]
 
+function stepUrl(index: number) {
+  const step = POOL_CREATION_FORM_STEPS[index]
+  if (!step) throw new Error(`Missing pool creation form step at index ${index}`)
+  return `${BASE_URL}/${step.id}`
+}
+
 export class CreatePoolPage {
   readonly urls = {
     base: BASE_URL,
-    type: `${BASE_URL}/${POOL_CREATION_FORM_STEPS[0].id}`,
-    tokens: `${BASE_URL}/${POOL_CREATION_FORM_STEPS[1].id}`,
-    details: `${BASE_URL}/${POOL_CREATION_FORM_STEPS[2].id}`,
-    fund: `${BASE_URL}/${POOL_CREATION_FORM_STEPS[3].id}`,
+    type: stepUrl(0),
+    tokens: stepUrl(1),
+    details: stepUrl(2),
+    fund: stepUrl(3),
     buildCow: `${BASE_URL}?protocol=cow`,
   }
 
@@ -121,20 +128,19 @@ export class CreatePoolPage {
     await this.page.getByText(network).click()
   }
 
-  async choosePoolType(poolType: PoolType) {
+  async choosePoolType(poolType: SupportedPoolTypes) {
     await clickRadio(this.page, 'Choose a pool type', POOL_TYPES[poolType].label)
   }
 
   async fillTokenAmounts() {
     const shouldOnlyFillOneAmount = this.isAutoRange || this.isGyroEclp
+    const tokens = shouldOnlyFillOneAmount ? this.config.tokens.slice(0, 1) : this.config.tokens
 
-    if (shouldOnlyFillOneAmount) {
-      await this.page.getByLabel('Token 1').fill(this.config.tokens[0].amount)
-    } else {
-      for (let i = 0; i < this.config.tokens.length; i++) {
-        const tokenAmount = this.config.tokens[i].amount
-        await this.page.getByLabel(`Token ${i + 1}`).fill(tokenAmount)
+    for (const [index, token] of tokens.entries()) {
+      if (token.amount === undefined) {
+        throw new Error(`Missing amount in the pool creation config for Token ${index + 1}`)
       }
+      await this.page.getByLabel(`Token ${index + 1}`).fill(token.amount)
     }
   }
 

--- a/packages/e2e-tests/helpers/user.helpers.ts
+++ b/packages/e2e-tests/helpers/user.helpers.ts
@@ -37,6 +37,7 @@ export async function setSliderPercent(page: Page, percent: number, scope?: Loca
   const root = scope ?? page
   const slider = root.locator('.chakra-slider')
   const box = await slider.boundingBox()
+  if (!box) throw new Error('Slider is not visible, cannot calculate click position')
   await slider.click({
     position: { x: (box.width * percent) / 100, y: box.height / 2 },
   })

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "playwright:install": "playwright install --with-deps",
+    "typecheck": "tsc --project tsconfig.json --noEmit --incremental",
     "playwright:install:chromium": "playwright install --with-deps chromium",
     "test:e2e:build:bal": "NEXT_PUBLIC_PROJECT_ID=balancer start-server-and-test 'cd ../../ && pnpm start --filter frontend-v3' 'http://localhost:3000' 'pnpm exec playwright test tests/build/balancer'",
     "test:e2e:build:ui:bal": "NEXT_PUBLIC_PROJECT_ID=balancer pnpm exec playwright test tests/build/balancer --ui",

--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -1,9 +1,18 @@
 {
+  "extends": "@repo/typescript-config/base.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "module": "es2022",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["node"],
+    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
     "paths": {
       "@/*": ["./*"],
       "@repo/*": ["../../packages/*"]
     }
-  }
+  },
+  "include": ["**/*.ts", "../../packages/lib/global.d.ts"],
+  "exclude": ["node_modules"]
 }

--- a/packages/lib/modules/pool/PoolDetail/PoolInfo/PoolRisks/usePoolRisks.spec.ts
+++ b/packages/lib/modules/pool/PoolDetail/PoolInfo/PoolRisks/usePoolRisks.spec.ts
@@ -7,7 +7,7 @@ describe('getPoolRisks', () => {
   it('includes Oracle risk when a rate provider has the market-rate warning', () => {
     const pool = getApiPoolMock(sDAIWeighted) as GqlPoolElement
 
-    pool.poolTokens[0].priceRateProviderData = {
+    pool.poolTokens[0]!.priceRateProviderData = {
       __typename: 'GqlPriceRateProviderData',
       address: '0x0000000000000000000000000000000000000001',
       name: 'MarketRateProvider',

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -11,7 +11,7 @@
     "module": "NodeNext",
     "moduleDetection": "force",
     "moduleResolution": "node",
-    "noUncheckedIndexedAccess": false,
+    "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,

--- a/turbo.json
+++ b/turbo.json
@@ -111,6 +111,8 @@
         "^transit"
       ],
       "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../packages/lib/global.d.ts",
         "shared/services/api/generated/**"
       ],
       "outputs": [


### PR DESCRIPTION
## What

- Extended `packages/e2e-tests/tsconfig.json` from `@repo/typescript-config/base.json` (with `module`/`moduleResolution`/`jsx`/`noEmit`/`types` overrides for Playwright) and included `packages/lib/global.d.ts` so the viem `formatUnits` augmentation applies to lib sources pulled in there.
- Added a `typecheck` script to `packages/e2e-tests` and widened the turbo `typecheck` task inputs to `$TURBO_DEFAULT$` + `global.d.ts`, so the task no longer hashes only `generated/**`.
- Fixed all `noUncheckedIndexedAccess` errors in the e2e helpers: non-empty tuple config arrays, guarded form-step lookups, `SupportedPoolTypes` narrowing, explicit throws for missing amounts / bounding boxes.
- Fixed the last `@repo/lib` error in `usePoolRisks.spec.ts` (non-null fixture token access).
- Activated `noUncheckedIndexedAccess: true` in `packages/typescript-config/base.json`.

## Why

Final PR of the #1028 migration. Every workspace that inherits the shared tsconfig was made clean across the preparatory PRs; `packages/e2e-tests` was the one gap — its tsconfig had no `extends`, so it silently inherited none of the shared settings, and it had no `typecheck` script, so turbo never ran `tsc` there at all. With that closed, the option is flipped on monorepo-wide per step 9 of the issue workflow.

## Test Steps

- [ ] `pnpm typecheck` — 7/7 tasks pass, including the new `e2e-tests:typecheck`.
- [ ] `pnpm --filter e2e-tests exec tsc --project tsconfig.json --noEmit --incremental false --noUncheckedIndexedAccess` — exit 0.
- [ ] `pnpm --filter @repo/lib exec tsc --project tsconfig.json --noEmit --incremental false --noUncheckedIndexedAccess` — exit 0.
- [ ] `pnpm --filter @repo/lib exec vitest run modules/pool/PoolDetail/PoolInfo/PoolRisks/usePoolRisks.spec.ts` — 2/2 pass.
- [ ] `pnpm --filter e2e-tests exec playwright test --list` — 44 tests in 22 files still collected (guards only fire on broken fixtures/configs, not in normal runs).
- No manual UI surface: only test helpers and compiler config change. The e2e helpers touched (`create-pool`, `create-lbp`, slider) are exercised by the fork-based `test:e2e:dev:bal:2` suite if a reviewer wants runtime confirmation.

## Risks / Breaking Changes

- `packages/typescript-config/base.json` affects **all** workspaces in both apps (Balancer + Beets) and `balancer-analytics`: any future code with unchecked indexed access fails typecheck. Intended.
- e2e helper failures now throw descriptive errors (`Missing amount in the pool creation config…`, `Slider is not visible…`) instead of passing `undefined`/dereferencing `null` — a Playwright failure message changes shape, behavior on valid configs is identical.
- `PoolCreationConfig.type` narrowed from `PoolType` to `SupportedPoolTypes`: a config using an unsupported pool type is now a compile error rather than a runtime `undefined` lookup.
- `packages/lib` change is spec-only; no runtime code touched.

## Other Notes

- `turbo.json` is not prettier-formatted at HEAD; the two added input lines match the file's existing style rather than reformatting it.
- `packages/e2e-tests` still has no `lint` script (pre-existing); only typecheck coverage was added here.

---

Closes #1028
