### PR TITLE
Fix LBP shared-link start time timezone hydration

### DIFF
--- a/packages/e2e-tests/helpers/create-lbp.helpers.ts
+++ b/packages/e2e-tests/helpers/create-lbp.helpers.ts
@@ -1,7 +1,12 @@
 import { clickButton, button, clickRadio, checkbox } from '@/helpers/user.helpers'
 import { expect, type Page } from '@playwright/test'
 import { LBP_FORM_STEPS } from '@repo/lib/modules/lbp/constants.lbp'
-import { oneDayInMs, oneWeekInMs, toISOString } from '@repo/lib/shared/utils/time'
+import {
+  oneDayInMs,
+  oneWeekInMs,
+  unixTimestampToDateTimeLocalString,
+  oneSecondInMs,
+} from '@repo/lib/shared/utils/time'
 
 export type LbpSaleType = 'seedless' | 'seeded' | 'fixed-price'
 export type LbpConfig = {
@@ -91,8 +96,12 @@ export async function doSaleStructureStep(
 
   await expect(page.getByRole('heading', { name: 'Sale period' })).toBeVisible()
   const dateInputs = page.locator('input[type="datetime-local"]')
-  await dateInputs.first().fill(toISOString(Date.now() + oneDayInMs).slice(0, 16))
-  await dateInputs.last().fill(toISOString(Date.now() + oneWeekInMs).slice(0, 16))
+  await dateInputs
+    .first()
+    .fill(unixTimestampToDateTimeLocalString((Date.now() + oneDayInMs) / oneSecondInMs))
+  await dateInputs
+    .last()
+    .fill(unixTimestampToDateTimeLocalString((Date.now() + oneWeekInMs) / oneSecondInMs))
 
   if (lbpConfig.saleType === 'seedless') {
     await expect(

--- a/packages/e2e-tests/tests/dev/balancer/create-lbp.spec.ts
+++ b/packages/e2e-tests/tests/dev/balancer/create-lbp.spec.ts
@@ -2,7 +2,11 @@ import { impersonate } from '@/helpers/e2e.helpers'
 import { clickButton } from '@/helpers/user.helpers'
 import { expect, test } from '@playwright/test'
 import { defaultAnvilAccount } from '@repo/lib/test/utils/wagmi/fork.helpers'
-import { oneDayInMs, toISOString } from '@repo/lib/shared/utils/time'
+import {
+  oneDayInMs,
+  oneSecondInMs,
+  unixTimestampToDateTimeLocalString,
+} from '@repo/lib/shared/utils/time'
 import {
   doProjectInfoStep,
   doReviewStep,
@@ -46,7 +50,9 @@ test.describe('LBP creation page', () => {
       await doSaleStructureStep(page)
 
       const dateInputs = page.locator('input[type="datetime-local"]')
-      const invalidEndTime = toISOString(Date.now() + oneDayInMs + 60 * 60 * 1000).slice(0, 16)
+      const invalidEndTime = unixTimestampToDateTimeLocalString(
+        (Date.now() + oneDayInMs + 60 * 60 * 1000) / oneSecondInMs,
+      )
       await dateInputs.last().fill(invalidEndTime)
 
       await clickButton(page, 'Next')

--- a/packages/lib/modules/lbp/useHydrateLbpForm.ts
+++ b/packages/lib/modules/lbp/useHydrateLbpForm.ts
@@ -14,7 +14,7 @@ import {
   WeightAdjustmentType,
 } from './lbp.types'
 import { PERCENTAGE_DECIMALS } from '../pool/actions/create/constants'
-import { toJsTimestamp, toISOString } from '@repo/lib/shared/utils/time'
+import { unixTimestampToDateTimeLocalString } from '@repo/lib/shared/utils/time'
 import { FixedPriceLBPoolAbi } from '@repo/lib/modules/web3/contracts/abi/FixedPriceLBPoolAbi'
 import { LBPoolAbi } from '@repo/lib/modules/web3/contracts/abi/LBPoolAbi'
 import type { GqlPoolLiquidityBootstrappingV3 } from '@repo/lib/shared/services/api/graphql-derived-types'
@@ -72,10 +72,6 @@ type FixedPriceLbpDataResponse = [
 ]
 
 type ContractDataResponse = LbpDataResponse | FixedPriceLbpDataResponse
-
-function formatLbpTimestamp(timestamp: bigint): string {
-  return toISOString(toJsTimestamp(Number(timestamp))).slice(0, 16)
-}
 
 export function useHydrateLbpForm() {
   const { slug } = useParams()
@@ -247,8 +243,8 @@ export function useHydrateLbpForm() {
       customStartWeight,
       customEndWeight,
       fee: +formatUnits(staticSwapFeePercentage.result, PERCENTAGE_DECIMALS),
-      startDateTime: formatLbpTimestamp(lbpImmutableData.result.startTime),
-      endDateTime: formatLbpTimestamp(lbpImmutableData.result.endTime),
+      startDateTime: unixTimestampToDateTimeLocalString(lbpImmutableData.result.startTime),
+      endDateTime: unixTimestampToDateTimeLocalString(lbpImmutableData.result.endTime),
     }
 
     saleStructureForm.reset(saleStructureFormValues)
@@ -297,8 +293,8 @@ export function useHydrateLbpForm() {
       collateralTokenAmount: '',
       userActions,
       fee: +formatUnits(staticSwapFeePercentage.result, PERCENTAGE_DECIMALS),
-      startDateTime: formatLbpTimestamp(startTime),
-      endDateTime: formatLbpTimestamp(endTime),
+      startDateTime: unixTimestampToDateTimeLocalString(startTime),
+      endDateTime: unixTimestampToDateTimeLocalString(endTime),
       launchTokenRate: formatUnits(fixedPriceImmutableData.result.projectTokenRate, 18), // Assuming 18 decimals
     }
 

--- a/packages/lib/shared/utils/time.spec.ts
+++ b/packages/lib/shared/utils/time.spec.ts
@@ -6,7 +6,9 @@ import {
 
 describe('unixTimestampToDateTimeLocalString', () => {
   it('formats a unix timestamp for datetime-local inputs in the local timezone', () => {
-    // 2026-09-01T18:00:00Z — tests run with TZ=Europe/Madrid (CEST, UTC+2)
+    // 2026-09-01T18:00:00Z. The expected value is CEST (UTC+2) because
+    // setup-vitest.tsx pins process.env.TZ to Europe/Madrid — if that pin changes,
+    // this assertion must change with it. The round-trip test below is TZ-agnostic.
     expect(unixTimestampToDateTimeLocalString(1788285600)).toBe('2026-09-01T20:00')
   })
 

--- a/packages/lib/shared/utils/time.spec.ts
+++ b/packages/lib/shared/utils/time.spec.ts
@@ -1,4 +1,22 @@
-import { formatDistanceToNowAbbr } from './time'
+import {
+  dateTimeToUnixTimestampBigInt,
+  formatDistanceToNowAbbr,
+  unixTimestampToDateTimeLocalString,
+} from './time'
+
+describe('unixTimestampToDateTimeLocalString', () => {
+  it('formats a unix timestamp for datetime-local inputs in the local timezone', () => {
+    // 2026-09-01T18:00:00Z — tests run with TZ=Europe/Madrid (CEST, UTC+2)
+    expect(unixTimestampToDateTimeLocalString(1788285600)).toBe('2026-09-01T20:00')
+  })
+
+  it('round-trips with dateTimeToUnixTimestampBigInt', () => {
+    const unixTimestamp = 1788285600
+    const dateTimeLocal = unixTimestampToDateTimeLocalString(unixTimestamp)
+
+    expect(dateTimeToUnixTimestampBigInt(dateTimeLocal)).toBe(BigInt(unixTimestamp))
+  })
+})
 
 describe('Time distance abbreviated', () => {
   beforeAll(() => {

--- a/packages/lib/shared/utils/time.ts
+++ b/packages/lib/shared/utils/time.ts
@@ -189,10 +189,6 @@ export function startOfDayUtc(dateUTC: Date) {
   )
 }
 
-export function toISOString(timestamp: number): string {
-  return new Date(timestamp).toISOString()
-}
-
 /**
  * Fixes date shown on pool charts
  *

--- a/packages/lib/shared/utils/time.ts
+++ b/packages/lib/shared/utils/time.ts
@@ -10,6 +10,7 @@ import {
   differenceInHours,
   differenceInMinutes,
   differenceInSeconds,
+  fromUnixTime,
 } from 'date-fns'
 
 const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm"
@@ -72,7 +73,7 @@ export function dateTimeToUnixTimestampBigInt(value?: string): bigint {
  * in the user's local timezone.
  */
 export function unixTimestampToDateTimeLocalString(unixTimestampSeconds: number | bigint): string {
-  return format(new Date(toJsTimestamp(Number(unixTimestampSeconds))), DATETIME_LOCAL_FORMAT)
+  return format(fromUnixTime(Number(unixTimestampSeconds)), DATETIME_LOCAL_FORMAT)
 }
 
 export function dateTimeLabelFor(date: Date): string {

--- a/packages/lib/shared/utils/time.ts
+++ b/packages/lib/shared/utils/time.ts
@@ -12,6 +12,8 @@ import {
   differenceInSeconds,
 } from 'date-fns'
 
+const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm"
+
 export const oneSecondInMs = 1000
 export const oneMinInMs = 60 * oneSecondInMs
 export const oneHourInMs = 60 * oneMinInMs
@@ -63,6 +65,14 @@ export function dateTimeToUnixTimestampBigInt(value?: string): bigint {
   if (!Number.isFinite(milliseconds)) return 0n
 
   return BigInt(millisecondsToSeconds(milliseconds))
+}
+
+/**
+ * Converts a unix timestamp (seconds) into a `datetime-local` input value
+ * in the user's local timezone.
+ */
+export function unixTimestampToDateTimeLocalString(unixTimestampSeconds: number | bigint): string {
+  return format(new Date(toJsTimestamp(Number(unixTimestampSeconds))), DATETIME_LOCAL_FORMAT)
 }
 
 export function dateTimeLabelFor(date: Date): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Added `unixTimestampToDateTimeLocalString` in `packages/lib/shared/utils/time.ts` to format on-chain unix timestamps for `datetime-local` inputs in the user's local timezone
- Updated `useHydrateLbpForm` to use the new helper instead of slicing a UTC ISO string when loading a deployed LBP from a shared initialize link (both the dynamic and fixed-price paths)
- Updated the LBP e2e helpers (`create-lbp.helpers.ts`, `create-lbp.spec.ts`) to fill `datetime-local` inputs through the same helper, replacing the `toISOString(...).slice(0, 16)` pattern
- Refactored the helper to build its date with `fromUnixTime` instead of a manual seconds-to-milliseconds conversion
- Removed the now-unused `toISOString` export from `packages/lib/shared/utils/time.ts`
- Added unit tests covering local-time formatting and round-trip conversion with `dateTimeToUnixTimestampBigInt`

## Why

When a deployed LBP is opened via a shared link (e.g. `/lbp/create/MAINNET/0x…`), start/end times are hydrated from on-chain UTC timestamps. The previous implementation used `toISOString(...).slice(0, 16)`, which produced a string like `2026-09-01T18:00` without timezone information. Browsers and `parseISO` interpret that as local wall time, so users in CET saw 18:00 UTC as 18:00 local (16:00 UTC) and hidden start-time validation failed silently — blocking **Next** even when the sale was still in the future.

The e2e helpers fed the same `datetime-local` inputs with the same UTC-sliced string, so the LBP creation tests only passed because the Playwright container runs in UTC; on a machine with a non-UTC timezone the filled start time lands in the past and step 1 rejects it. Routing both the app and the tests through one helper keeps the two in agreement.

## Test Steps

- [ ] Deploy an LBP without seeding and copy the initialize link
- [ ] Open the link in a browser set to a non-UTC timezone (e.g. Europe/Berlin)
- [ ] Connect a wallet with enough launch tokens, enter the sale amount, and click **Next**
- [ ] Confirm step 2 loads instead of the page staying on step 1 with no visible error
- [ ] Confirm the start/end time fields show the sale times in your local timezone, not UTC
- [ ] Run `pnpm --filter @repo/lib exec vitest run shared/utils/time.spec.ts` and confirm all tests pass
- [ ] Confirm `Unit-Test` and `E2E-Dev-Test-Balancer-2` (which runs `create-lbp.spec.ts`) pass on this PR

## Risks / Breaking Changes

- Touches shared `packages/lib` code used by both Balancer and Beets apps (`NEXT_PUBLIC_PROJECT_ID`), but only affects LBP form hydration from shared initialize links. Beets mounts the same `LbpCreationPage` at `/lbp/create` (its nav entry is gated to dev/staging in `packages/lib/config/projects/beets.ts:51`), so the fix applies there too rather than being Balancer-only.
- No change to how users pick dates when creating a new LBP from scratch; creation and initialize flows still round-trip through `dateTimeToUnixTimestampBigInt`.
- `toISOString` is removed from `packages/lib/shared/utils/time.ts`. It had no remaining callers in the repo; code needing a raw ISO string should use `Date.prototype.toISOString` directly.
- E2E coverage for the helper changes is only exercised against a dev server plus an anvil fork, so it is verified by CI rather than locally.

## Other Notes

`packages/lib/shared/utils/time.spec.ts` asserts an exact local-time string, which is only stable because `packages/lib/test/vitest/setup-vitest.tsx` pins `process.env.TZ` to `Europe/Madrid`. The comment there names that dependency; the round-trip test alongside it is timezone-agnostic.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7e934cc-9d33-41f3-90a9-949b9d460764?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7e934cc-9d33-41f3-90a9-949b9d460764&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
