### PR TITLE
chore(deps): update @balancer/sdk to 6.2.0 and viem to 2.56.0

### DIFF
--- a/apps/balancer-analytics/package.json
+++ b/apps/balancer-analytics/package.json
@@ -39,7 +39,7 @@
     "p-limit": "7.3.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "viem": "2.51.3",
+    "viem": "2.56.0",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/apps/beets-frontend-v3/lib/modules/loops/LoopsProvider.tsx
+++ b/apps/beets-frontend-v3/lib/modules/loops/LoopsProvider.tsx
@@ -10,8 +10,8 @@ import { LABELS } from '@repo/lib/shared/labels'
 import { isDisabledWithReason } from '@repo/lib/shared/utils/functions/isDisabledWithReason'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { useTokenInputsValidation } from '@repo/lib/modules/tokens/TokenInputsValidationProvider'
-import { bn } from '@repo/lib/shared/utils/numbers'
-import { formatUnits, parseUnits } from 'viem'
+import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'
+import { formatUnits } from 'viem'
 import { useLoopsGetRate } from './hooks/useLoopsGetRate'
 import { useLoopsWithdrawSteps } from './hooks/useLoopsWithdrawSteps'
 
@@ -81,7 +81,7 @@ export function useLoopsLogic() {
   function getAmountShares(amountAssets: string) {
     if (amountAssets === '') return '0'
 
-    const amountShares = (parseUnits(amountAssets, 18) * 10n ** 18n) / (rate || 1n)
+    const amountShares = (parseAmount(amountAssets, 18) * 10n ** 18n) / (rate || 1n)
 
     return formatUnits(amountShares, 18)
   }
@@ -89,7 +89,7 @@ export function useLoopsLogic() {
   function getAmountAssets(amountShares: string) {
     if (amountShares === '') return '0'
 
-    const amountAssets = (parseUnits(amountShares, 18) * (rate || 1n)) / 10n ** 18n
+    const amountAssets = (parseAmount(amountShares, 18) * (rate || 1n)) / 10n ** 18n
 
     return formatUnits(amountAssets, 18)
   }

--- a/apps/beets-frontend-v3/lib/modules/loops/components/LoopsDepositSummary.tsx
+++ b/apps/beets-frontend-v3/lib/modules/loops/components/LoopsDepositSummary.tsx
@@ -6,7 +6,8 @@ import { LoopsDepositReceiptResult } from '@repo/lib/modules/transactions/transa
 import { BeetsTokenRow } from '../../../components/shared/BeetsTokenRow'
 import { useLoops } from '../LoopsProvider'
 import { useLoopsGetConvertToShares } from '../hooks/useLoopsGetConvertToShares'
-import { formatUnits, parseUnits } from 'viem'
+import { formatUnits } from 'viem'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export function LoopsDepositSummary({
   isLoading: isLoadingReceipt,
@@ -24,7 +25,7 @@ export function LoopsDepositSummary({
   } = useLoops()
 
   const { sharesAmount, isLoading: isLoadingSharesAmount } = useLoopsGetConvertToShares(
-    amountAssets && nativeAsset?.decimals ? parseUnits(amountAssets, nativeAsset.decimals) : 0n,
+    amountAssets && nativeAsset?.decimals ? parseAmount(amountAssets, nativeAsset.decimals) : 0n,
     chain
   )
 

--- a/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsDepositStep.tsx
+++ b/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsDepositStep.tsx
@@ -9,10 +9,10 @@ import {
 import { useState } from 'react'
 import { ManagedTransactionInput } from '@repo/lib/modules/web3/contracts/useManagedTransaction'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
-import { parseUnits } from 'viem'
+
 import { BPT_DECIMALS } from '@repo/lib/modules/pool/pool.constants'
 import { noop } from 'lodash'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'
 import type { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { useTokenBalances } from '@repo/lib/modules/tokens/TokenBalancesProvider'
 import { isTransactionSuccess } from '@repo/lib/modules/transactions/transaction-steps/transaction.helper'
@@ -37,7 +37,7 @@ export function useLoopsDepositStep(humanAmount: string, chain: GqlChain, enable
     contractAddress: getNetworkConfig(chain).contracts.beets?.magpieLoopedSonicRouter || '',
     functionName: 'deposit',
     args: [],
-    value: parseUnits(humanAmount, BPT_DECIMALS),
+    value: parseAmount(humanAmount, BPT_DECIMALS),
     enabled: humanAmount !== '' && bn(humanAmount).gte(0) && isConnected && enabled,
     onTransactionChange: setTransaction,
   }

--- a/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsDepositStep.tsx
+++ b/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsDepositStep.tsx
@@ -9,7 +9,6 @@ import {
 import { useState } from 'react'
 import { ManagedTransactionInput } from '@repo/lib/modules/web3/contracts/useManagedTransaction'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
-
 import { BPT_DECIMALS } from '@repo/lib/modules/pool/pool.constants'
 import { noop } from 'lodash'
 import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'

--- a/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsGetCollateralAndDebtForShares.tsx
+++ b/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsGetCollateralAndDebtForShares.tsx
@@ -4,7 +4,7 @@ import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { useReadContract } from '@repo/lib/shared/utils/wagmi'
 import { loopedSonicVaultAbi } from '@repo/lib/modules/web3/contracts/abi/beets/generated'
 import type { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
-import { parseUnits } from 'viem'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export function useLoopsGetCollateralAndDebtForShares(sharesAmount: string, chain: GqlChain) {
   const { isConnected } = useUserAccount()
@@ -13,7 +13,7 @@ export function useLoopsGetCollateralAndDebtForShares(sharesAmount: string, chai
   const { shouldChangeNetwork } = useChainSwitch(chainId)
   const config = getNetworkConfig(chainId)
 
-  const amountShares = sharesAmount ? BigInt(parseUnits(sharesAmount, 18).toString()) : 0n
+  const amountShares = sharesAmount ? parseAmount(sharesAmount, 18) : 0n
 
   const query = useReadContract({
     chainId,

--- a/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsWithdrawStep.tsx
+++ b/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsWithdrawStep.tsx
@@ -9,7 +9,6 @@ import {
 import { useState } from 'react'
 import { ManagedTransactionInput } from '@repo/lib/modules/web3/contracts/useManagedTransaction'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
-
 import { BPT_DECIMALS } from '@repo/lib/modules/pool/pool.constants'
 import { noop } from 'lodash'
 import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'

--- a/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsWithdrawStep.tsx
+++ b/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsWithdrawStep.tsx
@@ -9,10 +9,10 @@ import {
 import { useState } from 'react'
 import { ManagedTransactionInput } from '@repo/lib/modules/web3/contracts/useManagedTransaction'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
-import { parseUnits } from 'viem'
+
 import { BPT_DECIMALS } from '@repo/lib/modules/pool/pool.constants'
 import { noop } from 'lodash'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'
 import type { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { useTokenBalances } from '@repo/lib/modules/tokens/TokenBalancesProvider'
 import { isTransactionSuccess } from '@repo/lib/modules/transactions/transaction-steps/transaction.helper'
@@ -47,7 +47,7 @@ export function useLoopsWithdrawStep(amountShares: string, chain: GqlChain, enab
     contractId: 'beets.loopedSonicRouter',
     contractAddress: getNetworkConfig(chain).contracts.beets?.magpieLoopedSonicRouter || '',
     functionName: 'withdrawWithFlashLoan',
-    args: [parseUnits(amountShares, BPT_DECIMALS), minWethAmountOut, convertLstToWethData || '0x'],
+    args: [parseAmount(amountShares, BPT_DECIMALS), minWethAmountOut, convertLstToWethData || '0x'],
     enabled:
       amountShares !== '' &&
       bn(amountShares).gt(0) &&

--- a/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsWithdrawSteps.tsx
+++ b/apps/beets-frontend-v3/lib/modules/loops/hooks/useLoopsWithdrawSteps.tsx
@@ -1,9 +1,10 @@
 import { useTokenApprovalSteps } from '@repo/lib/modules/tokens/approvals/useTokenApprovalSteps'
 import { useLoopsWithdrawStep } from './useLoopsWithdrawStep'
-import { Address, parseUnits } from 'viem'
+import { Address } from 'viem'
 import type { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { ApiToken } from '@repo/lib/modules/tokens/token.types'
 import { getNetworkConfig } from '@repo/lib/config/app.config'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export function useLoopsWithdrawSteps({
   amountShares,
@@ -27,7 +28,7 @@ export function useLoopsWithdrawSteps({
       approvalAmounts: [
         {
           address: loopedAsset?.address as Address,
-          rawAmount: parseUnits(amountShares, 18),
+          rawAmount: parseAmount(amountShares, 18),
         },
       ],
       actionType: 'Withdrawing',

--- a/apps/beets-frontend-v3/lib/modules/lst/LstProvider.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/LstProvider.tsx
@@ -10,13 +10,13 @@ import sonicNetworkConfig from '@repo/lib/config/networks/sonic'
 import { useLstUnstakeStep } from './hooks/useLstUnstakeStep'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { LABELS } from '@repo/lib/shared/labels'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'
 import { isDisabledWithReason } from '@repo/lib/shared/utils/functions/isDisabledWithReason'
 import { useTokens } from '@repo/lib/modules/tokens/TokensProvider'
 import { PaginationState } from '@repo/lib/shared/components/pagination/pagination.types'
 import { useLstWithdrawStep } from './hooks/useLstWithdrawStep'
 import { useTokenInputsValidation } from '@repo/lib/modules/tokens/TokenInputsValidationProvider'
-import { formatUnits, parseUnits } from 'viem'
+import { formatUnits } from 'viem'
 import { useGetRate } from './hooks/useGetRate'
 
 const CHAIN = GqlChainValues.Sonic
@@ -109,7 +109,7 @@ export function useLstLogic() {
   function getAmountShares(amountAssets: string) {
     if (amountAssets === '') return '0'
 
-    const amountShares = (parseUnits(amountAssets, 18) * 10n ** 18n) / (rate || 1n)
+    const amountShares = (parseAmount(amountAssets, 18) * 10n ** 18n) / (rate || 1n)
 
     return formatUnits(amountShares, 18)
   }
@@ -117,7 +117,7 @@ export function useLstLogic() {
   function getAmountAssets(amountShares: string) {
     if (amountShares === '') return '0'
 
-    const amountAssets = (parseUnits(amountShares, 18) * (rate || 1n)) / 10n ** 18n
+    const amountAssets = (parseAmount(amountShares, 18) * (rate || 1n)) / 10n ** 18n
 
     return formatUnits(amountAssets, 18)
   }

--- a/apps/beets-frontend-v3/lib/modules/lst/components/LstStakeSummary.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/components/LstStakeSummary.tsx
@@ -6,7 +6,8 @@ import { useLst } from '../LstProvider'
 import { LstStakeReceiptResult } from '@repo/lib/modules/transactions/transaction-steps/receipts/receipt.hooks'
 import { BeetsTokenRow } from '../../../components/shared/BeetsTokenRow'
 import { useGetConvertToShares } from '../hooks/useGetConvertToShares'
-import { formatUnits, parseUnits } from 'viem'
+import { formatUnits } from 'viem'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export function LstStakeSummary({
   isLoading: isLoadingReceipt,
@@ -18,7 +19,7 @@ export function LstStakeSummary({
     useLst()
 
   const { sharesAmount, isLoading: isLoadingSharesAmount } = useGetConvertToShares(
-    parseUnits(amountAssets, 18),
+    parseAmount(amountAssets, 18),
     chain
   )
 

--- a/apps/beets-frontend-v3/lib/modules/lst/hooks/useGetUnstakeValidators.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/hooks/useGetUnstakeValidators.tsx
@@ -16,6 +16,18 @@ export interface ValidatorUnstakeData {
   unstakeAmountShares: bigint
 }
 
+// Amount fields hold transient states ('', '.', '-') and pasted junk that parseAmount rejects.
+// Neither is a real unstake, so return null and let callers skip the request instead of asking
+// the API for amount=0 or letting a parse error escape into render.
+function parseSharesAmount(sharesAmount: string): bigint | null {
+  try {
+    const amountScaled = parseAmount(sharesAmount, 18)
+    return amountScaled > 0n ? amountScaled : null
+  } catch {
+    return null
+  }
+}
+
 export function useGetUnstakeValidators(
   sharesAmount: string,
   chain: GqlChain,
@@ -23,14 +35,15 @@ export function useGetUnstakeValidators(
 ) {
   const { chooseValidatorsForUnstakeAmount } = useGetAmountDelegatedPerValidator(chain)
 
+  const amountScaled = parseSharesAmount(sharesAmount)
+
   const queryResult = useQuery({
     queryKey: ['unstake-validators', sharesAmount, chain],
     queryFn: async () => {
-      if (!sharesAmount) {
+      if (amountScaled === null) {
         return []
       }
 
-      const amountScaled = parseAmount(sharesAmount, 18)
       const apiUrl = `https://sts-helper.beets-ftm-node.com/api/unstake-recommendation?amount=${amountScaled.toString()}`
       const response = await fetch(apiUrl)
 
@@ -49,7 +62,7 @@ export function useGetUnstakeValidators(
         unstakeAmountShares: item.withdrawalAmount,
       }))
     },
-    enabled: !!sharesAmount && unstakeEnabled,
+    enabled: amountScaled !== null && unstakeEnabled,
     staleTime: minutesToMilliseconds(5),
     retry: 1,
   })
@@ -58,8 +71,7 @@ export function useGetUnstakeValidators(
   const validators = queryResult.data ?? []
 
   // If query failed and we have no data, use fallback
-  if (queryResult.isError && validators.length === 0 && sharesAmount && unstakeEnabled) {
-    const amountScaled = parseAmount(sharesAmount, 18)
+  if (queryResult.isError && validators.length === 0 && amountScaled !== null && unstakeEnabled) {
     const fallbackValidators = chooseValidatorsForUnstakeAmount(amountScaled)
     return {
       validators: fallbackValidators,

--- a/apps/beets-frontend-v3/lib/modules/lst/hooks/useGetUnstakeValidators.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/hooks/useGetUnstakeValidators.tsx
@@ -2,7 +2,7 @@ import { useGetAmountDelegatedPerValidator } from '@/lib/modules/lst/hooks/useGe
 import type { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { useQuery } from '@tanstack/react-query'
 import { minutesToMilliseconds } from 'date-fns'
-import { parseUnits } from 'viem'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 interface ApiValidatorResponse {
   data: Array<{
@@ -30,7 +30,7 @@ export function useGetUnstakeValidators(
         return []
       }
 
-      const amountScaled = parseUnits(sharesAmount, 18)
+      const amountScaled = parseAmount(sharesAmount, 18)
       const apiUrl = `https://sts-helper.beets-ftm-node.com/api/unstake-recommendation?amount=${amountScaled.toString()}`
       const response = await fetch(apiUrl)
 
@@ -59,7 +59,7 @@ export function useGetUnstakeValidators(
 
   // If query failed and we have no data, use fallback
   if (queryResult.isError && validators.length === 0 && sharesAmount && unstakeEnabled) {
-    const amountScaled = parseUnits(sharesAmount, 18)
+    const amountScaled = parseAmount(sharesAmount, 18)
     const fallbackValidators = chooseValidatorsForUnstakeAmount(amountScaled)
     return {
       validators: fallbackValidators,

--- a/apps/beets-frontend-v3/lib/modules/lst/hooks/useLstStakeStep.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/hooks/useLstStakeStep.tsx
@@ -11,7 +11,6 @@ import {
 import { useState } from 'react'
 import { ManagedTransactionInput } from '@repo/lib/modules/web3/contracts/useManagedTransaction'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
-
 import { BPT_DECIMALS } from '@repo/lib/modules/pool/pool.constants'
 import { noop } from 'lodash'
 import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'

--- a/apps/beets-frontend-v3/lib/modules/lst/hooks/useLstStakeStep.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/hooks/useLstStakeStep.tsx
@@ -11,10 +11,10 @@ import {
 import { useState } from 'react'
 import { ManagedTransactionInput } from '@repo/lib/modules/web3/contracts/useManagedTransaction'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
-import { parseUnits } from 'viem'
+
 import { BPT_DECIMALS } from '@repo/lib/modules/pool/pool.constants'
 import { noop } from 'lodash'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'
 import type { GqlChain } from '@repo/lib/shared/services/api/generated/graphql'
 import { useTokenBalances } from '@repo/lib/modules/tokens/TokenBalancesProvider'
 import { isTransactionSuccess } from '@repo/lib/modules/transactions/transaction-steps/transaction.helper'
@@ -39,7 +39,7 @@ export function useLstStakeStep(humanAmount: string, chain: GqlChain, enabled: b
     contractAddress: getNetworkConfig(chain).contracts.beets?.lstStakingProxy || '',
     functionName: 'deposit',
     args: [],
-    value: parseUnits(humanAmount, BPT_DECIMALS),
+    value: parseAmount(humanAmount, BPT_DECIMALS),
     enabled: humanAmount !== '' && bn(humanAmount).gte(0.01) && isConnected && enabled,
     onTransactionChange: setTransaction,
   }

--- a/apps/beets-frontend-v3/lib/modules/lst/hooks/useLstUnstakeStep.tsx
+++ b/apps/beets-frontend-v3/lib/modules/lst/hooks/useLstUnstakeStep.tsx
@@ -61,7 +61,7 @@ export function useLstUnstakeStep(
       validators.map(validator => BigInt(validator.validatorId)),
       validators.map(validator => validator.unstakeAmountShares),
     ],
-    enabled: isConnected && !!sharesAmount && enabled,
+    enabled: isConnected && !!sharesAmount && validators.length > 0 && enabled,
     onTransactionChange: setTransaction,
   }
 

--- a/apps/beets-frontend-v3/package.json
+++ b/apps/beets-frontend-v3/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@apollo/client": "catalog:",
-    "@balancer/sdk": "6.1.1",
+    "@balancer/sdk": "6.2.0",
     "@chakra-ui/hooks": "2.4.2",
     "@chakra-ui/react": "2.10.10",
     "@chakra-ui/theme-tools": "2.2.6",
@@ -44,7 +44,7 @@
     "real-require": "0.1.0",
     "thread-stream": "0.15.2",
     "tinycolor2": "^1.6.0",
-    "viem": "2.51.3"
+    "viem": "2.56.0"
   },
   "devDependencies": {
     "@chakra-ui/cli": "2.5.8",

--- a/apps/frontend-v3/lib/vebal/lock/steps/useBuildLockSteps.tsx
+++ b/apps/frontend-v3/lib/vebal/lock/steps/useBuildLockSteps.tsx
@@ -18,7 +18,9 @@ export function useBuildLockSteps({ lockDuration, totalAmount }: UseBuildLockSte
 
   const { steps } = useLockSteps({
     lockAmount: {
-      rawAmount: parseUnits(totalAmount.toString(), vebalBptToken.decimals),
+      // toFixed, not toString: BigNumber.toString() emits exponential notation outside
+      // 1e-7..1e21, which parseUnits rejects.
+      rawAmount: parseUnits(totalAmount.toFixed(), vebalBptToken.decimals),
       address: vebalBptToken.address as Address,
     },
     lockActionTypes,

--- a/apps/frontend-v3/package.json
+++ b/apps/frontend-v3/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@apollo/client": "catalog:",
-    "@balancer/sdk": "6.1.1",
+    "@balancer/sdk": "6.2.0",
     "@chakra-ui/clickable": "^2.1.0",
     "@chakra-ui/hooks": "2.4.2",
     "@chakra-ui/icons": "2.2.4",
@@ -55,7 +55,7 @@
     "thread-stream": "0.15.2",
     "tinycolor2": "^1.6.0",
     "usehooks-ts": "3.1.1",
-    "viem": "2.51.3"
+    "viem": "2.56.0"
   },
   "devDependencies": {
     "@chakra-ui/cli": "2.5.8",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@balancer/sdk": "6.1.1",
+    "@balancer/sdk": "6.2.0",
     "@playwright/test": "1.62.1",
     "@repo/lib": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/packages/lib/config/networks/monad.ts
+++ b/packages/lib/config/networks/monad.ts
@@ -18,8 +18,8 @@ const networkConfig: NetworkConfig = {
   chain: GqlChainValues.Monad,
   iconPath: '/images/chains/MONAD.svg',
   blockExplorer: {
-    baseUrl: monad.blockExplorers.monadscan.url,
-    name: monad.blockExplorers.monadscan.name,
+    baseUrl: monad.blockExplorers.default.url,
+    name: monad.blockExplorers.default.name,
   },
   tokens: {
     addresses: {

--- a/packages/lib/modules/lbp/useCreateLbpInput.ts
+++ b/packages/lib/modules/lbp/useCreateLbpInput.ts
@@ -3,7 +3,7 @@ import { getNetworkConfig } from '@repo/lib/config/app.config'
 import { useLbpWeights } from './useLbpWeights'
 import { useTokenMetadata } from '../tokens/useTokenMetadata'
 import { LBPParams, PoolType } from '@balancer/sdk'
-import { parseUnits, zeroAddress } from 'viem'
+import { zeroAddress } from 'viem'
 import { Address } from 'viem'
 import { useUserAccount } from '../web3/UserAccountProvider'
 import { DEFAULT_DECIMALS, PERCENTAGE_DECIMALS } from '../pool/actions/create/constants'
@@ -13,6 +13,7 @@ import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
 
 import { CreatePoolInput } from '@repo/lib/modules/pool/actions/create/types'
 import { dateTimeToUnixTimestampBigInt } from '@repo/lib/shared/utils/time'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export function useCreateLbpInput(): CreatePoolInput {
   const { saleStructureForm, projectInfoForm, isCollateralNativeAsset, isFixedSale, isSeedless } =
@@ -86,14 +87,14 @@ export function useCreateLbpInput(): CreatePoolInput {
   const lbpParams: LBPParams = {
     ...baseLbpProps,
     blockProjectTokenSwapsIn,
-    projectTokenStartWeight: parseUnits(`${projectTokenStartWeight}`, PERCENTAGE_DECIMALS),
-    reserveTokenStartWeight: parseUnits(`${reserveTokenStartWeight}`, PERCENTAGE_DECIMALS),
-    projectTokenEndWeight: parseUnits(`${projectTokenEndWeight}`, PERCENTAGE_DECIMALS),
-    reserveTokenEndWeight: parseUnits(`${reserveTokenEndWeight}`, PERCENTAGE_DECIMALS),
+    projectTokenStartWeight: parseAmount(`${projectTokenStartWeight}`, PERCENTAGE_DECIMALS),
+    reserveTokenStartWeight: parseAmount(`${reserveTokenStartWeight}`, PERCENTAGE_DECIMALS),
+    projectTokenEndWeight: parseAmount(`${projectTokenEndWeight}`, PERCENTAGE_DECIMALS),
+    reserveTokenEndWeight: parseAmount(`${reserveTokenEndWeight}`, PERCENTAGE_DECIMALS),
   }
 
   if (isSeedless) {
-    lbpParams.reserveTokenVirtualBalance = parseUnits(
+    lbpParams.reserveTokenVirtualBalance = parseAmount(
       collateralTokenAmount,
       reserveTokenDecimals || 0
     )
@@ -103,7 +104,7 @@ export function useCreateLbpInput(): CreatePoolInput {
     protocolVersion: 3 as const,
     symbol: `${launchTokenSymbol}-${reserveTokenSymbol}-LBP`,
     name: `${name} ${isFixedSale ? 'Fixed' : 'Dynamic'} Price Liquidity Bootstrapping Pool`,
-    swapFeePercentage: parseUnits(`${fee}`, PERCENTAGE_DECIMALS),
+    swapFeePercentage: parseAmount(`${fee}`, PERCENTAGE_DECIMALS),
     chainId,
     poolCreator: (poolCreator as Address) || zeroAddress,
   }
@@ -114,7 +115,7 @@ export function useCreateLbpInput(): CreatePoolInput {
       poolType: PoolType.LiquidityBootstrappingFixedPrice,
       fixedPriceLbpParams: {
         ...baseLbpProps,
-        projectTokenRate: parseUnits(`${launchTokenRate}`, DEFAULT_DECIMALS),
+        projectTokenRate: parseAmount(`${launchTokenRate}`, DEFAULT_DECIMALS),
       },
     }
   } else {

--- a/packages/lib/modules/lbp/useInitializeLbpInput.ts
+++ b/packages/lib/modules/lbp/useInitializeLbpInput.ts
@@ -1,4 +1,4 @@
-import { Address, parseUnits } from 'viem'
+import { Address } from 'viem'
 import { useTokenMetadata } from '@repo/lib/modules/tokens/useTokenMetadata'
 import { useLbpForm } from './LbpFormProvider'
 import { getNetworkConfig } from '@repo/lib/config/app.config'
@@ -6,6 +6,7 @@ import { getChainId } from '@repo/lib/config/app.config'
 import { type InitPoolInputAmount } from '@repo/lib/modules/pool/actions/create/types'
 import { useWatch } from 'react-hook-form'
 import { PROJECT_CONFIG } from '@repo/lib/config/getProjectConfig'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export function useInitializeLbpInput() {
   const { saleStructureForm, isCollateralNativeAsset, isFixedSale, isSeeded } = useLbpForm()
@@ -62,7 +63,7 @@ export function useInitializeLbpInput() {
   const launchTokenAmountIn: InitPoolInputAmount = {
     address: launchTokenAddress as Address,
     decimals: launchTokenDecimals,
-    rawAmount: parseUnits(saleTokenAmount, launchTokenDecimals),
+    rawAmount: parseAmount(saleTokenAmount, launchTokenDecimals),
     symbol: launchTokenSymbol,
   }
 
@@ -70,7 +71,7 @@ export function useInitializeLbpInput() {
     address: reserveTokenAddress as Address,
     decimals: reserveTokenDecimals,
     // sdk requires reserve token amount to be zero for fixed sale
-    rawAmount: isFixedSale ? 0n : parseUnits(collateralTokenAmount, reserveTokenDecimals),
+    rawAmount: isFixedSale ? 0n : parseAmount(collateralTokenAmount, reserveTokenDecimals),
     symbol: reserveTokenSymbol,
   }
 

--- a/packages/lib/modules/pool/actions/create/modal/useCreatePoolInput.ts
+++ b/packages/lib/modules/pool/actions/create/modal/useCreatePoolInput.ts
@@ -1,9 +1,9 @@
 import { usePoolCreationForm } from '../PoolCreationFormProvider'
 import { TokenType, CreatePoolV3BaseInput, PoolType } from '@balancer/sdk'
-import { parseUnits, zeroAddress } from 'viem'
+import { zeroAddress } from 'viem'
 import { PERCENTAGE_DECIMALS, DEFAULT_DECIMALS } from '../constants'
 import { getNetworkConfig, getGqlChain } from '@repo/lib/config/app.config'
-import { invertNumber } from '@repo/lib/shared/utils/numbers'
+import { invertNumber, parseAmount } from '@repo/lib/shared/utils/numbers'
 import { CreatePoolInput } from '../types'
 import { calculateRotationComponents } from '../steps/details/gyro.helpers'
 
@@ -42,7 +42,7 @@ export function useCreatePoolInput(chainId: number): CreatePoolInput {
     protocolVersion: 3 as const,
     name,
     symbol,
-    swapFeePercentage: parseUnits(swapFeePercentage, PERCENTAGE_DECIMALS),
+    swapFeePercentage: parseAmount(swapFeePercentage, PERCENTAGE_DECIMALS),
     swapFeeManager: swapFeeManager ? swapFeeManager : zeroAddress,
     pauseManager: pauseManager ? pauseManager : zeroAddress,
     enableDonation,
@@ -76,7 +76,7 @@ export function useCreatePoolInput(chainId: number): CreatePoolInput {
       poolCreator,
       tokens: baseInput.tokens.map((token, index) => ({
         ...token,
-        weight: parseUnits(poolTokens[index]?.weight ?? '50', PERCENTAGE_DECIMALS),
+        weight: parseAmount(poolTokens[index]?.weight ?? '50', PERCENTAGE_DECIMALS),
       })),
     }
   }
@@ -96,9 +96,9 @@ export function useCreatePoolInput(chainId: number): CreatePoolInput {
     const targetPrice = areTokensInOrder ? initialTargetPrice : invertNumber(initialTargetPrice)
 
     const priceParams = {
-      initialMinPrice: parseUnits(minPrice, DEFAULT_DECIMALS),
-      initialMaxPrice: parseUnits(maxPrice, DEFAULT_DECIMALS),
-      initialTargetPrice: parseUnits(targetPrice, DEFAULT_DECIMALS),
+      initialMinPrice: parseAmount(minPrice, DEFAULT_DECIMALS),
+      initialMaxPrice: parseAmount(maxPrice, DEFAULT_DECIMALS),
+      initialTargetPrice: parseAmount(targetPrice, DEFAULT_DECIMALS),
       // hardcoded prices to not include rate until new AutoRange deployments.
       // without rate means boosted must be priced in terms of underlying
       tokenAPriceIncludesRate: false,
@@ -109,8 +109,8 @@ export function useCreatePoolInput(chainId: number): CreatePoolInput {
       ...baseInput,
       poolType,
       priceParams,
-      priceShiftDailyRate: parseUnits(priceShiftDailyRate, PERCENTAGE_DECIMALS),
-      centerednessMargin: parseUnits(centerednessMargin, PERCENTAGE_DECIMALS),
+      priceShiftDailyRate: parseAmount(priceShiftDailyRate, PERCENTAGE_DECIMALS),
+      centerednessMargin: parseAmount(centerednessMargin, PERCENTAGE_DECIMALS),
     }
   }
 
@@ -120,11 +120,11 @@ export function useCreatePoolInput(chainId: number): CreatePoolInput {
 
     // The SDK's normalizeEclpParamsAndTokens handles token sorting and param inversion
     const eclpParams = {
-      alpha: parseUnits(alpha, DEFAULT_DECIMALS),
-      beta: parseUnits(beta, DEFAULT_DECIMALS),
-      s: parseUnits(s, DEFAULT_DECIMALS),
-      c: parseUnits(c, DEFAULT_DECIMALS),
-      lambda: parseUnits(lambda, DEFAULT_DECIMALS),
+      alpha: parseAmount(alpha, DEFAULT_DECIMALS),
+      beta: parseAmount(beta, DEFAULT_DECIMALS),
+      s: parseAmount(s, DEFAULT_DECIMALS),
+      c: parseAmount(c, DEFAULT_DECIMALS),
+      lambda: parseAmount(lambda, DEFAULT_DECIMALS),
     }
 
     return { ...baseInput, poolType, eclpParams }

--- a/packages/lib/modules/pool/actions/create/modal/useInitializePoolInput.ts
+++ b/packages/lib/modules/pool/actions/create/modal/useInitializePoolInput.ts
@@ -2,7 +2,6 @@ import {
   type InitPoolInputAmount,
   type ExtendedInitPoolInput,
 } from '@repo/lib/modules/pool/actions/create/types'
-
 import { usePoolCreationForm } from '../PoolCreationFormProvider'
 import { getNetworkConfig, getGqlChain } from '@repo/lib/config/app.config'
 import { useWatch } from 'react-hook-form'

--- a/packages/lib/modules/pool/actions/create/modal/useInitializePoolInput.ts
+++ b/packages/lib/modules/pool/actions/create/modal/useInitializePoolInput.ts
@@ -2,10 +2,11 @@ import {
   type InitPoolInputAmount,
   type ExtendedInitPoolInput,
 } from '@repo/lib/modules/pool/actions/create/types'
-import { parseUnits } from 'viem'
+
 import { usePoolCreationForm } from '../PoolCreationFormProvider'
 import { getNetworkConfig, getGqlChain } from '@repo/lib/config/app.config'
 import { useWatch } from 'react-hook-form'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export function useInitializePoolInput(chainId: number): ExtendedInitPoolInput {
   const { poolCreationForm } = usePoolCreationForm()
@@ -27,7 +28,7 @@ export function useInitializePoolInput(chainId: number): ExtendedInitPoolInput {
     if (!address) throw new Error('token address missing for amountsIn of pool creation')
     if (!decimals) throw new Error('token decimals missing for amountsIn of pool creation')
     if (!symbol) throw new Error('token symbol missing for amountsIn of pool creation')
-    const rawAmount = parseUnits(token.amount, decimals)
+    const rawAmount = parseAmount(token.amount, decimals)
     return {
       address: address === nativeAsset ? wNativeAsset : address,
       decimals,

--- a/packages/lib/modules/pool/actions/create/steps/details/useValidateEclpParams.ts
+++ b/packages/lib/modules/pool/actions/create/steps/details/useValidateEclpParams.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 import { GyroECLPMath } from '@balancer-labs/balancer-maths'
 import { computeDerivedEclpParams, PoolType } from '@balancer/sdk'
-
 import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { DEFAULT_DECIMALS } from '../../constants'
 import { useWatch } from 'react-hook-form'

--- a/packages/lib/modules/pool/actions/create/steps/details/useValidateEclpParams.ts
+++ b/packages/lib/modules/pool/actions/create/steps/details/useValidateEclpParams.ts
@@ -1,11 +1,12 @@
 import { useMemo } from 'react'
 import { GyroECLPMath } from '@balancer-labs/balancer-maths'
 import { computeDerivedEclpParams, PoolType } from '@balancer/sdk'
-import { parseUnits } from 'viem'
+
 import { usePoolCreationForm } from '../../PoolCreationFormProvider'
 import { DEFAULT_DECIMALS } from '../../constants'
 import { useWatch } from 'react-hook-form'
 import { calculateRotationComponents } from './gyro.helpers'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export function useValidateEclpParams() {
   const { eclpConfigForm, poolCreationForm } = usePoolCreationForm()
@@ -23,11 +24,11 @@ export function useValidateEclpParams() {
     if (!alpha || !beta || !c || !s || !lambda) return null
 
     const rawEclpParams = {
-      alpha: parseUnits(alpha, DEFAULT_DECIMALS),
-      beta: parseUnits(beta, DEFAULT_DECIMALS),
-      c: parseUnits(c, DEFAULT_DECIMALS),
-      s: parseUnits(s, DEFAULT_DECIMALS),
-      lambda: parseUnits(lambda, DEFAULT_DECIMALS),
+      alpha: parseAmount(alpha, DEFAULT_DECIMALS),
+      beta: parseAmount(beta, DEFAULT_DECIMALS),
+      c: parseAmount(c, DEFAULT_DECIMALS),
+      s: parseAmount(s, DEFAULT_DECIMALS),
+      lambda: parseAmount(lambda, DEFAULT_DECIMALS),
     }
 
     try {

--- a/packages/lib/modules/pool/actions/create/steps/fund/useAutoRangeInitAmounts.ts
+++ b/packages/lib/modules/pool/actions/create/steps/fund/useAutoRangeInitAmounts.ts
@@ -10,7 +10,9 @@ export const useAutoRangeInitAmounts = (
 ) => {
   const { address: tokenAddress, amount: tokenAmount, data } = token
   const tokenDecimals = data?.decimals
-  const rawAmount = parseAmount(tokenAmount!, tokenDecimals!)
+  // tokenAmount/tokenDecimals are undefined while the token metadata is loading; parseAmount
+  // would mask that as 0n, so short-circuit and let `enabled` gate the query.
+  const rawAmount = tokenAmount && tokenDecimals ? parseAmount(tokenAmount, tokenDecimals) : 0n
   const enabled = !!poolAddress && !!tokenAddress && !!tokenAmount && !!tokenDecimals && isAutoRange
 
   const { data: autoRangeInitAmounts } = useReadContract({

--- a/packages/lib/modules/pool/actions/create/steps/fund/useAutoRangeInitAmounts.ts
+++ b/packages/lib/modules/pool/actions/create/steps/fund/useAutoRangeInitAmounts.ts
@@ -1,6 +1,7 @@
-import { Address, parseAbi, parseUnits } from 'viem'
+import { Address, parseAbi } from 'viem'
 import { PoolCreationToken } from '../../types'
 import { useReadContract } from 'wagmi'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export const useAutoRangeInitAmounts = (
   isAutoRange: boolean,
@@ -9,7 +10,7 @@ export const useAutoRangeInitAmounts = (
 ) => {
   const { address: tokenAddress, amount: tokenAmount, data } = token
   const tokenDecimals = data?.decimals
-  const rawAmount = parseUnits(tokenAmount!, tokenDecimals!)
+  const rawAmount = parseAmount(tokenAmount!, tokenDecimals!)
   const enabled = !!poolAddress && !!tokenAddress && !!tokenAmount && !!tokenDecimals && isAutoRange
 
   const { data: autoRangeInitAmounts } = useReadContract({

--- a/packages/lib/modules/pool/actions/create/steps/fund/useAutoRangeInitAmounts.ts
+++ b/packages/lib/modules/pool/actions/create/steps/fund/useAutoRangeInitAmounts.ts
@@ -3,17 +3,29 @@ import { PoolCreationToken } from '../../types'
 import { useReadContract } from 'wagmi'
 import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
+// parseAmount returns 0n for the transient states an amount field holds while typing ('', '0.')
+// and throws on values a float can stringify to ('5e-8'). Neither is a seed amount, so report
+// null and let `enabled` skip the call instead of computing balances for zero or throwing during
+// render. Metadata still loading (no amount or decimals) is null for the same reason.
+function parseSeedAmount(amount: string | undefined, decimals: number | undefined): bigint | null {
+  if (!amount || decimals === undefined) return null
+
+  try {
+    const rawAmount = parseAmount(amount, decimals)
+    return rawAmount > 0n ? rawAmount : null
+  } catch {
+    return null
+  }
+}
+
 export const useAutoRangeInitAmounts = (
   isAutoRange: boolean,
   poolAddress: Address | undefined,
   token: PoolCreationToken
 ) => {
   const { address: tokenAddress, amount: tokenAmount, data } = token
-  const tokenDecimals = data?.decimals
-  // tokenAmount/tokenDecimals are undefined while the token metadata is loading; parseAmount
-  // would mask that as 0n, so short-circuit and let `enabled` gate the query.
-  const rawAmount = tokenAmount && tokenDecimals ? parseAmount(tokenAmount, tokenDecimals) : 0n
-  const enabled = !!poolAddress && !!tokenAddress && !!tokenAmount && !!tokenDecimals && isAutoRange
+  const rawAmount = parseSeedAmount(tokenAmount, data?.decimals)
+  const enabled = !!poolAddress && !!tokenAddress && rawAmount !== null && isAutoRange
 
   const { data: autoRangeInitAmounts } = useReadContract({
     address: poolAddress,
@@ -21,7 +33,8 @@ export const useAutoRangeInitAmounts = (
       'function computeInitialBalancesRaw(address, uint256) view returns (uint256[])',
     ]),
     functionName: 'computeInitialBalancesRaw',
-    args: [tokenAddress!, rawAmount],
+    // Only read while enabled, where rawAmount is always a positive bigint.
+    args: [tokenAddress!, rawAmount ?? 0n],
     query: { enabled },
   })
 

--- a/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -5,7 +5,7 @@ import ButtonGroup, {
   ButtonGroupOption,
 } from '@repo/lib/shared/components/btns/button-group/ButtonGroup'
 import { InputWithSlider } from '@repo/lib/shared/components/inputs/InputWithSlider/InputWithSlider'
-import { fNum } from '@repo/lib/shared/utils/numbers'
+import { fNum, parseAmount } from '@repo/lib/shared/utils/numbers'
 import {
   Box,
   Button,
@@ -33,7 +33,7 @@ import { requiresProportionalInput } from '../../LiquidityActionHelpers'
 import { PriceImpactAccordion } from '@repo/lib/modules/price-impact/PriceImpactAccordion'
 import { PoolActionsPriceImpactDetails } from '../../PoolActionsPriceImpactDetails'
 import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvider'
-import { parseUnits } from 'viem'
+
 import { RemoveSimulationError } from '@repo/lib/shared/components/errors/RemoveSimulationError'
 import { InfoIcon } from '@repo/lib/shared/components/icons/InfoIcon'
 import { SafeAppAlert } from '@repo/lib/shared/components/alerts/SafeAppAlert'
@@ -274,7 +274,7 @@ export function RemoveLiquidityForm() {
                   }
                   accordionPanelComponent={
                     <PoolActionsPriceImpactDetails
-                      bptAmount={BigInt(parseUnits(humanBptIn, 18))}
+                      bptAmount={parseAmount(humanBptIn, 18)}
                       isLoading={isFetching}
                       slippage={slippage}
                       totalUSDValue={totalUSDValue}

--- a/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/form/RemoveLiquidityForm.tsx
@@ -33,7 +33,6 @@ import { requiresProportionalInput } from '../../LiquidityActionHelpers'
 import { PriceImpactAccordion } from '@repo/lib/modules/price-impact/PriceImpactAccordion'
 import { PoolActionsPriceImpactDetails } from '../../PoolActionsPriceImpactDetails'
 import { usePriceImpact } from '@repo/lib/modules/price-impact/PriceImpactProvider'
-
 import { RemoveSimulationError } from '@repo/lib/shared/components/errors/RemoveSimulationError'
 import { InfoIcon } from '@repo/lib/shared/components/icons/InfoIcon'
 import { SafeAppAlert } from '@repo/lib/shared/components/alerts/SafeAppAlert'

--- a/packages/lib/modules/pool/actions/remove-liquidity/handlers/BaseProportionalRemoveLiquidity.handler.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/handlers/BaseProportionalRemoveLiquidity.handler.ts
@@ -6,7 +6,7 @@ import {
   RemoveLiquidityKind,
   RemoveLiquidityProportionalInput,
 } from '@balancer/sdk'
-import { Address, parseEther } from 'viem'
+import { Address } from 'viem'
 import { Pool } from '../../../pool.types'
 import { BPT_DECIMALS } from '../../../pool.constants'
 import { LiquidityActionHelpers } from '../../LiquidityActionHelpers'
@@ -17,6 +17,7 @@ import {
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
 import { TransactionConfig } from '@repo/lib/modules/web3/contracts/contract.types'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export abstract class BaseProportionalRemoveLiquidityHandler implements RemoveLiquidityHandler {
   protected helpers: LiquidityActionHelpers
@@ -52,7 +53,7 @@ export abstract class BaseProportionalRemoveLiquidityHandler implements RemoveLi
     userAddress: Address
   ): RemoveLiquidityProportionalInput {
     const bptIn: InputAmount = {
-      rawAmount: parseEther(humanBptIn),
+      rawAmount: parseAmount(humanBptIn, 18),
       decimals: BPT_DECIMALS,
       address: this.helpers.pool.address as Address,
     }

--- a/packages/lib/modules/pool/actions/remove-liquidity/handlers/BaseSingleTokenRemoveLiquidity.handler.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/handlers/BaseSingleTokenRemoveLiquidity.handler.ts
@@ -9,7 +9,7 @@ import {
   RemoveLiquidityKind,
   RemoveLiquiditySingleTokenExactInInput,
 } from '@balancer/sdk'
-import { Address, parseEther } from 'viem'
+import { Address } from 'viem'
 import { Pool } from '../../../pool.types'
 import { BPT_DECIMALS } from '../../../pool.constants'
 import { LiquidityActionHelpers, getSender, isEmptyHumanAmount } from '../../LiquidityActionHelpers'
@@ -20,6 +20,7 @@ import {
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
 import { TransactionConfig } from '@repo/lib/modules/web3/contracts/contract.types'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export abstract class BaseSingleTokenRemoveLiquidityHandler implements RemoveLiquidityHandler {
   protected helpers: LiquidityActionHelpers
@@ -75,7 +76,7 @@ export abstract class BaseSingleTokenRemoveLiquidityHandler implements RemoveLiq
     userAddress?: Address
   ): RemoveLiquiditySingleTokenExactInInput {
     const bptInInputAmount: InputAmount = {
-      rawAmount: parseEther(humanBptIn),
+      rawAmount: parseAmount(humanBptIn, 18),
       decimals: BPT_DECIMALS,
       address: this.helpers.pool.address as Address,
     }

--- a/packages/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidity.handler.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidity.handler.ts
@@ -7,7 +7,6 @@ import {
   RemoveLiquidityNestedQueryOutput,
   Slippage,
 } from '@balancer/sdk'
-
 import { Pool } from '../../../pool.types'
 import { LiquidityActionHelpers } from '../../LiquidityActionHelpers'
 import {

--- a/packages/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidity.handler.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidity.handler.ts
@@ -7,7 +7,7 @@ import {
   RemoveLiquidityNestedQueryOutput,
   Slippage,
 } from '@balancer/sdk'
-import { parseEther } from 'viem'
+
 import { Pool } from '../../../pool.types'
 import { LiquidityActionHelpers } from '../../LiquidityActionHelpers'
 import {
@@ -17,6 +17,7 @@ import {
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
 import { getRpcUrl } from '@repo/lib/modules/web3/transports'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export interface NestedProportionalQueryRemoveLiquidityOutput extends QueryRemoveLiquidityOutput {
   sdkQueryOutput: RemoveLiquidityNestedQueryOutput
@@ -83,7 +84,7 @@ export class NestedProportionalRemoveLiquidityHandler implements RemoveLiquidity
    */
   private constructSdkInput(humanBptIn: HumanAmount): RemoveLiquidityNestedProportionalInputV2 {
     const result: RemoveLiquidityNestedProportionalInputV2 = {
-      bptAmountIn: parseEther(humanBptIn),
+      bptAmountIn: parseAmount(humanBptIn, 18),
       chainId: this.helpers.chainId,
       rpcUrl: getRpcUrl(this.helpers.chainId),
     }

--- a/packages/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidityV3.handler.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/handlers/NestedProportionalRemoveLiquidityV3.handler.ts
@@ -9,7 +9,7 @@ import {
 } from '@balancer/sdk'
 import { TransactionConfig } from '@repo/lib/modules/web3/contracts/contract.types'
 import { getRpcUrl } from '@repo/lib/modules/web3/transports'
-import { Address, Hex, parseEther } from 'viem'
+import { Address, Hex } from 'viem'
 import { Pool } from '../../../pool.types'
 import { getSender, LiquidityActionHelpers } from '../../LiquidityActionHelpers'
 import {
@@ -18,6 +18,7 @@ import {
   QueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export interface NestedProportionalQueryRemoveLiquidityOutput extends QueryRemoveLiquidityOutput {
   sdkQueryOutput: RemoveLiquidityNestedQueryOutput
@@ -96,7 +97,7 @@ export class NestedProportionalRemoveLiquidityV3Handler implements RemoveLiquidi
     userAddress: Address
   ): RemoveLiquidityNestedProportionalInputV3 {
     const result: RemoveLiquidityNestedProportionalInputV3 = {
-      bptAmountIn: parseEther(humanBptIn),
+      bptAmountIn: parseAmount(humanBptIn, 18),
       chainId: this.helpers.chainId,
       rpcUrl: getRpcUrl(this.helpers.chainId),
       sender: getSender(userAddress),

--- a/packages/lib/modules/pool/actions/remove-liquidity/handlers/NestedSingleTokenRemoveLiquidityV2.handler.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/handlers/NestedSingleTokenRemoveLiquidityV2.handler.ts
@@ -9,7 +9,7 @@ import {
   PriceImpact,
   RemoveLiquidityNestedCallInputV2,
 } from '@balancer/sdk'
-import { Address, parseEther } from 'viem'
+import { Address } from 'viem'
 import { Pool } from '../../../pool.types'
 import { LiquidityActionHelpers } from '../../LiquidityActionHelpers'
 import {
@@ -19,6 +19,7 @@ import {
 } from '../remove-liquidity.types'
 import { RemoveLiquidityHandler } from './RemoveLiquidity.handler'
 import { getRpcUrl } from '@repo/lib/modules/web3/transports'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 export interface NestedSingleTokenQueryRemoveLiquidityOutput extends QueryRemoveLiquidityOutput {
   sdkQueryOutput: RemoveLiquidityNestedQueryOutput
@@ -104,7 +105,7 @@ export class NestedSingleTokenRemoveLiquidityV2Handler implements RemoveLiquidit
     tokenOut: Address
   ): RemoveLiquidityNestedSingleTokenInputV2 {
     const result: RemoveLiquidityNestedSingleTokenInputV2 = {
-      bptAmountIn: parseEther(humanBptIn),
+      bptAmountIn: parseAmount(humanBptIn, 18),
       tokenOut,
       chainId: this.helpers.chainId,
       rpcUrl: getRpcUrl(this.helpers.chainId),

--- a/packages/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
@@ -15,7 +15,6 @@ import {
   SdkQueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
 import { TransactionConfig } from '@repo/lib/modules/web3/contracts/contract.types'
-
 import { BPT_DECIMALS } from '../../../pool.constants'
 import { getSender, LiquidityActionHelpers } from '../../LiquidityActionHelpers'
 import { getRpcUrl } from '@repo/lib/modules/web3/transports'

--- a/packages/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
+++ b/packages/lib/modules/pool/actions/remove-liquidity/handlers/RecoveryRemoveLiquidity.handler.ts
@@ -15,10 +15,11 @@ import {
   SdkQueryRemoveLiquidityOutput,
 } from '../remove-liquidity.types'
 import { TransactionConfig } from '@repo/lib/modules/web3/contracts/contract.types'
-import { parseEther } from 'viem'
+
 import { BPT_DECIMALS } from '../../../pool.constants'
 import { getSender, LiquidityActionHelpers } from '../../LiquidityActionHelpers'
 import { getRpcUrl } from '@repo/lib/modules/web3/transports'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 /*
  A recovery exit is just a Proportional one but with Recovery kind
@@ -95,7 +96,7 @@ export class RecoveryRemoveLiquidityHandler {
     userAddress: Address
   ): RemoveLiquidityRecoveryInput {
     const bptIn: InputAmount = {
-      rawAmount: parseEther(humanBptIn),
+      rawAmount: parseAmount(humanBptIn, 18),
       decimals: BPT_DECIMALS,
       address: this.helpers.pool.address as Address,
     }

--- a/packages/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquiditySummary.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquiditySummary.tsx
@@ -4,10 +4,10 @@ import { Card, VStack } from '@chakra-ui/react'
 import { MobileStepTracker } from '@repo/lib/modules/transactions/transaction-steps/step-tracker/MobileStepTracker'
 import { usePool } from '../../../PoolProvider'
 import { PoolActionsPriceImpactDetails } from '../../PoolActionsPriceImpactDetails'
-import { parseUnits } from 'viem'
+
 import { BptRow } from '@repo/lib/modules/tokens/TokenRow/BptRow'
 import { TokenRowGroup } from '@repo/lib/modules/tokens/TokenRow/TokenRowGroup'
-import { bn } from '@repo/lib/shared/utils/numbers'
+import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'
 import { AnimateHeightChange } from '@repo/lib/shared/components/animations/AnimateHeightChange'
 import { useUserAccount } from '@repo/lib/modules/web3/UserAccountProvider'
 import { RemoveLiquidityReceiptResult } from '@repo/lib/modules/transactions/transaction-steps/receipts/receipt.hooks'
@@ -114,7 +114,7 @@ export function RemoveLiquiditySummary({
           <Card variant="modalSubSection">
             <VStack align="start" spacing="sm">
               <PoolActionsPriceImpactDetails
-                bptAmount={BigInt(parseUnits(humanBptIn, 18))}
+                bptAmount={parseAmount(humanBptIn, 18)}
                 slippage={slippage}
                 totalUSDValue={totalUSDValue}
               />

--- a/packages/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquiditySummary.tsx
+++ b/packages/lib/modules/pool/actions/remove-liquidity/modal/RemoveLiquiditySummary.tsx
@@ -4,7 +4,6 @@ import { Card, VStack } from '@chakra-ui/react'
 import { MobileStepTracker } from '@repo/lib/modules/transactions/transaction-steps/step-tracker/MobileStepTracker'
 import { usePool } from '../../../PoolProvider'
 import { PoolActionsPriceImpactDetails } from '../../PoolActionsPriceImpactDetails'
-
 import { BptRow } from '@repo/lib/modules/tokens/TokenRow/BptRow'
 import { TokenRowGroup } from '@repo/lib/modules/tokens/TokenRow/TokenRowGroup'
 import { bn, parseAmount } from '@repo/lib/shared/utils/numbers'

--- a/packages/lib/modules/swap/SwapProvider.tsx
+++ b/packages/lib/modules/swap/SwapProvider.tsx
@@ -14,10 +14,10 @@ import { GqlSorSwapTypeValues } from '@repo/lib/shared/services/api/graphql-enum
 import { isSameAddress, selectByAddress } from '@repo/lib/shared/utils/addresses'
 import { useMandatoryContext } from '@repo/lib/shared/utils/contexts'
 import { isDisabledWithReason } from '@repo/lib/shared/utils/functions/isDisabledWithReason'
-import { bn, isBnParseable } from '@repo/lib/shared/utils/numbers'
+import { bn, isBnParseable, parseAmount } from '@repo/lib/shared/utils/numbers'
 import { invert } from 'lodash'
 import { PropsWithChildren, createContext, useEffect, useMemo, useRef, useState } from 'react'
-import { Address, Hash, isAddress, parseUnits } from 'viem'
+import { Address, Hash, isAddress } from 'viem'
 import { ChainSlug, chainToSlugMap, getChainSlug } from '../pool/pool.utils'
 import { getWalletChainSyncAction } from './useWalletChainSync'
 import { calcMarketPriceImpact } from '../price-impact/price-impact.utils'
@@ -489,8 +489,7 @@ export function useSwapLogic({ poolActionableTokens, pool, pathParams }: SwapPro
   }
 
   function scaleTokenAmount(amount: string, token: ApiToken): bigint {
-    if (amount === '') return parseUnits('0', 18)
-    return parseUnits(amount, token.decimals)
+    return parseAmount(amount, token.decimals)
   }
 
   function calcPriceImpact() {

--- a/packages/lib/modules/swap/useSwapSteps.tsx
+++ b/packages/lib/modules/swap/useSwapSteps.tsx
@@ -1,6 +1,6 @@
 import { getChainId } from '@repo/lib/config/app.config'
 import { useMemo } from 'react'
-import { Address, parseUnits } from 'viem'
+import { Address } from 'viem'
 import { useApproveRelayerStep } from '../relayer/useApproveRelayerStep'
 import { useRelayerMode, RelayerMode } from '../relayer/useRelayerMode'
 import { RawAmount } from '../tokens/approvals/approval-rules'
@@ -17,6 +17,7 @@ import { usePermit2ApprovalSteps } from '../tokens/approvals/permit2/usePermit2A
 import { hasSomePendingNestedTxInBatch } from '@repo/lib/modules/transactions/transaction-steps/tx-batch.helpers'
 import { useShouldBatchTransactions } from '@repo/lib/modules/web3/safe.hooks'
 import { TransactionStep } from '@repo/lib/modules/transactions/transaction-steps/lib'
+import { parseAmount } from '@repo/lib/shared/utils/numbers'
 
 type Params = SwapStepParams & {
   vaultAddress: Address
@@ -61,7 +62,7 @@ export function useSwapSteps({
     return [
       {
         address: tokenInInfo.address as Address,
-        rawAmount: parseUnits(swapState.tokenIn.amount, tokenInInfo.decimals),
+        rawAmount: parseAmount(swapState.tokenIn.amount, tokenInInfo.decimals),
         symbol: tokenInInfo.symbol,
       },
     ]

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@apollo/client": "catalog:",
     "@balancer-labs/balancer-maths": "0.0.41",
-    "@balancer/sdk": "6.1.1",
+    "@balancer/sdk": "6.2.0",
     "@chakra-ui/anatomy": "^2.2.2",
     "@chakra-ui/clickable": "^2.1.0",
     "@chakra-ui/hooks": "2.4.2",
@@ -78,7 +78,7 @@
     "use-debounce": "10.1.1",
     "use-sound": "5.0.0",
     "usehooks-ts": "3.1.1",
-    "viem": "2.51.3",
+    "viem": "2.56.0",
     "wagmi": "3.7.7",
     "zod": "3.25.76"
   },

--- a/packages/lib/shared/utils/numbers.spec.ts
+++ b/packages/lib/shared/utils/numbers.spec.ts
@@ -609,8 +609,6 @@ describe('parseAmount', () => {
     expect(parseAmount('.', 18)).toBe(0n)
     expect(parseAmount('-', 18)).toBe(0n)
     expect(parseAmount('  ', 18)).toBe(0n)
-    expect(parseAmount('abc', 18)).toBe(0n)
-    expect(parseAmount('1.2.3', 18)).toBe(0n)
   })
 
   test('parses valid decimal strings', () => {
@@ -619,5 +617,15 @@ describe('parseAmount', () => {
     expect(parseAmount('.5', 18)).toBe(500000000000000000n)
     expect(parseAmount('1.', 18)).toBe(1000000000000000000n)
     expect(parseAmount('1', 6)).toBe(1000000n)
+  })
+
+  test('throws on input that is not a number, matching parseUnits', () => {
+    // Coercing these to 0n would turn a bad form value into a zero-value transaction.
+    expect(() => parseAmount('abc', 18)).toThrow()
+    expect(() => parseAmount('1.2.3', 18)).toThrow()
+    // bn().toString() emits exponential notation outside 1e-7..1e21, which parseUnits rejects
+    // on both 2.51.3 and 2.56.0. Call sites must not feed it here.
+    expect(() => parseAmount('1e-7', 18)).toThrow()
+    expect(() => parseAmount('5e-8', 18)).toThrow()
   })
 })

--- a/packages/lib/shared/utils/numbers.spec.ts
+++ b/packages/lib/shared/utils/numbers.spec.ts
@@ -10,6 +10,7 @@ import {
   isValidNumber,
   sum,
   ZERO_VALUE_DASH,
+  parseAmount,
 } from './numbers'
 
 test('Stringifies bigints', () => {
@@ -597,5 +598,26 @@ describe('isBnParseable', () => {
     expect(isBnParseable('0.')).toBe(true)
     expect(isBnParseable('.5')).toBe(true)
     expect(isBnParseable('0.0000000000000035')).toBe(true)
+  })
+})
+
+describe('parseAmount', () => {
+  test('returns 0n for transient, half-typed amount inputs', () => {
+    // viem >=2.56 throws InvalidDecimalNumberError on these; amount fields legitimately
+    // hold them while the user types or when a form resets.
+    expect(parseAmount('', 18)).toBe(0n)
+    expect(parseAmount('.', 18)).toBe(0n)
+    expect(parseAmount('-', 18)).toBe(0n)
+    expect(parseAmount('  ', 18)).toBe(0n)
+    expect(parseAmount('abc', 18)).toBe(0n)
+    expect(parseAmount('1.2.3', 18)).toBe(0n)
+  })
+
+  test('parses valid decimal strings', () => {
+    expect(parseAmount('1', 18)).toBe(1000000000000000000n)
+    expect(parseAmount('0.5', 18)).toBe(500000000000000000n)
+    expect(parseAmount('.5', 18)).toBe(500000000000000000n)
+    expect(parseAmount('1.', 18)).toBe(1000000000000000000n)
+    expect(parseAmount('1', 6)).toBe(1000000n)
   })
 })

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -782,3 +782,19 @@ function splitDecimalString(value: string): [integerPart: string, fractionPart: 
   if (decimalIndex === -1) return [value, '']
   return [value.slice(0, decimalIndex), value.slice(decimalIndex + 1)]
 }
+
+// Parses a user-entered amount into a scaled bigint, returning 0n when the input is not a
+// number yet. Empty and half-typed inputs ('', '.', '-') are normal transient states for an
+// amount field: viem <2.56 coerced them to 0n, 2.56 made parseUnits throw. Callers that must
+// reject bad input should validate with isBnParseable first, not rely on this.
+// Parses a user-entered amount into a scaled bigint, returning 0n while the input is not a
+// number yet. '', '.' and '-' are normal transient states for an amount field: viem <2.56
+// coerced them to 0n, and 2.56 rewrote parseUnits on top of ox's Value.from, which rejects
+// them with InvalidDecimalNumberError. Valid input is handed straight to parseUnits so
+// rounding behaviour is unchanged. Callers that must reject bad input should validate with
+// isBnParseable first, not rely on this.
+export function parseAmount(value: string, decimals: number): bigint {
+  if (!/^-?(?:\d+(?:\.\d*)?|\.\d+)$/.test(value.trim())) return 0n
+
+  return parseUnits(value.trim(), decimals)
+}

--- a/packages/lib/shared/utils/numbers.ts
+++ b/packages/lib/shared/utils/numbers.ts
@@ -783,18 +783,16 @@ function splitDecimalString(value: string): [integerPart: string, fractionPart: 
   return [value.slice(0, decimalIndex), value.slice(decimalIndex + 1)]
 }
 
-// Parses a user-entered amount into a scaled bigint, returning 0n when the input is not a
-// number yet. Empty and half-typed inputs ('', '.', '-') are normal transient states for an
-// amount field: viem <2.56 coerced them to 0n, 2.56 made parseUnits throw. Callers that must
-// reject bad input should validate with isBnParseable first, not rely on this.
-// Parses a user-entered amount into a scaled bigint, returning 0n while the input is not a
-// number yet. '', '.' and '-' are normal transient states for an amount field: viem <2.56
-// coerced them to 0n, and 2.56 rewrote parseUnits on top of ox's Value.from, which rejects
-// them with InvalidDecimalNumberError. Valid input is handed straight to parseUnits so
-// rounding behaviour is unchanged. Callers that must reject bad input should validate with
-// isBnParseable first, not rely on this.
+// Parses a user-entered amount into a scaled bigint, returning 0n while the input is a
+// half-typed transient state. '', '.' and '-' are what an amount field holds while the user
+// types or after a form reset: viem <2.56 coerced them to 0n, and 2.56 rewrote parseUnits on
+// top of ox's Value.from, which rejects them with InvalidDecimalNumberError. Everything else
+// goes straight to parseUnits, so genuinely invalid input ('abc', '1.2.3', exponential
+// notation) keeps throwing instead of silently becoming a zero-value transaction. Callers that
+// must reject bad input should validate with isBnParseable first, not rely on this.
 export function parseAmount(value: string, decimals: number): bigint {
-  if (!/^-?(?:\d+(?:\.\d*)?|\.\d+)$/.test(value.trim())) return 0n
+  const trimmed = value.trim()
+  if (trimmed === '' || trimmed === '.' || trimmed === '-') return 0n
 
-  return parseUnits(value.trim(), decimals)
+  return parseUnits(trimmed, decimals)
 }

--- a/packages/lib/test/vitest/setup-vitest.tsx
+++ b/packages/lib/test/vitest/setup-vitest.tsx
@@ -1,17 +1,9 @@
 import '@testing-library/jest-dom'
 import { configure } from '@testing-library/react'
-import fetch from 'cross-fetch'
 import { apolloTestClient } from '../../../test/utils/apollo-test-client'
 
 // Set timezone to GMT for consistent date handling in tests
 process.env.TZ = 'Europe/Madrid'
-
-/*
-Using the default node-fetch in node 18 causes a viem exception in integration tests
-(Expected signal to be an instanceof AbortSignal)
-Replacing fetch with cross-fetch implementation solves the issue
-*/
-global.fetch = fetch
 
 // Avoid using next/image in tests
 vi.mock('next/image', () => ({

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -12,7 +12,6 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@types/node": "24.0.3",
-    "cross-fetch": "4.1.0",
     "eslint": "9.27.0",
     "prool": "0.2.4",
     "viem": "2.56.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "devDependencies": {
     "@apollo/client": "catalog:",
-    "@balancer/sdk": "6.1.1",
+    "@balancer/sdk": "6.2.0",
     "@repo/eslint-config": "workspace:*",
     "@repo/prettier-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
@@ -15,8 +15,8 @@
     "cross-fetch": "4.1.0",
     "eslint": "9.27.0",
     "prool": "0.2.4",
-    "viem": "2.51.3",
-    "wagmi": "3.6.16"
+    "viem": "2.56.0",
+    "wagmi": "3.7.7"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/test/vitest/vitest.integration.base.ts
+++ b/packages/test/vitest/vitest.integration.base.ts
@@ -15,6 +15,19 @@ export function createIntegrationVitestConfig(monorepoRoot: string): ViteUserCon
 
   const integrationTestOptions: Partial<InlineConfig> = {
     include: ['./**/*.integration.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    // Integration tests call third-party endpoints (Balancer API, raw.githubusercontent.com)
+    // that do not answer a browser preflight. happy-dom's fetch enforces the same-origin
+    // policy, which blocks those responses and doubles every cross-origin POST with an
+    // OPTIONS request. This is the setting happy-dom exposes for exactly that case.
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          fetch: {
+            disableSameOriginPolicy: true,
+          },
+        },
+      },
+    },
     // Avoid msw in integration tests
     setupFiles: [
       ...setupFilesWithoutMswSetup(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,9 +829,6 @@ importers:
       '@types/node':
         specifier: 24.0.3
         version: 24.0.3
-      cross-fetch:
-        specifier: 4.1.0
-        version: 4.1.0
       eslint:
         specifier: 9.27.0
         version: 9.27.0(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 'catalog:'
-        version: 4.2.12(graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.20.1))(graphql@16.14.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rxjs@7.8.2)
+        version: 4.2.12(graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.21.0))(graphql@16.14.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rxjs@7.8.2)
       '@chakra-ui/icons':
         specifier: 2.2.4
         version: 2.2.4(@chakra-ui/react@2.10.10(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.18)(framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
@@ -119,15 +119,15 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       viem:
-        specifier: 2.51.3
-        version: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+        specifier: 2.56.0
+        version: 2.56.0(typescript@5.9.3)(zod@3.25.76)
       zod:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
       '@chakra-ui/cli':
         specifier: 2.5.8
-        version: 2.5.8(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.20.1)
+        version: 2.5.8(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.0)
       '@chakra-ui/styled-system':
         specifier: 2.12.0
         version: 2.12.0(react@19.2.8)
@@ -171,8 +171,8 @@ importers:
         specifier: 'catalog:'
         version: 4.2.12(graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.21.3))(graphql@16.14.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rxjs@7.8.2)
       '@balancer/sdk':
-        specifier: 6.1.1
-        version: 6.1.1(typescript@5.9.3)(zod@3.25.76)
+        specifier: 6.2.0
+        version: 6.2.0(typescript@5.9.3)(zod@3.25.76)
       '@chakra-ui/hooks':
         specifier: 2.4.2
         version: 2.4.2(react@19.2.8)
@@ -237,8 +237,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
       viem:
-        specifier: 2.51.3
-        version: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+        specifier: 2.56.0
+        version: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     devDependencies:
       '@chakra-ui/cli':
         specifier: 2.5.8
@@ -298,8 +298,8 @@ importers:
         specifier: 'catalog:'
         version: 4.2.12(graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.21.3))(graphql@16.14.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rxjs@7.8.2)
       '@balancer/sdk':
-        specifier: 6.1.1
-        version: 6.1.1(typescript@5.9.3)(zod@3.25.76)
+        specifier: 6.2.0
+        version: 6.2.0(typescript@5.9.3)(zod@3.25.76)
       '@chakra-ui/clickable':
         specifier: ^2.1.0
         version: 2.1.0(react@19.2.8)
@@ -385,8 +385,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(react@19.2.8)
       viem:
-        specifier: 2.51.3
-        version: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+        specifier: 2.56.0
+        version: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     devDependencies:
       '@chakra-ui/cli':
         specifier: 2.5.8
@@ -452,8 +452,8 @@ importers:
   packages/e2e-tests:
     devDependencies:
       '@balancer/sdk':
-        specifier: 6.1.1
-        version: 6.1.1(typescript@5.9.3)(zod@3.25.76)
+        specifier: 6.2.0
+        version: 6.2.0(typescript@5.9.3)(zod@3.25.76)
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1
@@ -533,8 +533,8 @@ importers:
         specifier: 0.0.41
         version: 0.0.41
       '@balancer/sdk':
-        specifier: 6.1.1
-        version: 6.1.1(typescript@5.9.3)(zod@3.25.76)
+        specifier: 6.2.0
+        version: 6.2.0(typescript@5.9.3)(zod@3.25.76)
       '@chakra-ui/anatomy':
         specifier: ^2.2.2
         version: 2.3.4
@@ -582,7 +582,7 @@ importers:
         version: 0.23.1
       '@rainbow-me/rainbowkit':
         specifier: 2.2.11
-        version: 2.2.11(e7869c669ab6e293b488e7506a6a2784)
+        version: 2.2.11(c23e933fd3f533574bb2735b7fb95715)
       '@safe-global/safe-apps-provider':
         specifier: 0.18.6
         version: 0.18.6(typescript@5.9.3)(zod@3.25.76)
@@ -695,11 +695,11 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(react@19.2.8)
       viem:
-        specifier: 2.51.3
-        version: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+        specifier: 2.56.0
+        version: 2.56.0(typescript@5.9.3)(zod@3.25.76)
       wagmi:
         specifier: 3.7.7
-        version: 3.7.7(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(@x402/core@2.23.0)(@x402/evm@2.23.0(typescript@5.9.3))(@x402/extensions@2.23.0(typescript@5.9.3))(@x402/svm@2.23.0(@solana/kit@5.5.1(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3)))(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(react@19.2.8)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
+        version: 3.7.7(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(react@19.2.8)(typescript@5.9.3)(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -809,8 +809,8 @@ importers:
         specifier: 'catalog:'
         version: 4.2.12(graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.21.3))(graphql@16.14.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rxjs@7.8.2)
       '@balancer/sdk':
-        specifier: 6.1.1
-        version: 6.1.1(typescript@5.9.3)(zod@3.25.76)
+        specifier: 6.2.0
+        version: 6.2.0(typescript@5.9.3)(zod@3.25.76)
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -839,11 +839,11 @@ importers:
         specifier: 0.2.4
         version: 0.2.4(debug@4.4.3(supports-color@10.2.2))
       viem:
-        specifier: 2.51.3
-        version: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+        specifier: 2.56.0
+        version: 2.56.0(typescript@5.9.3)(zod@3.25.76)
       wagmi:
-        specifier: 3.6.16
-        version: 3.6.16(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(react@19.2.8)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
+        specifier: 3.7.7
+        version: 3.7.7(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(react@19.2.8)(typescript@5.9.3)(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))
 
   packages/typescript-config: {}
 
@@ -1053,8 +1053,8 @@ packages:
     resolution: {integrity: sha512-ihYLgOnFoVbyN1HJmLT2WH4DzCJt65PMfjtZVoXc4JaK+2Pd8dwcRVbpdLfyXAqfpVZAW9zqB/2JnBHemyuMrQ==}
     engines: {node: '>=18.x'}
 
-  '@balancer/sdk@6.1.1':
-    resolution: {integrity: sha512-SnEK+NypOx+RJnjJOqZHF7URyrqFKzwfR9md8iKaOhZNz+1l+B7dH74D3apcQGzBp4NdkyJHno4lTss/DFjmzg==}
+  '@balancer/sdk@6.2.0':
+    resolution: {integrity: sha512-tI4KYP2jPUpgiFD/XZE6jlLiz4iIIEofQnYjQQUWa50//55B51JMoeIzvN3Mo5259xt648LJeerXMLhNM2p+dw==}
     engines: {node: '>=20.x'}
 
   '@base-org/account@2.4.0':
@@ -4502,40 +4502,6 @@ packages:
       typescript:
         optional: true
 
-  '@wagmi/connectors@8.0.15':
-    resolution: {integrity: sha512-LNr73YNs2KY6y6GXUWRXsDG0xSB5YpkO/9BSp3/2IAcM5XDPWcS4V1HfstXnP/ms9LARKLe2BAOCG44LajTWjw==}
-    peerDependencies:
-      '@base-org/account': ^2.5.1
-      '@coinbase/wallet-sdk': ^4.3.6
-      '@metamask/connect-evm': ^1.3.0
-      '@safe-global/safe-apps-provider': ~0.18.6
-      '@safe-global/safe-apps-sdk': ^9.1.0
-      '@wagmi/core': 3.5.0
-      '@walletconnect/ethereum-provider': ^2.21.1
-      accounts: ~0.10
-      porto: ~0.2.35
-      typescript: '>=5.9.3'
-      viem: 2.x
-    peerDependenciesMeta:
-      '@base-org/account':
-        optional: true
-      '@coinbase/wallet-sdk':
-        optional: true
-      '@metamask/connect-evm':
-        optional: true
-      '@safe-global/safe-apps-provider':
-        optional: true
-      '@safe-global/safe-apps-sdk':
-        optional: true
-      '@walletconnect/ethereum-provider':
-        optional: true
-      accounts:
-        optional: true
-      porto:
-        optional: true
-      typescript:
-        optional: true
-
   '@wagmi/connectors@8.2.0':
     resolution: {integrity: sha512-hPwdmePYjQqSWlw9JmzrzVgmw2PJ+NJsUQ/BuPBYbzBS8+cW5vWdqiaKLB4qTF9m+yr+zSp7u91KBgvOWz50og==}
     peerDependencies:
@@ -4561,21 +4527,6 @@ packages:
       '@safe-global/safe-apps-sdk':
         optional: true
       '@walletconnect/ethereum-provider':
-        optional: true
-      accounts:
-        optional: true
-      typescript:
-        optional: true
-
-  '@wagmi/core@3.5.0':
-    resolution: {integrity: sha512-OcbdnZA6XPyDOHtY6GR8MFzRa89/EkMFCxdrWV4cgKjfsLi02NzEbMG6LQEO7VJ9ltwmLwpRQgcWnn6pBJPo7Q==}
-    peerDependencies:
-      '@tanstack/query-core': '>=5.0.0'
-      accounts: ~0.12
-      typescript: '>=5.9.3'
-      viem: 2.x
-    peerDependenciesMeta:
-      '@tanstack/query-core':
         optional: true
       accounts:
         optional: true
@@ -7646,8 +7597,8 @@ packages:
     resolution: {integrity: sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==}
     engines: {node: '>= 0.4'}
 
-  ox@0.14.25:
-    resolution: {integrity: sha512-8DoibKtxE8yw63Y2jjMhlbjaURev6WCx4QR4MWLusl2/qIaeTzMJMBIYIDl1KOF45+8H1Ur6eLTdPlUoO8PlRw==}
+  ox@0.14.34:
+    resolution: {integrity: sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -9160,8 +9111,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.51.3:
-    resolution: {integrity: sha512-DA4EbrsvatzzLo6MwcWWiv6kI6dIr3I9HH9B6qsJaClN/s0AjIDUz5RIxl+VmGrovIUCcIvG8744yuGH7d37zw==}
+  viem@2.56.0:
+    resolution: {integrity: sha512-JmkgIk4jN+im4oguLxwPv19pwSaGH9kcGSq25Ilm55106ULBBMNR3eWKKA0wZoeyLPSHIiOwZ4sGceEYEIq7LA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -9245,17 +9196,6 @@ packages:
       happy-dom:
         optional: true
       jsdom:
-        optional: true
-
-  wagmi@3.6.16:
-    resolution: {integrity: sha512-tM6/81vwmiNrJneApCL+qJdQoAyn2Fyd6bL88dC8A0Zp13MVeK7/cp1wzia5AoY0yqJRQHjEGk2Zzqrkdht/kA==}
-    peerDependencies:
-      '@tanstack/react-query': '>=5.0.0'
-      react: '>=18'
-      typescript: '>=5.9.3'
-      viem: 2.x
-    peerDependenciesMeta:
-      typescript:
         optional: true
 
   wagmi@3.7.7:
@@ -9398,8 +9338,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9670,7 +9610,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@apollo/client@4.2.12(graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.20.1))(graphql@16.14.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rxjs@7.8.2)':
+  '@apollo/client@4.2.12(graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.21.0))(graphql@16.14.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rxjs@7.8.2)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
       '@wry/caches': 1.0.1
@@ -9682,7 +9622,7 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
     optionalDependencies:
-      graphql-ws: 6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.20.1)
+      graphql-ws: 6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.21.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
@@ -9834,10 +9774,10 @@ snapshots:
 
   '@balancer-labs/balancer-maths@0.0.41': {}
 
-  '@balancer/sdk@6.1.1(typescript@5.9.3)(zod@3.25.76)':
+  '@balancer/sdk@6.2.0(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@balancer-labs/balancer-maths': 0.0.40
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -9853,7 +9793,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.4.0(react@19.2.8))
     transitivePeerDependencies:
       - '@types/react'
@@ -9894,11 +9834,11 @@ snapshots:
 
   '@chakra-ui/anatomy@2.3.6': {}
 
-  '@chakra-ui/cli@2.5.8(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.20.1)':
+  '@chakra-ui/cli@2.5.8(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.0)':
     dependencies:
       bundle-n-require: 1.1.2
       chokidar: 3.6.0
-      cli-welcome: 2.2.3(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.20.1)
+      cli-welcome: 2.2.3(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.0)
       commander: 11.1.0
       ora: 7.0.1
       prettier: 3.9.6
@@ -10181,7 +10121,7 @@ snapshots:
       jose: 6.2.10
       md5: 2.3.0
       uncrypto: 0.1.3
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
       zod: 3.25.76
     optionalDependencies:
       '@x402/core': 2.23.0
@@ -10202,7 +10142,7 @@ snapshots:
       clsx: 1.2.1
       eventemitter3: 5.0.4
       preact: 10.29.8
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - preact-render-to-string
@@ -12192,7 +12132,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@rainbow-me/rainbowkit@2.2.11(e7869c669ab6e293b488e7506a6a2784)':
+  '@rainbow-me/rainbowkit@2.2.11(c23e933fd3f533574bb2735b7fb95715)':
     dependencies:
       '@tanstack/react-query': 5.101.4(react@19.2.8)
       '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
@@ -12204,8 +12144,8 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@19.2.8)
       ua-parser-js: 2.0.10
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
-      wagmi: 3.7.7(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(@x402/core@2.23.0)(@x402/evm@2.23.0(typescript@5.9.3))(@x402/extensions@2.23.0(typescript@5.9.3))(@x402/svm@2.23.0(@solana/kit@5.5.1(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3)))(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(react@19.2.8)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
+      wagmi: 3.7.7(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(react@19.2.8)(typescript@5.9.3)(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -12215,7 +12155,7 @@ snapshots:
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -12228,7 +12168,7 @@ snapshots:
       '@reown/appkit-wallet': 1.8.19(typescript@5.9.3)
       '@walletconnect/universal-provider': 2.23.7(typescript@5.9.3)(zod@3.25.76)
       valtio: 2.1.7(@types/react@19.2.18)(react@19.2.8)
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12397,7 +12337,7 @@ snapshots:
       '@walletconnect/logger': 3.0.2
       '@walletconnect/universal-provider': 2.23.7(typescript@5.9.3)(zod@3.25.76)
       valtio: 2.1.7(@types/react@19.2.18)(react@19.2.8)
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
       '@base-org/account': 2.4.0(@types/react@19.2.18)(@x402/core@2.23.0)(@x402/evm@2.23.0(typescript@5.9.3))(@x402/extensions@2.23.0(typescript@5.9.3))(@x402/svm@2.23.0(@solana/kit@5.5.1(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3)))(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76)
       '@safe-global/safe-apps-provider': 0.18.6(typescript@5.9.3)(zod@3.25.76)
@@ -12463,7 +12403,7 @@ snapshots:
       bs58: 6.0.0
       semver: 7.7.2
       valtio: 2.1.7(@types/react@19.2.18)(react@19.2.8)
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
       '@lit/react': 1.0.8(@types/react@19.2.18)
     transitivePeerDependencies:
@@ -12614,7 +12554,7 @@ snapshots:
   '@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -12635,7 +12575,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -12867,11 +12807,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       apg-js: 4.4.0
 
-  '@signinwithethereum/siwe@4.2.0(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))':
+  '@signinwithethereum/siwe@4.2.0(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))':
     dependencies:
       '@signinwithethereum/siwe-parser': 4.2.0
     optionalDependencies:
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -13811,7 +13751,7 @@ snapshots:
       picocolors: 1.1.1
       picomatch: 3.0.2
       prettier: 3.9.6
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
       zod: 3.25.76
     optionalDependencies:
       typescript: 5.9.3
@@ -13819,21 +13759,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@wagmi/connectors@8.0.15(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@wagmi/core@3.5.0(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76)))(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))':
+  '@wagmi/connectors@8.2.0(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@wagmi/core@3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.56.0(typescript@5.9.3)(zod@3.25.76)))(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(typescript@5.9.3)(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))':
     dependencies:
-      '@wagmi/core': 3.5.0(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
-    optionalDependencies:
-      '@coinbase/wallet-sdk': 4.3.7(typescript@5.9.3)(zod@3.25.76)
-      '@safe-global/safe-apps-provider': 0.18.6(typescript@5.9.3)(zod@3.25.76)
-      '@safe-global/safe-apps-sdk': 9.1.0(typescript@5.9.3)(zod@3.25.76)
-      '@walletconnect/ethereum-provider': 2.23.10(@types/react@19.2.18)(@x402/core@2.23.0)(@x402/evm@2.23.0(typescript@5.9.3))(@x402/extensions@2.23.0(typescript@5.9.3))(@x402/svm@2.23.0(@solana/kit@5.5.1(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3)))(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76)
-      typescript: 5.9.3
-
-  '@wagmi/connectors@8.2.0(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@wagmi/core@3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76)))(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(@x402/core@2.23.0)(@x402/evm@2.23.0(typescript@5.9.3))(@x402/extensions@2.23.0(typescript@5.9.3))(@x402/svm@2.23.0(@solana/kit@5.5.1(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3)))(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))':
-    dependencies:
-      '@wagmi/core': 3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      '@wagmi/core': 3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
       '@coinbase/wallet-sdk': 4.3.7(typescript@5.9.3)(zod@3.25.76)
       '@metamask/connect-evm': 2.1.1(supports-color@10.2.2)
@@ -13842,26 +13771,11 @@ snapshots:
       '@walletconnect/ethereum-provider': 2.23.10(@types/react@19.2.18)(@x402/core@2.23.0)(@x402/evm@2.23.0(typescript@5.9.3))(@x402/extensions@2.23.0(typescript@5.9.3))(@x402/svm@2.23.0(@solana/kit@5.5.1(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3)))(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76)
       typescript: 5.9.3
 
-  '@wagmi/core@3.5.0(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))':
+  '@wagmi/core@3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
-      zustand: 5.0.0(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.4.0(react@19.2.8))
-    optionalDependencies:
-      '@tanstack/query-core': 5.101.4
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
       zustand: 5.0.0(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.4.0(react@19.2.8))
     optionalDependencies:
       '@tanstack/query-core': 5.101.4
@@ -14540,7 +14454,7 @@ snapshots:
   '@x402/evm@2.23.0(typescript@5.9.3)':
     dependencies:
       '@x402/core': 2.23.0
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -14551,12 +14465,12 @@ snapshots:
     dependencies:
       '@noble/curves': 1.9.7
       '@scure/base': 1.2.6
-      '@signinwithethereum/siwe': 4.2.0(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
+      '@signinwithethereum/siwe': 4.2.0(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))
       '@x402/core': 2.23.0
       ajv: 8.20.0
       jose: 5.10.0
       tweetnacl: 1.0.3
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -15086,10 +15000,10 @@ snapshots:
 
   cjs-module-lexer@2.2.1: {}
 
-  clear-any-console@1.16.4(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.20.1):
+  clear-any-console@1.16.4(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.0):
     dependencies:
       command-code: 1.33.0(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(supports-color@10.2.2)
-      langbase: 1.2.4(react@19.2.8)(ws@8.20.1)
+      langbase: 1.2.4(react@19.2.8)(ws@8.21.0)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -15211,10 +15125,10 @@ snapshots:
       slice-ansi: 9.0.0
       string-width: 8.2.2
 
-  cli-welcome@2.2.3(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.20.1):
+  cli-welcome@2.2.3(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.0):
     dependencies:
       chalk: 2.4.2
-      clear-any-console: 1.16.4(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.20.1)
+      clear-any-console: 1.16.4(@neondatabase/serverless@1.1.0)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.0)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -16607,12 +16521,12 @@ snapshots:
       graphql: 16.14.2
       tslib: 2.8.1
 
-  graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.20.1):
+  graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.21.0):
     dependencies:
       graphql: 16.14.2
     optionalDependencies:
       crossws: 0.3.5
-      ws: 8.20.1
+      ws: 8.21.0
     optional: true
 
   graphql-ws@6.2.1(crossws@0.3.5)(graphql@16.14.2)(ws@8.21.3):
@@ -17062,9 +16976,9 @@ snapshots:
     dependencies:
       ws: 8.21.3
 
-  isows@1.0.7(ws@8.20.1):
+  isows@1.0.7(ws@8.21.0):
     dependencies:
-      ws: 8.20.1
+      ws: 8.21.0
 
   isows@1.0.7(ws@8.21.3):
     dependencies:
@@ -17213,10 +17127,10 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  langbase@1.2.4(react@19.2.8)(ws@8.20.1):
+  langbase@1.2.4(react@19.2.8)(ws@8.21.0):
     dependencies:
       dotenv: 16.6.1
-      openai: 4.104.0(ws@8.20.1)(zod@3.25.76)
+      openai: 4.104.0(ws@8.21.0)(zod@3.25.76)
       zod: 3.25.76
       zod-validation-error: 3.5.4(zod@3.25.76)
     optionalDependencies:
@@ -17728,7 +17642,7 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@4.104.0(ws@8.20.1)(zod@3.25.76):
+  openai@4.104.0(ws@8.21.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -17738,7 +17652,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      ws: 8.20.1
+      ws: 8.21.0
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
@@ -17812,7 +17726,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.14.25(typescript@5.9.3)(zod@3.25.76):
+  ox@0.14.34(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -17820,7 +17734,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.3.0(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -19334,16 +19248,16 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.51.3(typescript@5.9.3)(zod@3.25.76):
+  viem@2.56.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.20.1)
-      ox: 0.14.25(typescript@5.9.3)(zod@3.25.76)
-      ws: 8.20.1
+      isows: 1.0.7(ws@8.21.0)
+      ox: 0.14.34(typescript@5.9.3)(zod@3.25.76)
+      ws: 8.21.0
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19436,37 +19350,14 @@ snapshots:
       - tsx
       - yaml
 
-  wagmi@3.6.16(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(react@19.2.8)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@3.25.76)):
+  wagmi@3.7.7(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(react@19.2.8)(typescript@5.9.3)(viem@2.56.0(typescript@5.9.3)(zod@3.25.76)):
     dependencies:
       '@tanstack/react-query': 5.101.4(react@19.2.8)
-      '@wagmi/connectors': 8.0.15(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@wagmi/core@3.5.0(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76)))(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
-      '@wagmi/core': 3.5.0(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
+      '@wagmi/connectors': 8.2.0(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@wagmi/core@3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.56.0(typescript@5.9.3)(zod@3.25.76)))(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(typescript@5.9.3)(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))
+      '@wagmi/core': 3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.56.0(typescript@5.9.3)(zod@3.25.76))
       react: 19.2.8
       use-sync-external-store: 1.4.0(react@19.2.8)
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@base-org/account'
-      - '@coinbase/wallet-sdk'
-      - '@metamask/connect-evm'
-      - '@safe-global/safe-apps-provider'
-      - '@safe-global/safe-apps-sdk'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@walletconnect/ethereum-provider'
-      - accounts
-      - immer
-      - porto
-
-  wagmi@3.7.7(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(@x402/core@2.23.0)(@x402/evm@2.23.0(typescript@5.9.3))(@x402/extensions@2.23.0(typescript@5.9.3))(@x402/svm@2.23.0(@solana/kit@5.5.1(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3)))(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(react@19.2.8)(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@3.25.76)):
-    dependencies:
-      '@tanstack/react-query': 5.101.4(react@19.2.8)
-      '@wagmi/connectors': 8.2.0(@coinbase/wallet-sdk@4.3.7(typescript@5.9.3)(zod@3.25.76))(@metamask/connect-evm@2.1.1(supports-color@10.2.2))(@safe-global/safe-apps-provider@0.18.6(typescript@5.9.3)(zod@3.25.76))(@safe-global/safe-apps-sdk@9.1.0(typescript@5.9.3)(zod@3.25.76))(@wagmi/core@3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76)))(@walletconnect/ethereum-provider@2.23.10(@types/react@19.2.18)(@x402/core@2.23.0)(@x402/evm@2.23.0(typescript@5.9.3))(@x402/extensions@2.23.0(typescript@5.9.3))(@x402/svm@2.23.0(@solana/kit@5.5.1(typescript@5.9.3))(@solana/sysvars@5.5.1(typescript@5.9.3)))(debug@4.4.3(supports-color@10.2.2))(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(zod@3.25.76))(typescript@5.9.3)(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
-      '@wagmi/core': 3.6.5(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.8))(viem@2.51.3(typescript@5.9.3)(zod@3.25.76))
-      react: 19.2.8
-      use-sync-external-store: 1.4.0(react@19.2.8)
-      viem: 2.51.3(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.56.0(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19657,7 +19548,7 @@ snapshots:
 
   ws@7.5.13: {}
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   ws@8.21.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,4 +35,4 @@ publicHoistPattern:
   - '@reown/*' # Fix for @reown/appkit resolution in Next + pnpm
 
 minimumReleaseAgeExclude:
-  - '@balancer/sdk@6.1.1'
+  - '@balancer/sdk@6.2.0'


### PR DESCRIPTION
## What

- Updated `@balancer/sdk` from `6.1.1` to `6.2.0` in `apps/frontend-v3`, `apps/beets-frontend-v3`, `packages/lib`, `packages/e2e-tests` and `packages/test`.
- Updated `viem` from `2.51.3` to `2.56.0` in every workspace that declares it (`apps/balancer-analytics`, `apps/frontend-v3`, `apps/beets-frontend-v3`, `packages/lib`, `packages/test`).
- Updated `wagmi` in `packages/test` from `3.6.16` to `3.7.7` to match `packages/lib`.
- Updated `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` to `@balancer/sdk@6.2.0`.
- Added `parseAmount()` in `packages/lib/shared/utils/numbers.ts` and routed every call site that parses a user-entered amount through it — 26 files, including swap (`useSwapSteps`, `SwapProvider.scaleTokenAmount`), LBP create/init, pool creation (config, details, fund), all six remove-liquidity handlers plus `RemoveLiquidityForm`/`RemoveLiquiditySummary`, and the Beets-only `lst` and `loops` modules.
- Fixed `useAutoRangeInitAmounts` to stop non-null-asserting `tokenAmount`/`tokenDecimals` into the parser while token metadata is still loading.
- Fixed the vEBAL lock step to parse `totalAmount.toFixed()` instead of `totalAmount.toString()`.
- Updated `packages/lib/config/networks/monad.ts` to read `monad.blockExplorers.default` instead of `monad.blockExplorers.monadscan`.
- Removed the `global.fetch = cross-fetch` shim from `packages/lib/test/vitest/setup-vitest.tsx` and dropped the now-unused `cross-fetch` devDependency from `packages/test`.
- Set `environmentOptions.happyDOM.settings.fetch.disableSameOriginPolicy` in `packages/test/vitest/vitest.integration.base.ts`, so integration tests keep reaching third-party endpoints once the shim is gone.
- Regenerated `pnpm-lock.yaml`.

## Why

`@balancer/sdk` 6.2.0 is the latest release and its only changes are the viem bumps (2.55.18, then 2.56.0). The SDK declares `viem@2.56.0` as a direct dependency, so the app's `viem` pin had to move to the same version to keep a single copy resolved across the graph.

Four follow-on changes were forced by that move, not chosen:

- **`parseUnits` validation tightened.** viem 2.56 reimplemented `parseUnits` on top of ox's `Value.from`, whose regex requires at least one digit. `''`, `'.'` and `'-'` coerced to `0n` under 2.51.3 and now throw `InvalidDecimalNumberError`. `/swap` crashed on mount because `swapState.tokenIn.amount` initialises to `''` and `useSwapSteps` parsed it unguarded; the LST and loops forms, the remove-liquidity handlers and the pool-creation steps hit the same class. `parseAmount()` returns `0n` for exactly those three transient inputs and hands everything else straight to `parseUnits`, so valid input keeps viem's rounding behaviour and invalid input keeps throwing. Only form-driven call sites moved; the 19 remaining `parseUnits` sites in `packages/lib` parse API balances or `bn().toFixed()` output, which always yields a valid fixed-point number.
- **`wagmi@3.6.16` pulls `@wagmi/core@3.5.0`**, which imports the `viem/tempo/zones` subpath. That export exists in `2.51.3` and is gone in `2.56.0`, so 19 unit specs in `packages/lib` failed at import time. `@wagmi/core@3.6.5` (used by `wagmi@3.7.x`) has no reference to it, so `packages/test` moves to the version `packages/lib` already uses.
- **viem 2.56 swapped Monad's explorers**: `default` is now Monadscan (with the etherscan-v2 `apiUrl`) and `monadvision` is the named entry, so `monad.blockExplorers.monadscan` no longer typechecks. `plasma.ts` already reads `.blockExplorers.default`, so `monad.ts` now matches it.
- **The `cross-fetch` shim was in the wrong layer.** It overwrote `global.fetch` in the vitest setup file, which runs *after* the environment installs happy-dom's `BrowserWindow.fetch` — so the shim was replacing the happy-dom implementation, not Node's. The `AbortSignal` mismatch it existed for was a Node 18 issue and is gone on Node 24, so the shim was no longer needed by viem. Dropping it means `global.fetch` is now happy-dom's, which enforces the same-origin policy: `raw.githubusercontent.com` answers the preflight with 403, and every cross-origin POST to the Balancer API costs an extra `OPTIONS`. Integration tests therefore opt out of the policy via the happy-dom setting above. Unit tests are untouched — they run under msw and want browser behaviour intact.

Two of the `parseAmount` fixes are correctness follow-ups found in review of the earlier commits on this branch, not new behaviour:

- The first cut used a regex that rejected anything not in fixed-point decimal and returned `0n` for all of it. `invertNumber()` emits exponential notation outside 1e-7..1e21 (`invertNumber('20000000')` → `'5e-8'`), and `useCreatePoolInput` feeds its result straight into `parseAmount(targetPrice, DEFAULT_DECIMALS)` — so an inverted AutoRange target price would have silently become `initialTargetPrice = 0`. viem threw on that input on *both* versions, so the broad coercion was a new failure mode rather than a restored one. The guard is now narrowed to the three transient states.
- `useBuildLockSteps` parsed a `BigNumber` with `.toString()`, which also switches to exponential below 1e-7. `toFixed()` always returns fixed notation.

## Test Steps

- [ ] `pnpm install --frozen-lockfile` completes without lockfile drift
- [ ] `pnpm typecheck` passes for all 7 turbo tasks
- [ ] `pnpm test:unit` passes (711 tests: `@repo/lib` 551, `balancer-analytics` 110, `beets-frontend-v3` 38, `frontend-v3` 12)
- [ ] Visit `/swap` with no wallet connected: the page renders with an empty amount field and no `InvalidDecimalNumberError` overlay
- [ ] In the swap form, type an amount, delete it back to empty, then type `.` on its own — the form stays usable at every step and the quote reappears once the amount is valid
- [ ] Complete a swap end to end on a v3 pool: quote, approval, calldata build and confirmation all succeed on the new SDK
- [ ] Open a pool detail page on Monad and confirm the block explorer link still points at `https://monadscan.com` and is labelled "Monadscan"
- [ ] Remove liquidity (proportional and single-token) on a v3 pool, and confirm the price-impact accordion in the modal shows a non-zero BPT amount once the slider is above 0
- [ ] Walk the pool creation modal for a Weighted, an AutoRange and a GyroE pool: at the AutoRange step swap the token order so the prices invert, then confirm the preview chart and the submitted `initialTargetPrice` are non-zero; at the GyroE step confirm the ECLP validation still flags an out-of-range config
- [ ] `pnpm dev:beets`, run an LST stake and unstake, and a loops deposit and withdraw — each with the amount field cleared mid-flow, to confirm no crash and no zero-value tx
- [ ] `pnpm dev`, open `/vebal/lock`, enter a lock amount and confirm the lock step builds calldata rather than throwing

## Risks / Breaking Changes

- Dependency bump touching `packages/lib`, which is shared by both apps — Balancer and Beets are both affected via `NEXT_PUBLIC_PROJECT_ID`, so both need the smoke tests above rather than just `frontend-v3`.
- `viem` is a broad-surface dependency (350 files). Typecheck and unit tests pass, but SDK-generated calldata changes would only surface in a live quote/build-call-data flow, so swaps and add/remove liquidity on a v3 pool are the checks that matter.
- `parseAmount()` returns `0n` for `''`, `'.'` and `'-'`, and throws for anything else. That is deliberate — an amount field legitimately holds those three values mid-typing — but it means a caller that needs to *reject* input must validate with `isBnParseable` first, and any new caller that passes a computed value (rather than raw field state) must guarantee fixed-point notation.
- `packages/test` wagmi moves two minors (`3.6.16` → `3.7.7`); its `@wagmi/core` goes from `3.5.0` to `3.6.5`. Only test helpers consume it, but a connector-related failure there would come from this.
- Removing the `cross-fetch` shim changes the fetch implementation used by tests: `global.fetch` is now happy-dom's rather than node-fetch's. Integration tests run with the same-origin policy disabled, so they no longer exercise CORS at all — a regression that only shows up as a blocked cross-origin request in the browser would not be caught there. Unit tests keep the policy on and pass under msw.
- Monad's explorer URL and label are unchanged in practice — the bump only changed which viem key holds them.

## Other Notes

- The unit suite could not catch the `parseUnits` regression: no existing spec renders `useSwapSteps` with an empty amount. `parseAmount` now has direct coverage for the transient inputs, for the throwing inputs, and for valid fixed-point parsing in `numbers.spec.ts`.
- The integration suite still hits the live test API at module scope: 11 specs `await fetchPoolMock(...)` during collect, while `packages/lib/modules/pool/__mocks__/api-mocks/` already holds 21 saved fixtures served by `getApiPoolMock()`. Moving those to the saved mocks removes most of the rate-limit exposure; `fetchPoolMock`'s retry (3 attempts, flat 1s, `Retry-After` ignored) is the smaller half of the fix. Left for a follow-up.
- `getProportionalExitAmountsForBptIn` in `packages/lib/modules/pool/pool.utils.ts` takes a form-shaped human BPT amount and still calls `parseUnits` on it. It currently has no callers anywhere in the repo, so it is left alone, but it is the one place a future caller would reintroduce this crash.
- The two `wagmi` pins (`packages/lib` and `packages/test`) drifted apart once already and only surfaced as a test-time failure. Worth folding into the `catalog:` in `pnpm-workspace.yaml` in a separate change so a viem bump cannot desync them again.
- `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` holds a single pinned version, so it has to be moved forward on each SDK bump — it now points at `6.2.0`.
