### PR TITLE
fix(token-input): collapse repeated decimal separators

### DIFF
--- a/packages/lib/modules/tokens/TokenInput/useTokenInput.spec.ts
+++ b/packages/lib/modules/tokens/TokenInput/useTokenInput.spec.ts
@@ -23,6 +23,15 @@ describe('cleanAmountInput', () => {
     expect(cleanAmountInput('1e5')).toBe('15')
   })
 
+  test('collapses repeated decimal separators', () => {
+    // Regression: only the first '.' was deduplicated, so typing '1.2' then '.' produced '1.2.',
+    // which both parseAmount and bn() reject and which crashed the LST page during render.
+    expect(cleanAmountInput('1.2.')).toBe('1.2')
+    expect(cleanAmountInput('1.2.3')).toBe('1.23')
+    expect(cleanAmountInput('1..2')).toBe('1.2')
+    expect(cleanAmountInput('1,2,3')).toBe('1.23')
+  })
+
   test('keeps valid amounts untouched', () => {
     expect(cleanAmountInput('')).toBe('')
     expect(cleanAmountInput('0')).toBe('0')

--- a/packages/lib/modules/tokens/TokenInput/useTokenInput.ts
+++ b/packages/lib/modules/tokens/TokenInput/useTokenInput.ts
@@ -18,8 +18,8 @@ export function overflowProtected(value: Numberish, decimalLimit: number): strin
 export function cleanAmountInput(newValue: string): string {
   let cleanValue = newValue.replace(',', '.')
   cleanValue = cleanValue.replace(/[^\d.]/g, '')
-  let separators = 0 // Remove all non decimal chars except the first decimal separator
-  cleanValue = cleanValue.replace('.', () => (separators++ === 0 ? '.' : ''))
+  let separators = 0 // Keep only the first decimal separator, drop any extras (e.g. pasted '1.2.3')
+  cleanValue = cleanValue.replace(/\./g, () => (separators++ === 0 ? '.' : ''))
   // A bare leading separator ('.') is not parseable by BigNumber and would crash downstream
   if (cleanValue.startsWith('.')) cleanValue = '0' + cleanValue
 


### PR DESCRIPTION
## What

- Updated `cleanAmountInput` to deduplicate every decimal separator instead of only the first one, by switching `.replace('.', fn)` to `.replace(/\./g, fn)`.
- Added a regression test covering `'1.2.'`, `'1.2.3'`, `'1..2'` and `'1,2,3'`.

## Why

A string pattern in `String.prototype.replace` substitutes only the first occurrence, so the existing separator counter never saw a second dot. Typing `1.2` and then `.` stored `1.2.` in the amount field, and pasting `1.2.3` stored it verbatim. Neither is parseable by BigNumber or viem `parseUnits`, so both threw during render wherever the amount is read — e.g. the `bn(amountShares)` disabled conditions in the LST provider and `useAutoRangeInitAmounts`' `parseUnits(tokenAmount)`. This is the same crash class as the earlier bare-`.` fix (`83ff9d909`), which only handled the leading-separator case.

## Test Steps

- [ ] Go to `/stake` on Beets, select the Unstake tab
- [ ] Type `1.2` into the amount input, then type another `.`
- [ ] The input should keep showing `1.2` and the page should not crash or show an error boundary
- [ ] Paste `1.2.3` into the amount input — it should become `1.23`
- [ ] Type `.5` — it should still become `0.5` (first separator still wins, leading separator still prefixed with zero)
- [ ] Run `pnpm --filter @repo/lib exec vitest run modules/tokens/TokenInput/useTokenInput.spec.ts`

## Risks / Breaking Changes

- Touches shared `packages/lib`, so it affects both apps via `NEXT_PUBLIC_PROJECT_ID`. `cleanAmountInput` feeds every `TokenInput`, so amounts with repeated separators now normalize differently: `1.2.3` becomes `1.23` rather than passing through unchanged. Such values previously crashed the page, so no working behavior regresses.
- No changes to token decimals handling, balance parsing, or the parsing of already-valid amounts.

## Other Notes

- The two coderabbit follow-ups that surfaced this (gating the LST unstake-validator query and the AutoRange init-amount query on a positive parsed amount) are on #2724, since they build on the `parseAmount` helper introduced with the viem 2.56 bump. This PR is deliberately independent of that bump — the bug and its crash exist on `main`.
